### PR TITLE
allowing styling error page

### DIFF
--- a/dmz/src/main/java/io/stormbird/token/web/AppSiteController.java
+++ b/dmz/src/main/java/io/stormbird/token/web/AppSiteController.java
@@ -30,6 +30,8 @@ import io.stormbird.token.tools.ParseMagicLink;
 import io.stormbird.token.web.Ethereum.TransactionHandler;
 import io.stormbird.token.web.Service.CryptoFunctions;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
 import org.xml.sax.SAXException;
 
 
@@ -60,9 +62,9 @@ public class AppSiteController {
                 "}";
     }
 
-    @RequestMapping("/")
-    public String home(HttpServletRequest request){
-        return "index";
+    @GetMapping("/")
+    public RedirectView home(RedirectAttributes attributes){
+        return new RedirectView("https://awallet.io");
     }
 
     @GetMapping(value = "/{UniversalLink}")

--- a/dmz/src/main/resources/templates/error.html
+++ b/dmz/src/main/resources/templates/error.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title th:text="${error}">Error</title>
+  <style type="text/css">
+      #footer dt, #footer dd {
+          display: inline;
+      }
+      #footer dt {
+          font-weight: bold;
+      }
+      #footer dd {
+          margin-left: 0em;
+          padding-left: 1em;
+          margin-right: 3em;
+      }
+  </style>
+</head>
+<body>
+<h1 th:text="${error}">Error</h1>
+<p th:text="${message}">Error Message</p>
+
+<hr/>
+<dl id="footer">
+  <dt>Time: </dt><dd th:text="${timestamp}"></dd>
+  <dt>Path: </dt><dd th:text="${path}"></dd>
+  <dt>Message: </dt><dd th:text="${message}"></dd>
+</dl>
+</body>
+</html>


### PR DESCRIPTION
A simple error page is provided.

This partially solves #238 because now '/' redirects to https://awallet.io - more needs to be done.