### PR TITLE
Fixed alignment in the box

### DIFF
--- a/dmz/src/main/resources/static/css/main.css
+++ b/dmz/src/main/resources/static/css/main.css
@@ -105,16 +105,28 @@ header.main {
   border: solid 1px #f3f3f3;
   padding: 1.5em; } }
 
+ .inline-box {
+  margin-top: 0;
+}
+  @media (min-width: 992px) {
+     .inline-box {
+  margin-top: 1em;
+  position: relative;
+  display: inline-block;
+} }
+
+
 .box-img {
   margin-left: 1em;
-  height: 20px;
-  width: 20px; }
+  height: 16px;
+  width: 16px; }
 @media (min-width: 992px) {
 .box-img {
-  margin-top: 1em;
   margin-left: 0;
-  height: 25px;
-  width: 25px; } }
+  height: 20px;
+  width: 20px; } }
+
+
 
 .device-img {
   width: 90%; }

--- a/dmz/src/main/resources/templates/error.html
+++ b/dmz/src/main/resources/templates/error.html
@@ -17,7 +17,6 @@
               <b><h1 th:text="${error}">Error</h1></b>
               <br>
               <p th:text="${message}">Error Message</p>
-              <b><h1>Error</h1></b>
             </div>
           </div>
         </div>

--- a/dmz/src/main/resources/templates/index.html
+++ b/dmz/src/main/resources/templates/index.html
@@ -29,17 +29,17 @@
                   <strong th:text="${tokenName}"/>
                   <em th:text="${ticketCategory}"></em>
                 </p>
-                <dl>
+                <dl class="inline-box">
                   <dt>
                   <img class="box-img" src="images/calendar.png" />
                   </dt>
-                  <dd th:text="${ticketDate}"/>
+                  <dd class="ml-1" style="font-size: 0.85em;" th:text="${ticketDate}"/>
                   <dt>
                   <img class="box-img" src="images/ticket.png" />
-                  </dt><dd th:text="${ticketSides}"/>
+                  </dt><dd class="ml-1" style="font-size: 0.85em;" th:text="${ticketSides}"/>
                   <dt>
                   <img class="box-img" src="images/category.png" />
-                  </dt><dd th:text="${ticketMatch}"/>
+                  </dt><dd class="ml-1" style="font-size: 0.85em;" th:text="${ticketMatch}"/>
                 </dl>
                 <p>Available till <span th:attr="title='Unix Time is ' + ${link.expiry}" th:text="${#dates.format(new java.util.Date(link.expiry*1000))}"/></p>
               </span>


### PR DESCRIPTION
Noticed alignment problems in the box, in particular the blue images and text beside it, after people imported tickets on their phones.

<img width="320" alt="screen shot 2018-07-10 at 12 27 45 am" src="https://user-images.githubusercontent.com/20555752/42463506-e20500a4-83d8-11e8-8ef7-0677fd18675c.png">
<img width="391" alt="screen shot 2018-07-10 at 12 27 53 am" src="https://user-images.githubusercontent.com/20555752/42463508-e26ed75e-83d8-11e8-89d9-c2a935b93beb.png">