### PR TITLE
Fix bug in XML parser

### DIFF
--- a/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
+++ b/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
@@ -231,7 +231,8 @@ public class TokenDefinition {
         return this.keyName;
     }
 
-    public String getFeemasterAPI(){
+    public String getFeemasterAPI()
+    {
         return feemasterAPI;
     }
 
@@ -269,7 +270,7 @@ public class TokenDefinition {
         for (Node nNode = node.getFirstChild(); nNode != null; nNode = nNode.getNextSibling()) {
             if (nNode.getNodeType() == Node.ELEMENT_NODE) {
                 Element eElement = (Element) nNode;
-                if (eElement.getTagName() == tagname) {
+                if (eElement.getTagName().equals(tagname)) {
                     return eElement.getTextContent();
                 }
             }


### PR DESCRIPTION
Fix for tag compare - language is Java unfortunately is not C++ or any civilised language where you can do operator overloading.