### PR TITLE
Detect erc875 interface spec and use appropriate function signatures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "io.stormbird.wallet"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 21
-        versionName "1.0.15"
+        versionCode 20
+        versionName "1.0.14"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
 

--- a/app/src/main/java/io/stormbird/wallet/di/ConfirmationModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/ConfirmationModule.java
@@ -10,6 +10,7 @@ import io.stormbird.wallet.repository.TransactionRepositoryType;
 import io.stormbird.wallet.repository.WalletRepositoryType;
 import io.stormbird.wallet.router.GasSettingsRouter;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.ConfirmationViewModelFactory;
 
 import dagger.Module;
@@ -23,9 +24,10 @@ public class ConfirmationModule {
             FetchGasSettingsInteract fetchGasSettingsInteract,
             CreateTransactionInteract createTransactionInteract,
             GasSettingsRouter gasSettingsRouter,
-            MarketQueueService marketQueueService
+            MarketQueueService marketQueueService,
+            TokensService tokensService
     ) {
-        return new ConfirmationViewModelFactory(findDefaultWalletInteract, fetchGasSettingsInteract, createTransactionInteract, gasSettingsRouter, marketQueueService);
+        return new ConfirmationViewModelFactory(findDefaultWalletInteract, fetchGasSettingsInteract, createTransactionInteract, gasSettingsRouter, marketQueueService, tokensService);
     }
 
     @Provides

--- a/app/src/main/java/io/stormbird/wallet/di/PurchaseTicketsModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/PurchaseTicketsModule.java
@@ -9,6 +9,7 @@ import io.stormbird.wallet.repository.PasswordStore;
 import io.stormbird.wallet.repository.TransactionRepositoryType;
 import io.stormbird.wallet.repository.WalletRepositoryType;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.PurchaseTicketsViewModelFactory;
 
 import dagger.Module;
@@ -26,9 +27,10 @@ public class PurchaseTicketsModule
             FindDefaultNetworkInteract findDefaultNetworkInteract,
             FindDefaultWalletInteract findDefaultWalletInteract,
             CreateTransactionInteract createTransactionInteract,
-            MarketQueueService marketQueueService) {
+            MarketQueueService marketQueueService,
+            TokensService tokensService) {
         return new PurchaseTicketsViewModelFactory(
-                findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, marketQueueService);
+                findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, marketQueueService, tokensService);
     }
 
     @Provides

--- a/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
@@ -13,6 +13,7 @@ import io.stormbird.wallet.router.TransferTicketRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.FeeMasterService;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.TransferTicketDetailViewModelFactory;
 
 import dagger.Module;
@@ -34,9 +35,10 @@ public class TransferTicketDetailModule {
             TransferTicketDetailRouter transferTicketDetailRouter,
             FeeMasterService feeMasterService,
             AssetDisplayRouter assetDisplayRouter,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            TokensService tokensService) {
         return new TransferTicketDetailViewModelFactory(
-                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService);
+                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService);
     }
 
     @Provides

--- a/app/src/main/java/io/stormbird/wallet/entity/EtherscanTransaction.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/EtherscanTransaction.java
@@ -95,15 +95,18 @@ public class EtherscanTransaction
                     switch (f.functionData.functionFullName)
                     {
                         case "trade(uint256,uint16[],uint8,bytes32,bytes32)":
+                        case "trade(uint256,uint256[],uint8,bytes32,bytes32)":
                             o = processTrade(f);
                             setName(o, TransactionType.MAGICLINK_TRANSFER);
                             break;
                         case "transferFrom(address,address,uint16[])":
+                        case "transferFrom(address,address,uint256[])":
                             o = generateERC875Op();
                             o[0].contract.setIndicies(f.paramValues);
                             setName(o, TransactionType.TRANSFER_TO);
                             break;
                         case "transfer(address,uint16[])":
+                        case "transfer(address,uint256[])":
                             o = generateERC875Op();
                             o[0].contract.setOtherParty(from);
                             o[0].contract.setIndicies(f.paramValues);
@@ -119,6 +122,7 @@ public class EtherscanTransaction
                             setName(o, TransactionType.TRANSFER_TO);
                             break;
                         case "loadNewTickets(bytes32[])":
+                        case "loadNewTickets(uint256[])":
                             o = generateERC875Op();
                             op = o[0];
                             op.from = from;
@@ -127,6 +131,7 @@ public class EtherscanTransaction
                             setName(o, TransactionType.LOAD_NEW_TOKENS);
                             break;
                         case "passTo(uint256,uint16[],uint8,bytes32,bytes32,address)":
+                        case "passTo(uint256,uint256[],uint8,bytes32,bytes32,address)":
                             o = processPassTo(f);
                             op = o[0];
                             op.from = from;

--- a/app/src/main/java/io/stormbird/wallet/entity/MagicLinkParcel.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/MagicLinkParcel.java
@@ -95,7 +95,7 @@ public class MagicLinkParcel implements Parcelable
         return 0;
     }
 
