### PR TITLE
Display date and time in human readable form

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/BaseTicketHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/BaseTicketHolder.java
@@ -63,7 +63,7 @@ public class BaseTicketHolder extends BinderViewHolder<TicketRange> implements V
     @Override
     public void bind(@Nullable TicketRange data, @NonNull Bundle addition)
     {
-        DateFormat date = android.text.format.DateFormat.getDateFormat(getContext());
+        DateFormat date = android.text.format.DateFormat.getLongDateFormat(getContext());
         date.setTimeZone(TimeZone.getTimeZone("Europe/Moscow")); // TODO: use the timezone defined in XML
         DateFormat time = android.text.format.DateFormat.getTimeFormat(getContext());
         time.setTimeZone(TimeZone.getTimeZone("Europe/Moscow")); // TODO: use the timezone defined in XML

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -114,6 +114,11 @@
                             android:contentDescription="@string/empty"
                             android:src="@drawable/ic_calendar" />
 
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical">
+
                         <TextView
                             android:id="@+id/date"
                             android:paddingRight="5dp"
@@ -123,16 +128,20 @@
 
                         <TextView
                             android:id="@+id/time"
-                            android:paddingLeft="5dp"
+                            android:paddingRight="5dp"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:textSize="12sp"
                             android:layout_gravity="center_vertical" />
+
+                        </LinearLayout>
                     </LinearLayout>
 
                     <LinearLayout
                         android:id="@+id/ticketlayout"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
                         android:layout_weight="1"
                         android:orientation="horizontal">
 
@@ -159,6 +168,7 @@
                         android:id="@+id/catlayout"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
                         android:layout_weight="1"
                         android:orientation="horizontal">
 


### PR DESCRIPTION
Fix for difficult to read UI time bug plus issue with readability. 
- Time was written in a vertical column a few pixels wide.
- Time format was using a non-standard format that European and Asia-Pacific region people are unfamiliar with ie month/day/year. This has been corrected so the month is in written format to remove ambiguity.