### PR TITLE
Tidy up display of import screen before ticket gets imported

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -3,6 +3,7 @@ package io.stormbird.wallet.entity;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
@@ -433,6 +434,38 @@ public class Ticket extends Token implements Parcelable
         }
 
         return displayIDs;
+    }
+
+    /**
+     * Routine to blank a ticket on a page. It can be static because it doesn't use any class members
+     * It will throw an exception if given an activity page with no ticket on it
+     * @param activity
+     * @param blankingString
+     */
+    public static void blankTicketHolder(int blankingString, BaseActivity activity)
+    {
+        try
+        {
+            TextView textAmount = activity.findViewById(R.id.amount);
+            TextView textTicketName = activity.findViewById(R.id.name);
+            TextView textVenue = activity.findViewById(R.id.venue);
+            TextView textDate = activity.findViewById(R.id.date);
+            TextView textRange = activity.findViewById(R.id.tickettext);
+            TextView textCat = activity.findViewById(R.id.cattext);
+            TextView ticketDetails = activity.findViewById(R.id.ticket_details);
+
+            textAmount.setText("");
+            textTicketName.setText(blankingString);
+            textVenue.setText("");
+            textDate.setText("");
+            textRange.setText("");
+            textCat.setText("");
+            ticketDetails.setText("");
+        }
+        catch (Exception e)
+        {
+            Log.d("TICKET", e.getMessage());
+        }
     }
 
     /**

--- a/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
@@ -121,6 +121,8 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
 
         ticketRange = null;
 
+        Ticket.blankTicketHolder(R.string.loading,this);
+
         loadTicketToken();
     }
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -307,4 +307,5 @@
     <string name="unverified_contract">没有验证过的合约</string>
     <string name="ticket_not_valid">无效的Token</string>
     <string name="ticket_not_valid_body">在当前网络上此地址没有有效智能合约： 合同可能已经被终止，或者它可能位于不同的网络上。 可以尝试将网络改为“Ropsten（测试网络）”。</string>
+    <string name="loading">正在导入</string>
 </resources>

--- a/app/src/main/res/values/αWallet.xml
+++ b/app/src/main/res/values/αWallet.xml
@@ -312,4 +312,5 @@
     <string name="unverified_contract">Unverified Contract</string>
     <string name="ticket_not_valid">Invalid Ticket</string>
     <string name="ticket_not_valid_body">No valid contract at this address on this network. The contract could have been terminated or it may be on a different network. Try changing to \'Ropsten (Test)\'.</string>
+    <string name="loading">Loading …</string>
 </resources>


### PR DESCRIPTION
This patch tidies the appearance of the import screen.

Previously the import screen would display 'test data' (which is in the layout file) immediately on startup.
This text stays until the all the ticket details have been loaded. If loading is slow it looks bad.