-    public static byte[] generateReverseTradeData(MagicLinkData order)
+    public static byte[] generateReverseTradeData(MagicLinkData order, Token token)
     {
         byte[] data = null;
         try
@@ -108,7 +108,7 @@ public class MagicLinkParcel implements Parcelable
             //convert to signature representation
             Sign.SignatureData sellerSig = sigFromByteArray(order.signature);
 
-            data = TokenRepository.createTrade(expiry, ticketIndices, (int)sellerSig.getV(), sellerSig.getR(), sellerSig.getS());
+            data = TokenRepository.createTrade(token, expiry, ticketIndices, (int)sellerSig.getV(), sellerSig.getR(), sellerSig.getS());
         }
         catch (Exception e)
         {

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -201,6 +201,12 @@ public class Ticket extends Token implements Parcelable
     }
 
     @Override
+    public void setRealmInterfaceSpec(RealmToken realmToken)
+    {
+        realmToken.setInterfaceSpec(interfaceSpec.ordinal());
+    }
+
+    @Override
     public void clickReact(BaseViewModel viewModel, Context context)
     {
         viewModel.showRedeemToken(context, this);
@@ -704,6 +710,22 @@ public class Ticket extends Token implements Parcelable
         }
     }
 
+    @Override
+    public void setInterfaceSpecFromRealm(RealmToken realm)
+    {
+        this.interfaceSpec = InterfaceType.values()[realm.getInterfaceSpec()];
+    }
+
+    @Override
+    public void patchAuxData(Token token)
+    {
+        if (token instanceof Ticket)
+        {
+            this.interfaceSpec = InterfaceType.values()[((Ticket)token).interfaceOrdinal()];
+        }
+        super.patchAuxData(token);
+    }
+
     public Function getTradeFunction(BigInteger expiry, List<BigInteger> indices, int v, byte[] r, byte[] s)
     {
         return new Function(
@@ -757,16 +779,20 @@ public class Ticket extends Token implements Parcelable
         return dynArray;
     }
 
-    public boolean needsInterfaceSpecUpdate(RealmToken realmToken)
+    @Override
+    public boolean checkRealmBalanceChange(RealmToken realmToken)
     {
-        int spec = 256;
-        if (interfaceSpec == InterfaceType.UsingUint16) spec = 16;
+        if (interfaceSpec.ordinal() != realmToken.getInterfaceSpec()) return true;
+        return super.checkRealmBalanceChange(realmToken);
+    }
 
-        return (realmToken.getTokenId() != spec);
+    public int interfaceOrdinal()
+    {
+        return interfaceSpec.ordinal();
     }
 
     private enum InterfaceType
     {
-        UsingUint16, UsingUint256
+        NotSpecified, UsingUint16, UsingUint256
     };
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -9,6 +9,9 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Function;
+import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.generated.Uint16;
 import org.web3j.utils.Numeric;
 
@@ -18,8 +21,9 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.List;
@@ -50,6 +54,7 @@ public class Ticket extends Token implements Parcelable
     public final List<BigInteger> balanceArray;
     private List<Integer> burnIndices;
     private boolean isMatchedInXML = false;
+    private InterfaceType interfaceSpec = InterfaceType.UsingUint256;
 
     public Ticket(TokenInfo tokenInfo, List<BigInteger> balances, List<Integer> burned, long blancaTime) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime);
@@ -69,6 +74,8 @@ public class Ticket extends Token implements Parcelable
         burnIndices = new ArrayList<Integer>();
         int objSize = in.readInt();
         int burnSize = in.readInt();
+        int interfaceOrdinal = in.readInt();
+        interfaceSpec = InterfaceType.values()[interfaceOrdinal];
         if (objSize > 0)
         {
             Object[] readObjArray = in.readArray(Object.class.getClassLoader());
@@ -124,6 +131,7 @@ public class Ticket extends Token implements Parcelable
         super.writeToParcel(dest, flags);
         dest.writeInt(balanceArray.size());
         dest.writeInt(burnIndices.size());
+        dest.writeInt(interfaceSpec.ordinal());
         if (balanceArray.size() > 0) dest.writeArray(balanceArray.toArray());
         if (burnIndices.size() > 0) dest.writeArray(burnIndices.toArray());
     }
@@ -670,48 +678,6 @@ public class Ticket extends Token implements Parcelable
         }
     }
 
