### PR TITLE
Fix for the event that user rolls back app version

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/EtherscanTransaction.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/EtherscanTransaction.java
@@ -52,6 +52,7 @@ public class EtherscanTransaction
         TransactionOperation[] o;
         // Parse internal transaction - this is a RECEIVE_FROM_MAGICLINK transaction.
         /* 'operations' member is used in a lot of places. However,
+
 	 * I'd say a good refactor will sort this out, I think Scoff &
 	 * co had to make the unwieldy nested class set there to read
 	 * in data from their server. 'Operations' should really hold
@@ -59,7 +60,11 @@ public class EtherscanTransaction
 	 * object for each type of contract - ERC20/875 etc. The
 	 * places where operations is used then can be moved inside
 	 * these classes. We don't use his transaction server now
-	 * anyway.
+	 * anyway. - james
+	 *
+	 * I think Operations are intended in the context of transactional database.
+	 * This part needs review once there is a transactional framework in Ethereum.
+	 * - weiwu
          */
 
         if (internal)

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionOperation.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionOperation.java
@@ -3,6 +3,9 @@ package io.stormbird.wallet.entity;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+/* weiwu: I think this is what intended:
+   a transaction is a single unit of logic or work, sometimes made up of multiple operations.
+ */
 public class TransactionOperation implements Parcelable {
     public String transactionId;
     public String viewType;

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -14,9 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.stormbird.token.tools.ParseMagicLink;
+import io.stormbird.wallet.entity.ERC875ContractTransaction;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
+import io.stormbird.wallet.entity.TransactionContract;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.AddTokenInteract;
 import io.stormbird.wallet.interact.FetchTokensInteract;
@@ -204,6 +207,16 @@ public class TransactionsViewModel extends BaseViewModel
         {
             txMap.put(tx.hash, tx);
             if (Long.valueOf(tx.blockNumber) > lastBlock) lastBlock = Long.valueOf(tx.blockNumber);
+            //this code fixes values in case user rolls back version
+            if (tx.operations != null && tx.operations.length > 0 && tx.operations[0] != null)
+            {
+                TransactionContract ct = tx.operations[0].contract;
+                if (ct instanceof ERC875ContractTransaction && ((ERC875ContractTransaction)ct).operation > 0 && ((ERC875ContractTransaction)ct).operation < 30)
+                {
+                    refreshCache = true;
+                    break;
+                }
+            }
         }
 
         if (refreshCache)

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -211,6 +211,8 @@ public class TransactionsViewModel extends BaseViewModel
             if (tx.operations != null && tx.operations.length > 0 && tx.operations[0] != null)
             {
                 TransactionContract ct = tx.operations[0].contract;
+                // weiwu: james said this is his private tur for now and all references to a fixed number for operation will be fixed no late than Nov 2018
+                // FIXME: there shouldn't be a magic number 30, why not 32 or 32768?
                 if (ct instanceof ERC875ContractTransaction && ((ERC875ContractTransaction)ct).operation > 0 && ((ERC875ContractTransaction)ct).operation < 30)
                 {
                     refreshCache = true;

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -207,7 +207,7 @@ public class TransactionsViewModel extends BaseViewModel
         {
             txMap.put(tx.hash, tx);
             if (Long.valueOf(tx.blockNumber) > lastBlock) lastBlock = Long.valueOf(tx.blockNumber);
-            //this code fixes values in case user rolls back version
+            //this code fixes values in case user rolls back the version of their αWallet app
             if (tx.operations != null && tx.operations.length > 0 && tx.operations[0] != null)
             {
                 TransactionContract ct = tx.operations[0].contract;


### PR DESCRIPTION
With the swathe of refactoring about to come in - should the user (or us) roll back versions for whatever reason the transactions view will show a lot of blank entries. This fix causes the app to rebuild the cached transactions if the user rolls back.