### PR TITLE
Handle the network tag in the XML file

### DIFF
--- a/app/src/main/java/io/awallet/crypto/alphawallet/di/ImportTokenModule.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/di/ImportTokenModule.java
@@ -2,8 +2,10 @@ package io.awallet.crypto.alphawallet.di;
 
 import io.awallet.crypto.alphawallet.interact.CreateTransactionInteract;
 import io.awallet.crypto.alphawallet.interact.FetchTokensInteract;
+import io.awallet.crypto.alphawallet.interact.FindDefaultNetworkInteract;
 import io.awallet.crypto.alphawallet.interact.FindDefaultWalletInteract;
 import io.awallet.crypto.alphawallet.interact.SetupTokensInteract;
+import io.awallet.crypto.alphawallet.repository.EthereumNetworkRepositoryType;
 import io.awallet.crypto.alphawallet.repository.PasswordStore;
 import io.awallet.crypto.alphawallet.repository.TokenRepositoryType;
 import io.awallet.crypto.alphawallet.repository.TransactionRepositoryType;
@@ -23,13 +25,20 @@ public class ImportTokenModule {
 
     @Provides
     ImportTokenViewModelFactory importTokenViewModelFactory(
+            FindDefaultNetworkInteract findDefaultNetworkInteract,
             FindDefaultWalletInteract findDefaultWalletInteract,
             CreateTransactionInteract createTransactionInteract,
             FetchTokensInteract fetchTokensInteract,
             SetupTokensInteract setupTokensInteract,
             FeeMasterService feeMasterService) {
         return new ImportTokenViewModelFactory(
-                findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService);
+                findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService);
+    }
+
+    @Provides
+    FindDefaultNetworkInteract provideFindDefaultNetworkInteract(
+            EthereumNetworkRepositoryType ethereumNetworkRepository) {
+        return new FindDefaultNetworkInteract(ethereumNetworkRepository);
     }
 
     @Provides

--- a/app/src/main/java/io/awallet/crypto/alphawallet/entity/Ticket.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/entity/Ticket.java
@@ -481,13 +481,13 @@ public class Ticket extends Token implements Parcelable
         }
     }
 