-//    public int getXMLTokenNetwork(BaseActivity activity)
-//    {
-//        TokenDefinition td = getTokenDefinition(activity);
-//        if (td != null) return td.getNetworkId();
-//        else return 1;
-//    }
-//
-//    public String getXMLContractAddress(BaseActivity activity, int networkId)
-//    {
-//        TokenDefinition td = getTokenDefinition(activity);
-//        if (td != null) return td.getContractAddress(networkId);
-//        else return "0x";
-//    }
-//
-//    public String getXMLTokenName()
-//    {
-//        TokenDefinition td = getTokenDefinition(activity);
-//        if (td != null) return td.
-//                getTokenName();
-//        else return "Generic Token";
-//    }
-
-//    private TokenDefinition getTokenDefinition(BaseActivity activity)
-//    {
-//        try
-//        {
-//            return new TokenDefinition(
-//                    activity.getResources().getAssets().open("TicketingContract.xml"),
-//                    activity.getResources().getConfiguration().locale);
-//        }
-//        catch (IOException e)
-//        {
-//            //react to file not found
-//            return null;
-//        }
-//        catch (SAXException e)
-//        {
-//            //react to interpretation exception
-//            return null;
-//        }
-//    }
-
     public void checkIsMatchedInXML(AssetDefinitionService assetService)
     {
         int networkId = assetService.getNetworkId(getAddress());
@@ -722,4 +688,85 @@ public class Ticket extends Token implements Parcelable
     {
         return isMatchedInXML;
     }
+
+    @Override
+    public void setInterfaceSpec(int data)
+    {
+        switch (data)
+        {
+            case 16:
+                this.interfaceSpec = InterfaceType.UsingUint16;
+                break;
+            case 256:
+            default:
+                this.interfaceSpec = InterfaceType.UsingUint256;
+                break;
+        }
+    }
+
+    public Function getTradeFunction(BigInteger expiry, List<BigInteger> indices, int v, byte[] r, byte[] s)
+    {
+        return new Function(
+                "trade",
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(expiry),
+                                    getDynArray(indices),
+                                    new org.web3j.abi.datatypes.generated.Uint8(v),
+                                    new org.web3j.abi.datatypes.generated.Bytes32(r),
+                                    new org.web3j.abi.datatypes.generated.Bytes32(s)),
+                Collections.<TypeReference<?>>emptyList());
+    }
+
+    public Function getTransferFunction(String to, List<BigInteger> indices)
+    {
+        return new Function(
+                "transfer",
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(to),
+                                    getDynArray(indices)
+                                ),
+                Collections.<TypeReference<?>>emptyList());
+    }
+
+    public boolean isOldSpec()
+    {
+        switch (interfaceSpec)
+        {
+            case UsingUint16:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private org.web3j.abi.datatypes.DynamicArray getDynArray(List<BigInteger> indices)
+    {
+        org.web3j.abi.datatypes.DynamicArray dynArray;
+
+        switch (interfaceSpec)
+        {
+            case UsingUint16:
+                dynArray = new org.web3j.abi.datatypes.DynamicArray<>(
+                        org.web3j.abi.Utils.typeMap(indices, org.web3j.abi.datatypes.generated.Uint16.class));
+                break;
+            case UsingUint256:
+            default:
+                dynArray = new org.web3j.abi.datatypes.DynamicArray<>(
+                        org.web3j.abi.Utils.typeMap(indices, org.web3j.abi.datatypes.generated.Uint256.class));
+                break;
+        }
+
+        return dynArray;
+    }
+
+    public boolean needsInterfaceSpecUpdate(RealmToken realmToken)
+    {
+        int spec = 256;
+        if (interfaceSpec == InterfaceType.UsingUint16) spec = 16;
+
+        return (realmToken.getTokenId() != spec);
+    }
+
+    private enum InterfaceType
+    {
+        UsingUint16, UsingUint256
+    };
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -309,9 +309,15 @@ public class Token implements Parcelable
         String currentState = realmToken.getBalance();
         if (currentState == null) return true;
         if (tokenInfo.name != null && realmToken.getName() == null) return true; //signal to update database if correct name has been fetched (node timeout etc)
+        if (tokenInfo.name != null && (!tokenInfo.name.equals(realmToken.getName()) || !tokenInfo.symbol.equals(realmToken.getSymbol()))) return true;
         if (tokenInfo.isStormbird != realmToken.isStormbird()) return true;
         String currentBalance = getFullBalance();
         return !currentState.equals(currentBalance);
+    }
+
+    public void setRealmInterfaceSpec(RealmToken realmToken)
+    {
+
     }
 
     public void setIsEthereum()
@@ -350,6 +356,10 @@ public class Token implements Parcelable
 
     public void setInterfaceSpec(int b) { }
     public boolean isOldSpec() { return false; }
+    public void setInterfaceSpecFromRealm(RealmToken ordinal)
+    {
+
+    }
 
     public String getFunctionSignature(String function)
     {
@@ -359,5 +369,10 @@ public class Token implements Parcelable
     public boolean needsInterfaceSpecUpdate(RealmToken realmToken)
     {
         return false;
+    }
+
+    public void patchAuxData(Token token)
+    {
+
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -347,4 +347,17 @@ public class Token implements Parcelable
     {
         this.tokenNetwork = (short)tokenNetwork;
     }
+
+    public void setInterfaceSpec(int b) { }
+    public boolean isOldSpec() { return false; }
+
+    public String getFunctionSignature(String function)
+    {
+        return "";
+    }
+
+    public boolean needsInterfaceSpecUpdate(RealmToken realmToken)
+    {
+        return false;
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
@@ -48,7 +48,6 @@ public class TokenFactory
             String balances = realmItem.getBalance();
             String burnList = realmItem.getBurnList();
             thisToken = new Ticket(tokenInfo, balances, burnList, updateBlancaTime);
-            thisToken.setInterfaceSpec(realmItem.getTokenId());
         }
         else
         {
@@ -57,6 +56,8 @@ public class TokenFactory
                 ? null : new BigDecimal(realmItem.getBalance());
             thisToken = new Token(tokenInfo, balance, updateBlancaTime);
         }
+
+        thisToken.setInterfaceSpecFromRealm(realmItem);
 
         return thisToken;
     }
@@ -79,6 +80,8 @@ public class TokenFactory
             BigDecimal balance = new BigDecimal(realmBalance);
             thisToken = new Token(tokenInfo, balance, updateBlancaTime);
         }
+
+        thisToken.setInterfaceSpecFromRealm(realmItem);
 
         return thisToken;
     }

