### PR TITLE
Firebase Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,22 +1,6 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.fabric.io/public' }
-    }
-
-    dependencies {
-        classpath 'io.fabric.tools:gradle:1.25.1'
-    }
-}
 apply plugin: 'com.android.application'
-//apply plugin: 'io.fabric'
 apply plugin: 'realm-android'
-
-repositories {
-    maven {
-        url 'https://maven.fabric.io/public'
-    }
-}
-
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 27
@@ -149,15 +133,13 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    // Fabric
-//    implementation('com.crashlytics.sdk.android:crashlytics:2.8.0@aar') {
-//        transitive = true
-//    }
-//    implementation('com.crashlytics.sdk.android:answers:1.4.1@aar') {
-//        transitive = true
-//    }
+    // Firebase + Crashlytics
+    implementation 'com.google.firebase:firebase-core:16.0.4'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
 
     // PW
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':tn')
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/app/fabric.properties
+++ b/app/fabric.properties
@@ -1,4 +1,0 @@
-#Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
-#Thu Dec 21 15:16:27 KRAT 2017
-#Wed Dec 13 10:43:28 KRAT 2017
-apiSecret=8973b953bafdeaf177a2bae935a2bfba6158575b615f75305af25cf01a6adac6

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,55 @@
+{
+  "project_info": {
+    "project_number": "409922468441",
+    "firebase_url": "https://alpha-wallet-android-186eb.firebaseio.com",
+    "project_id": "alpha-wallet-android-186eb",
+    "storage_bucket": "alpha-wallet-android-186eb.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:409922468441:android:4695da910af3c1e8",
+        "android_client_info": {
+          "package_name": "io.stormbird.wallet"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "409922468441-ob3b2hpr9ftopgcki00s5mvr0cmtut1m.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "io.stormbird.wallet",
+            "certificate_hash": "a0f71d66080a0678f7a9ae27aa781aaeb8e1b911"
+          }
+        },
+        {
+          "client_id": "409922468441-379o98s1143kp1vlgk26e140ej1mgoq0.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyANAsW3omQK0Ze19NlIXtQTWNhZWv_PS3k"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "409922468441-379o98s1143kp1vlgk26e140ej1mgoq0.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -36,9 +36,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="74d3fa8b5038a154c0c05555d27112a0d4a80d68" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <application
         android:name="io.stormbird.wallet.App"
         android:allowBackup="false"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:launchMode="singleTask"
@@ -19,7 +20,6 @@
         android:supportsRtl="true"
         android:testOnly="false"
         android:theme="@style/AppTheme.NoActionBar"
-        android:hardwareAccelerated="true"
         tools:replace="android:name, android:theme, android:allowBackup">
         <activity
             android:name="io.stormbird.wallet.ui.SplashActivity"
@@ -52,7 +52,7 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/filepaths"/>
+                android:resource="@xml/filepaths" />
         </provider>
 
         <activity
@@ -154,7 +154,7 @@
 
         <activity
             android:name="io.stormbird.wallet.ui.zxing.QRScanningActivity"
-            android:label="@string/qr_scanner"/>
+            android:label="@string/qr_scanner" />
 
         <meta-data
             android:name="preloaded_fonts"

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,16 @@ buildscript {
         jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://maven.fabric.io/public' }
         google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "io.realm:realm-gradle-plugin:4.4.0"
+        classpath 'com.google.gms:google-services:4.1.0'
+
+        // Add dependency
+        classpath 'io.fabric.tools:gradle:1.25.4'
     }
 }
 
@@ -21,9 +26,8 @@ allprojects {
         mavenCentral()
         maven { url 'https://jitpack.io' }
         // needed for pincode Lollipin
-        maven {
-            url "https://github.com/omadahealth/omada-nexus/raw/master/release"
-        }
+        maven { url "https://github.com/omadahealth/omada-nexus/raw/master/release" }
+        maven { url 'https://maven.google.com/' }
     }
 }
 


### PR DESCRIPTION
Added crash monitoring function via Firebase Crashlytics - was intend to solve #190

ACTION ITEM:
I would need a list of Google emails so I could add/transfer ownership of the dashboard. Currently only I have access to this.

Have tested with forced crashes via `Crashlytics.getInstance().crash()`. Screenshot below:

![screen shot 2018-10-12 at 10 57 47 pm](https://user-images.githubusercontent.com/17334718/46877019-59069f80-ce72-11e8-9bdd-43749558dc2a.png)