-    public String getXMLProperty(String property, BaseActivity activity)
+    public String getXMLProperty(int network, String property, BaseActivity activity)
     {
         String value;
         try
         {
             AssetDefinition ad = new AssetDefinition("TicketingContract.xml", activity.getResources());
-            value = ad.networkInfo.get(property);
+            value = ad.getNetworkValue(network, property);
         }
         catch (IOException | SAXException e)
         {

--- a/app/src/main/java/io/awallet/crypto/alphawallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/ui/ImportTokenActivity.java
@@ -19,6 +19,7 @@ import javax.inject.Inject;
 import dagger.android.AndroidInjection;
 import io.awallet.crypto.alphawallet.R;
 import io.awallet.crypto.alphawallet.entity.ErrorEnvelope;
+import io.awallet.crypto.alphawallet.entity.NetworkInfo;
 import io.awallet.crypto.alphawallet.entity.SalesOrder;
 import io.awallet.crypto.alphawallet.entity.Ticket;
 import io.awallet.crypto.alphawallet.router.HomeRouter;
@@ -53,6 +54,7 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
     private TextView importTxt;
 
     private LinearLayout costLayout;
+    private int networkId = 0;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -91,8 +93,14 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         viewModel.newTransaction().observe(this, this::onTransaction);
         viewModel.error().observe(this, this::onError);
         viewModel.invalidLink().observe(this, this::onBadLink);
+        viewModel.network().observe(this, this::onNetwork);
 
         ticketRange = null;
+    }
+
+    private void onNetwork(NetworkInfo networkInfo)
+    {
+        networkId = networkInfo.chainId;
     }
 
     private void onBadLink(Boolean aBoolean)
@@ -297,9 +305,9 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
                     else {
                         onProgress(true);
                         Ticket t = viewModel.getImportToken();
-                        if (t.getXMLProperty("address", this).equalsIgnoreCase(t.getAddress()))
+                        if (t.getXMLProperty(networkId,"address", this).equalsIgnoreCase(t.getAddress()))
                         {
-                            viewModel.importThroughFeemaster(t.getXMLProperty("feemaster", this));
+                            viewModel.importThroughFeemaster(t.getXMLProperty(networkId,"feemaster", this));
                         }
                         else
                         {

--- a/app/src/main/java/io/awallet/crypto/alphawallet/ui/TransactionsFragment.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/ui/TransactionsFragment.java
@@ -63,6 +63,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     private Dialog dialog;
 
     private boolean isVisible = false;
+    private int networkId = 0;
 
     RecyclerView list;
 
@@ -160,7 +161,16 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         try
         {
             AssetDefinition ad = new AssetDefinition("TicketingContract.xml", getResources());
-            viewModel.setXMLContractAddress(ad.networkInfo.get("address").toLowerCase());
+            String contractNetwork = ad.getNetworkValue(networkId,"network");
+            if (contractNetwork != null)
+            {
+                int contractNetworkId = Integer.valueOf(contractNetwork);
+                if (contractNetworkId == this.networkId)
+                {
+                    viewModel.setXMLContractAddress(ad.getNetworkValue(networkId, "address").toLowerCase());
+                    viewModel.setFeemasterURL(ad.getNetworkValue(networkId,"feemaster"));
+                }
+            }
         }
         catch (IOException|SAXException e)
         {
@@ -170,6 +180,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
 
     private void onDefaultNetwork(NetworkInfo networkInfo) {
         adapter.setDefaultNetwork(networkInfo);
+        networkId = networkInfo.chainId;
     }
 
     private void onError(ErrorEnvelope errorEnvelope) {

--- a/app/src/main/java/io/awallet/crypto/alphawallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/ui/WalletFragment.java
@@ -57,6 +57,7 @@ public class WalletFragment extends Fragment implements View.OnClickListener {
     private SystemView systemView;
     private ProgressView progressView;
     private TokensAdapter adapter;
+    private int networkId = 0;
 
     private Wallet wallet;
 
@@ -229,7 +230,7 @@ public class WalletFragment extends Fragment implements View.OnClickListener {
         try
         {
             AssetDefinition ad = new AssetDefinition("TicketingContract.xml", getResources());
-            adapter.setLiveTokenAddress(ad.networkInfo.get("address").toLowerCase());
+            adapter.setLiveTokenAddress(ad.getNetworkValue(networkId,"address").toLowerCase());
         }
         catch (IOException |SAXException e)
         {
@@ -239,6 +240,7 @@ public class WalletFragment extends Fragment implements View.OnClickListener {
 
     private void onDefaultNetwork(NetworkInfo networkInfo)
     {
+        networkId = networkInfo.chainId;
 //        adapter.setDefaultNetwork(networkInfo);
 //        setBottomMenu(R.menu.menu_main_network);
     }

--- a/app/src/main/java/io/awallet/crypto/alphawallet/viewmodel/ImportTokenViewModelFactory.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/viewmodel/ImportTokenViewModelFactory.java
@@ -17,17 +17,20 @@ import io.awallet.crypto.alphawallet.service.ImportTokenService;
 
 public class ImportTokenViewModelFactory implements ViewModelProvider.Factory {
 
+    private final FindDefaultNetworkInteract findDefaultNetworkInteract;
     private final FindDefaultWalletInteract findDefaultWalletInteract;
     private final CreateTransactionInteract createTransactionInteract;
     private final FetchTokensInteract fetchTokensInteract;
     private final SetupTokensInteract setupTokensInteract;
     private final FeeMasterService feeMasterService;
 
-    public ImportTokenViewModelFactory(FindDefaultWalletInteract findDefaultWalletInteract,
+    public ImportTokenViewModelFactory(FindDefaultNetworkInteract findDefaultNetworkInteract,
+                                       FindDefaultWalletInteract findDefaultWalletInteract,
                                        CreateTransactionInteract createTransactionInteract,
                                        FetchTokensInteract fetchTokensInteract,
                                        SetupTokensInteract setupTokensInteract,
                                        FeeMasterService feeMasterService) {
+        this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.createTransactionInteract = createTransactionInteract;
         this.fetchTokensInteract = fetchTokensInteract;
@@ -38,7 +41,7 @@ public class ImportTokenViewModelFactory implements ViewModelProvider.Factory {
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new ImportTokenViewModel(findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService);
+        return (T) new ImportTokenViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService);
     }
 }
 

--- a/app/src/main/java/io/awallet/crypto/alphawallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/awallet/crypto/alphawallet/viewmodel/TransactionsViewModel.java
@@ -59,6 +59,7 @@ public class TransactionsViewModel extends BaseViewModel {
     private Map<String, Transaction> txMap = new ConcurrentHashMap<>();
     private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private String xmlContractAddress = null;
+    private String feemasterUrl = null;
     private int transactionCount;
 
     TransactionsViewModel(
@@ -414,4 +415,5 @@ public class TransactionsViewModel extends BaseViewModel {
     {
         xmlContractAddress = address;
     }
+    public void setFeemasterURL(String address) { feemasterUrl = address; };
 }

--- a/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
+++ b/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
@@ -21,7 +21,7 @@ public class TokenDefinition {
     protected Document xml;
     public Map<String, FieldDefinition> fields = new ConcurrentHashMap<>();
     public String locale;
-    public Map<String, String> networkInfo = new ConcurrentHashMap<>();
+    private Map<String, String> networkInfo = new ConcurrentHashMap<>();
 
     protected class FieldDefinition {
         public BigInteger bitmask;   // TODO: BigInteger !== BitInt. Test edge conditions.
@@ -143,6 +143,21 @@ public class TokenDefinition {
         extract(xml, "address");
         extract(xml, "gateway");
         extract(xml, "feemaster");
+        extract(xml, "network");
+    }
+
+    public String getNetworkValue(int network, String field)
+    {
+        int definitionNetwork = Integer.valueOf(networkInfo.get("network"));
+        if (network == definitionNetwork)
+        {
+            return networkInfo.get(field);
+        }
+        else
+        {
+            //XML doesn't apply to this request
+            return "";
+        }
     }
 
     private void extract(Document xml, String field)


### PR DESCRIPTION
Ensure the network ID (eg 1:Mainnet, 3:Ropsten) of the XML file matches the network currently in use, before we try to use the wrong feemaster or look up contracts on a different network.