--- a/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
@@ -48,6 +48,7 @@ public class TokenFactory
             String balances = realmItem.getBalance();
             String burnList = realmItem.getBurnList();
             thisToken = new Ticket(tokenInfo, balances, burnList, updateBlancaTime);
+            thisToken.setInterfaceSpec(realmItem.getTokenId());
         }
         else
         {

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionDecoder.java
@@ -240,6 +240,13 @@ public class TransactionDecoder
             "approve(address,uint256)",
             "loadNewTickets(bytes32[])",
             "passTo(uint256,uint16[],uint8,bytes32,bytes32,address)",
+            //updated ERC875 function sigs
+            "transferFrom(address,address,uint256[])",
+            "transfer(address,uint256[])",
+            "trade(uint256,uint256[],uint8,bytes32,bytes32)",
+            "passTo(uint256,uint256[],uint8,bytes32,bytes32,address)",
+            "loadNewTickets(uint256[])",
+            //end updated ERC875 sigs
             "endContract()",
             "selfdestruct()",
             "kill()"
@@ -254,6 +261,11 @@ public class TransactionDecoder
             false,
             false, //loadNewTickets
             true,  //passTo
+            false, //updated transferFrom
+            false,
+            true, //updated trade
+            true, //updated passTo
+            false,
             false, //endContract
             false,  //selfdestruct()
             false
@@ -271,7 +283,12 @@ public class TransactionDecoder
             ERC20,
             ERC20,
             ERC875,
+            ERC875, //old loadnewtickets
+            ERC875, //updated transferFrom
             ERC875,
+            ERC875,
+            ERC875,
+            ERC875, //updated loadNewTickets
             CREATION, //endContract
             CREATION, //selfdestruct
             CREATION  //kill
@@ -339,7 +356,7 @@ public class TransactionDecoder
         return indices;
     }
 
-    private static String buildMethodId(String methodSignature) {
+    public static String buildMethodId(String methodSignature) {
         byte[] input = methodSignature.getBytes();
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);

--- a/app/src/main/java/io/stormbird/wallet/interact/SetupTokensInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/SetupTokensInteract.java
@@ -313,12 +313,6 @@ public class SetupTokensInteract {
                     TransactionInput data = transactionDecoder.decodeInput(thisTrans.input);
                     token = thisTokenTrans.token;
 
-                    if (token != null && thisTrans.isConstructor && thisTrans.operations.length > 0)
-                    {
-                        token.setInterfaceSpec(thisTrans.operations[0].contract.decimals);
-                        tokensService.setInterfaceSpec(token.getAddress(), thisTrans.operations[0].contract.decimals);
-                    }
-
                     if (walletInvolvedInTransaction(thisTrans, data, wallet)) {
                         Transaction newTx = parseTransaction(thisTokenTrans.token, thisTrans, data, tokensService);
                         if (newTx != null)
@@ -344,7 +338,7 @@ public class SetupTokensInteract {
             catch (Exception e) {
                 e.printStackTrace();
             }
-            if (highestBlock > 0) tokensService.tokenContractUpdated(token, highestBlock);
+            if (highestBlock > 0) tokensService.setLatestBlock(token.getAddress(), highestBlock);
             return processedTransactions.toArray(new Transaction[processedTransactions.size()]);
         });
     }

--- a/app/src/main/java/io/stormbird/wallet/interact/SetupTokensInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/SetupTokensInteract.java
@@ -8,13 +8,14 @@ import android.util.Log;
 
 import org.web3j.utils.Numeric;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.stormbird.wallet.R;
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 import io.stormbird.wallet.entity.ERC875ContractTransaction;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Token;
@@ -28,9 +29,6 @@ import io.stormbird.wallet.entity.TransactionOperation;
 import io.stormbird.wallet.entity.TransactionType;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.repository.TokenRepositoryType;
-import io.reactivex.Observable;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
 import io.stormbird.wallet.service.TokensService;
 
 public class SetupTokensInteract {
@@ -314,6 +312,12 @@ public class SetupTokensInteract {
                     Transaction thisTrans = thisTokenTrans.transaction;
                     TransactionInput data = transactionDecoder.decodeInput(thisTrans.input);
                     token = thisTokenTrans.token;
+
+                    if (token != null && thisTrans.isConstructor && thisTrans.operations.length > 0)
+                    {
+                        token.setInterfaceSpec(thisTrans.operations[0].contract.decimals);
+                        tokensService.setInterfaceSpec(token.getAddress(), thisTrans.operations[0].contract.decimals);
+                    }
 
                     if (walletInvolvedInTransaction(thisTrans, data, wallet)) {
                         Transaction newTx = parseTransaction(thisTokenTrans.token, thisTrans, data, tokensService);

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -266,16 +266,6 @@ public class TokenRepository implements TokenRepositoryType {
                 });
     }
 
-//    private Single<Token> attachCachedEth(NetworkInfo network, Wallet wallet) {
-//        return walletRepository.balanceInWei(wallet)
-//                .map(balance -> {
-//                    TokenInfo info = new TokenInfo(wallet.address, network.name, network.symbol, 18, true);
-//                    Token eth = new Token(info, balance, System.currentTimeMillis());
-//                    eth.setIsEthereum();
-//                    return eth;
-//                });
-//    }
-
     private Single<Token> attachCachedEth(NetworkInfo network, Wallet wallet)
     {
         //get stored eth balance
@@ -421,6 +411,22 @@ public class TokenRepository implements TokenRepositoryType {
         newToken.setTokenWallet(wallet.address);
         newToken.setTokenNetwork(ethereumNetworkRepository.getDefaultNetwork().chainId);
         Log.d(TAG, "Create for store3: " + tokenInfo.name);
+
+        return localSource.saveToken(
+                ethereumNetworkRepository.getDefaultNetwork(),
+                wallet,
+                newToken);
+    }
+
+    @Override
+    public Single<Token> addToken(Wallet wallet, TokenInfo tokenInfo, int interfaceSpec)
+    {
+        TokenFactory tf = new TokenFactory();
+        Token newToken = tf.createToken(tokenInfo);
+        newToken.setTokenWallet(wallet.address);
+        newToken.setTokenNetwork(ethereumNetworkRepository.getDefaultNetwork().chainId);
+        newToken.setInterfaceSpec(interfaceSpec);
+        Log.d(TAG, "Create for store4: " + tokenInfo.name);
 
         return localSource.saveToken(
                     ethereumNetworkRepository.getDefaultNetwork(),
@@ -592,6 +598,7 @@ public class TokenRepository implements TokenRepositoryType {
                 }
 
                 Token updated = tFactory.createToken(tInfo, balance, balanceArray, burnArray, System.currentTimeMillis());
+                updated.patchAuxData(token); //perform any updates we need here
                 localSource.updateTokenBalance(network, wallet, updated);
                 updated.setTokenWallet(wallet.address);
                 updated.setTokenNetwork(network.chainId);
@@ -1097,46 +1104,20 @@ public class TokenRepository implements TokenRepositoryType {
         return Numeric.hexStringToByteArray(Numeric.cleanHexPrefix(encodedFunction));
     }
 
-    private static Function getTransferFunction(String to, List<BigInteger> ticketIndices)
-    {
-        Function function = new Function(
-                "transfer",
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(to),
-                        new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint16>(
-                                org.web3j.abi.Utils.typeMap(ticketIndices, org.web3j.abi.datatypes.generated.Uint16.class))),
-                Collections.<TypeReference<?>>emptyList());
-        return function;
-    }
-
-    public static byte[] createTicketTransferData(String to, String indexListStr) {
-        //params are: Address, List<Uint16> of ticket indicies
+    public static byte[] createTicketTransferData(String to, String indexListStr, Token token) {
         List ticketIndicies = Observable.fromArray(indexListStr.split(","))
                 .map(s -> new BigInteger(s.trim())).toList().blockingGet();
-        Function function = getTransferFunction(to, ticketIndicies);
+        Function function = ((Ticket)token).getTransferFunction(to, ticketIndicies);
 
         String encodedFunction = FunctionEncoder.encode(function);
         return Numeric.hexStringToByteArray(Numeric.cleanHexPrefix(encodedFunction));
     }
 
-    public static byte[] createTrade(BigInteger expiry, List<BigInteger> ticketIndices, int v, byte[] r, byte[] s)
+    public static byte[] createTrade(Token token, BigInteger expiry, List<BigInteger> ticketIndices, int v, byte[] r, byte[] s)
     {
-        Function function = getTradeFunction(expiry, ticketIndices, v, r, s);
+        Function function = ((Ticket)token).getTradeFunction(expiry, ticketIndices, v, r, s);
         String encodedFunction = FunctionEncoder.encode(function);
         return Numeric.hexStringToByteArray(Numeric.cleanHexPrefix(encodedFunction));
-    }
-
-    private static Function getTradeFunction(BigInteger expiry, List<BigInteger> ticketIndices, int v, byte[] r, byte[] s)
-    {
-        Function function = new Function(
-                "trade",
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(expiry),
-                        new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint16>(
-                                org.web3j.abi.Utils.typeMap(ticketIndices, org.web3j.abi.datatypes.generated.Uint16.class)),
-                        new org.web3j.abi.datatypes.generated.Uint8(v),
-                        new org.web3j.abi.datatypes.generated.Bytes32(r),
-                        new org.web3j.abi.datatypes.generated.Bytes32(s)),
-                Collections.<TypeReference<?>>emptyList());
-        return function;
     }
 
     private Token[] mapToTokens(TokenInfo[] items) {

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -40,6 +40,7 @@ public interface TokenRepositoryType {
     rx.Subscription memPoolListener(SubscribeWrapper wrapper); //only listen to transactions relating to this address
     rx.Observable<TransferFromEventResponse> burnListenerObservable(String contractAddress);
     Single<Token> addToken(Wallet wallet, TokenInfo tokenInfo);
+    Single<Token> addToken(Wallet wallet, TokenInfo tokenInfo, int interfaceSpec);
     Completable setBurnList(Wallet wallet, Token token, List<Integer> burnList);
     Single<Token[]> addTokens(Wallet wallet, TokenInfo[] tokenInfos);
     Single<Ticker> getEthTicker();

--- a/app/src/main/java/io/stormbird/wallet/repository/entity/RealmToken.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/entity/RealmToken.java
@@ -17,6 +17,7 @@ public class RealmToken extends RealmObject {
     private boolean isStormbird;
     private String burnList;
     private int nullCheckCount = 0;
+    private int interfaceSpec;
 
     public int getDecimals() {
         return decimals;
@@ -119,5 +120,15 @@ public class RealmToken extends RealmObject {
     public int getNullCheckCount()
     {
         return nullCheckCount;
+    }
+
+    public int getInterfaceSpec()
+    {
+        return interfaceSpec;
+    }
+
+    public void setInterfaceSpec(int interfaceSpec)
+    {
+        this.interfaceSpec = interfaceSpec;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -14,6 +14,7 @@ public class TokensService
     private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private List<String> terminationList = new ArrayList<>();
     private Map<String, Long> updateMap = new ConcurrentHashMap<>();
+    private Map<String, Integer> interfaceSpecMap = new ConcurrentHashMap<>();
 
     private String currentAddress = null;
     private int currentNetwork = 0;
@@ -32,8 +33,32 @@ public class TokensService
         if (t.checkTokenNetwork(currentNetwork) && t.checkTokenWallet(currentAddress))
         {
             tokenMap.put(t.getAddress(), t);
+            setSpec(t);
         }
+
         return t;
+    }
+
+    private void setSpec(Token t)
+    {
+        if (interfaceSpecMap.get(t.getAddress()) != null)
+        {
+            t.setInterfaceSpec(interfaceSpecMap.get(t.getAddress()));
+        }
+    }
+
+    public boolean hasOldSpec(String address)
+    {
+        Token token = tokenMap.get(address);
+        if (token != null && interfaceSpecMap.get(address) != null)
+        {
+            token.setInterfaceSpec(interfaceSpecMap.get(token.getAddress()));
+            return token.isOldSpec();
+        }
+        else
+        {
+            return false;
+        }
     }
 
     public Token getToken(String addr)
@@ -46,6 +71,7 @@ public class TokensService
         currentAddress = "";
         currentNetwork = 0;
         tokenMap.clear();
+        updateMap.clear();
     }
 
     public List<Token> getAllTokens()
@@ -86,6 +112,7 @@ public class TokensService
             if (t.checkTokenNetwork(currentNetwork) && t.checkTokenWallet(currentAddress))
             {
                 tokenMap.put(t.getAddress(), t);
+                setSpec(t);
             }
         }
     }
@@ -132,5 +159,16 @@ public class TokensService
     public void setCurrentNetwork(int currentNetwork)
     {
         this.currentNetwork = currentNetwork;
+    }
+
+    public void setInterfaceSpec(String address, int functionSpec)
+    {
+        interfaceSpecMap.put(address, functionSpec);
+
+        Token token = tokenMap.get(address);
+        if (token != null)
+        {
+            token.setInterfaceSpec(functionSpec);
+        }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -13,9 +13,8 @@ public class TokensService
 {
     private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private List<String> terminationList = new ArrayList<>();
+    private static Map<String, Integer> interfaceSpecMap = new ConcurrentHashMap<>();
     private Map<String, Long> updateMap = new ConcurrentHashMap<>();
-    private Map<String, Integer> interfaceSpecMap = new ConcurrentHashMap<>();
-
     private String currentAddress = null;
     private int currentNetwork = 0;
 
@@ -44,20 +43,6 @@ public class TokensService
         if (interfaceSpecMap.get(t.getAddress()) != null)
         {
             t.setInterfaceSpec(interfaceSpecMap.get(t.getAddress()));
-        }
-    }
-
-    public boolean hasOldSpec(String address)
-    {
-        Token token = tokenMap.get(address);
-        if (token != null && interfaceSpecMap.get(address) != null)
-        {
-            token.setInterfaceSpec(interfaceSpecMap.get(token.getAddress()));
-            return token.isOldSpec();
-        }
-        else
-        {
-            return false;
         }
     }
 
@@ -117,11 +102,9 @@ public class TokensService
         }
     }
 
-
     public Observable<List<String>> reduceToUnknown(List<String> addrs)
     {
         return Observable.fromCallable(() -> {
-            List<String> addresses = new ArrayList<>();
             for (Token t : tokenMap.values())
             {
                 if (addrs.contains(t.getAddress()))
@@ -134,41 +117,36 @@ public class TokensService
         });
     }
 
-    public void tokenContractUpdated(Token token, long blockNumber)
-    {
-        updateMap.put(token.getAddress(), blockNumber);
-    }
-
-    public long getLastBlock(Token token)
-    {
-        if (updateMap.get(token.getAddress()) != null)
-        {
-            return updateMap.get(token.getAddress());
-        }
-        else
-        {
-            return 0;
-        }
-    }
-
     public void setCurrentAddress(String currentAddress)
     {
         this.currentAddress = currentAddress;
     }
+    public String getCurrentAddress() { return this.currentAddress; }
 
     public void setCurrentNetwork(int currentNetwork)
     {
         this.currentNetwork = currentNetwork;
     }
 
-    public void setInterfaceSpec(String address, int functionSpec)
+    public static void setInterfaceSpec(String address, int functionSpec)
     {
         interfaceSpecMap.put(address, functionSpec);
+    }
 
-        Token token = tokenMap.get(address);
-        if (token != null)
-        {
-            token.setInterfaceSpec(functionSpec);
-        }
+    public int getInterfaceSpec(String address)
+    {
+        if (interfaceSpecMap.containsKey(address)) return interfaceSpecMap.get(address);
+        else return 0;
+    }
+
+    public void setLatestBlock(String address, long block)
+    {
+        updateMap.put(address, block);
+    }
+
+    public long getLatestBlock(String address)
+    {
+        if (updateMap.containsKey(address)) return updateMap.get(address);
+        else return 0;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModelFactory.java
@@ -9,6 +9,7 @@ import io.stormbird.wallet.interact.FetchGasSettingsInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.router.GasSettingsRouter;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 
 public class ConfirmationViewModelFactory implements ViewModelProvider.Factory {
 
@@ -17,22 +18,25 @@ public class ConfirmationViewModelFactory implements ViewModelProvider.Factory {
     private CreateTransactionInteract createTransactionInteract;
     private GasSettingsRouter gasSettingsRouter;
     private MarketQueueService marketQueueService;
+    private TokensService tokensService;
 
     public ConfirmationViewModelFactory(FindDefaultWalletInteract findDefaultWalletInteract,
                                         FetchGasSettingsInteract fetchGasSettingsInteract,
                                         CreateTransactionInteract createTransactionInteract,
                                         GasSettingsRouter gasSettingsRouter,
-                                        MarketQueueService marketQueueService) {
+                                        MarketQueueService marketQueueService,
+                                        TokensService tokensService) {
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.fetchGasSettingsInteract = fetchGasSettingsInteract;
         this.createTransactionInteract = createTransactionInteract;
         this.gasSettingsRouter = gasSettingsRouter;
         this.marketQueueService = marketQueueService;
+        this.tokensService = tokensService;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new ConfirmationViewModel(findDefaultWalletInteract, fetchGasSettingsInteract, createTransactionInteract, gasSettingsRouter, marketQueueService);
+        return (T) new ConfirmationViewModel(findDefaultWalletInteract, fetchGasSettingsInteract, createTransactionInteract, gasSettingsRouter, marketQueueService, tokensService);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
@@ -399,7 +399,7 @@ public class ImportTokenViewModel extends BaseViewModel
             initParser();
             MagicLinkData order = parser.parseUniversalLink(univeralImportLink);
             //ok let's try to drive this guy through
-            final byte[] tradeData = generateReverseTradeData(order);
+            final byte[] tradeData = generateReverseTradeData(order, importToken);
             Log.d(TAG, "Approx value of trade: " + order.price);
             //now push the transaction
             disposable = createTransactionInteract

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/PurchaseTicketsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/PurchaseTicketsViewModel.java
@@ -6,12 +6,14 @@ import android.arch.lifecycle.MutableLiveData;
 import io.stormbird.wallet.entity.GasSettings;
 import io.stormbird.wallet.entity.MagicLinkParcel;
 import io.stormbird.wallet.entity.NetworkInfo;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.repository.TokenRepository;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 
 import static io.stormbird.wallet.entity.MagicLinkParcel.generateReverseTradeData;
 
@@ -35,15 +37,18 @@ public class PurchaseTicketsViewModel extends BaseViewModel
     private final FindDefaultWalletInteract findDefaultWalletInteract;
     private final CreateTransactionInteract createTransactionInteract;
     private final MarketQueueService marketQueueService;
+    private final TokensService tokensService;
 
     PurchaseTicketsViewModel(FindDefaultNetworkInteract findDefaultNetworkInteract,
                              FindDefaultWalletInteract findDefaultWalletInteract,
                              CreateTransactionInteract createTransactionInteract,
-                             MarketQueueService marketQueueService) {
+                             MarketQueueService marketQueueService,
+                             TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.createTransactionInteract = createTransactionInteract;
         this.marketQueueService = marketQueueService;
+        this.tokensService = tokensService;
     }
 
     public LiveData<Wallet> defaultWallet() {
@@ -78,8 +83,9 @@ public class PurchaseTicketsViewModel extends BaseViewModel
 
     public void buyRange(MagicLinkParcel marketInstance)
     {
+        Token token = tokensService.getToken(marketInstance.magicLink.contractAddress);
         //ok let's try to drive this guy through
-        final byte[] tradeData = generateReverseTradeData(marketInstance.magicLink);
+        final byte[] tradeData = generateReverseTradeData(marketInstance.magicLink, token);
         //quick sanity check, dump price
         BigInteger milliWei = Convert.fromWei(marketInstance.magicLink.priceWei.toString(), Convert.Unit.FINNEY).toBigInteger();
         double recreatePrice = milliWei.doubleValue() / 1000.0;

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/PurchaseTicketsViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/PurchaseTicketsViewModelFactory.java
@@ -8,6 +8,7 @@ import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 
 /**
  * Created by James on 23/02/2018.
@@ -19,21 +20,24 @@ public class PurchaseTicketsViewModelFactory implements ViewModelProvider.Factor
     private FindDefaultWalletInteract findDefaultWalletInteract;
     private CreateTransactionInteract createTransactionInteract;
     private MarketQueueService marketQueueService;
+    private TokensService tokensService;
 
     public PurchaseTicketsViewModelFactory(FindDefaultNetworkInteract findDefaultNetworkInteract,
                                            FindDefaultWalletInteract findDefaultWalletInteract,
                                            CreateTransactionInteract createTransactionInteract,
-                                           MarketQueueService marketQueueService) {
+                                           MarketQueueService marketQueueService,
+                                           TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.createTransactionInteract = createTransactionInteract;
         this.marketQueueService = marketQueueService;
+        this.tokensService = tokensService;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new PurchaseTicketsViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, marketQueueService);
+        return (T) new PurchaseTicketsViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, marketQueueService, tokensService);
     }
 }
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -293,7 +293,7 @@ public class TransactionsViewModel extends BaseViewModel
                 .filter(token -> !token.isEthereum())
                 .filter(token -> !token.isTerminated())
                 .map(this::addTokenToChecklist)
-                .map(token -> fetchTransactionsInteract.fetch(new Wallet(token.tokenInfo.address), token, tokensService.getLastBlock(token))) //single that fetches all the tx's from etherscan for each token from fetchSequential
+                .map(token -> fetchTransactionsInteract.fetch(new Wallet(token.tokenInfo.address), token, tokensService.getLatestBlock(token.getAddress()))) //single that fetches all the tx's from etherscan for each token from fetchSequential
                 .map(tokenTransactions -> setupTokensInteract.processTokenTransactions(defaultWallet().getValue(), tokenTransactions.blockingLast(), tokensService)) //process these into a map
                 .map(transactions -> fetchTransactionsInteract.storeTransactionsObservable(network.getValue(), wallet.getValue(), transactions.blockingLast()))
                 .map(transactions -> removeFromMapTx(transactions.blockingLast()))

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
@@ -10,6 +10,7 @@ import io.stormbird.wallet.entity.ErrorEnvelope;
 import io.stormbird.wallet.entity.GasSettings;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Ticket;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TokenInfo;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
@@ -21,6 +22,7 @@ import io.stormbird.wallet.router.TransferTicketDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.FeeMasterService;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.ui.TransferTicketDetailActivity;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -53,6 +55,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
     private final FeeMasterService feeMasterService;
     private final AssetDisplayRouter assetDisplayRouter;
     private final AssetDefinitionService assetDefinitionService;
+    private final TokensService tokensService;
 
     private CryptoFunctions cryptoFunctions;
     private ParseMagicLink parser;
@@ -66,7 +69,8 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
                                   TransferTicketDetailRouter transferTicketDetailRouter,
                                   FeeMasterService feeMasterService,
                                   AssetDisplayRouter assetDisplayRouter,
-                                  AssetDefinitionService assetDefinitionService) {
+                                  AssetDefinitionService assetDefinitionService,
+                                  TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.marketQueueService = marketQueueService;
@@ -75,6 +79,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
         this.feeMasterService = feeMasterService;
         this.assetDisplayRouter = assetDisplayRouter;
         this.assetDefinitionService = assetDefinitionService;
+        this.tokensService = tokensService;
     }
 
     public LiveData<Wallet> defaultWallet() {
@@ -168,7 +173,8 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
 
     public void createTicketTransfer(String to, String contractAddress, String indexList, BigInteger gasPrice, BigInteger gasLimit)
     {
-        final byte[] data = TokenRepository.createTicketTransferData(to, indexList);
+        Token token = tokensService.getToken(contractAddress);
+        final byte[] data = TokenRepository.createTicketTransferData(to, indexList, token);
         disposable = createTransactionInteract
                 .create(defaultWallet.getValue(), contractAddress, BigInteger.valueOf(0), gasPrice, gasLimit, data)
                 .subscribe(this::onCreateTransaction, this::onError);

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
@@ -12,6 +12,7 @@ import io.stormbird.wallet.router.TransferTicketDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.FeeMasterService;
 import io.stormbird.wallet.service.MarketQueueService;
+import io.stormbird.wallet.service.TokensService;
 
 /**
  * Created by James on 21/02/2018.
@@ -27,6 +28,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
     private FeeMasterService feeMasterService;
     private AssetDisplayRouter assetDisplayRouter;
     private AssetDefinitionService assetDefinitionService;
+    private TokensService tokensService;
 
     public TransferTicketDetailViewModelFactory(FindDefaultNetworkInteract findDefaultNetworkInteract,
                                                 FindDefaultWalletInteract findDefaultWalletInteract,
@@ -35,7 +37,8 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
                                                 TransferTicketDetailRouter transferTicketDetailRouter,
                                                 FeeMasterService feeMasterService,
                                                 AssetDisplayRouter assetDisplayRouter,
-                                                AssetDefinitionService assetDefinitionService) {
+                                                AssetDefinitionService assetDefinitionService,
+                                                TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.marketQueueService = marketQueueService;
@@ -44,12 +47,13 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
         this.feeMasterService = feeMasterService;
         this.assetDisplayRouter = assetDisplayRouter;
         this.assetDefinitionService = assetDefinitionService;
+        this.tokensService = tokensService;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService);
+        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService);
     }
 }
 


### PR DESCRIPTION
This PR covers detecting which function spec of ERC875 we are dealing with and use the appropriate transfer function:

- Detect Uint16 or Uint256 function signatures in the constructor.
- Signal to Token contract which interface spec is in use.
- Store the spec in the DB.
- When user activates a Transfer or Trade function get the appropriate function signature.