### PR TITLE
Improve refresh of wallet balances

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "io.stormbird.wallet"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 20
-        versionName "1.0.14"
+        versionCode 21
+        versionName "1.0.15"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/WalletsAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/WalletsAdapter.java
@@ -95,7 +95,10 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     {
         for (Wallet wallet : wallets)
         {
-        	wallet.setWalletBalance(balances.get(wallet.address));
+        	if (balances.containsKey(wallet.address))
+			{
+				wallet.setWalletBalance(balances.get(wallet.address));
+			}
         }
         notifyDataSetChanged();
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/WalletsAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/WalletsAdapter.java
@@ -16,30 +16,35 @@ import io.stormbird.wallet.ui.widget.holder.WalletHolder;
 
 import static io.stormbird.wallet.util.BalanceUtils.weiToEth;
 
-public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> {
+public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder>
+{
 
 	private final OnSetWalletDefaultListener onSetWalletDefaultListener;
 	private final OnWalletDeleteListener onWalletDeleteListener;
-    private final OnExportWalletListener onExportWalletListener;
+	private final OnExportWalletListener onExportWalletListener;
 
-    private Wallet[] wallets = new Wallet[0];
+	private Wallet[] wallets = new Wallet[0];
 
 	private Wallet defaultWallet = null;
 
 	public WalletsAdapter(
 			OnSetWalletDefaultListener onSetWalletDefaultListener,
 			OnWalletDeleteListener onWalletDeleteListener,
-            OnExportWalletListener onExportWalletListener) {
+			OnExportWalletListener onExportWalletListener)
+	{
 		this.onSetWalletDefaultListener = onSetWalletDefaultListener;
 		this.onWalletDeleteListener = onWalletDeleteListener;
 		this.onExportWalletListener = onExportWalletListener;
 	}
 
 	@Override
-	public BinderViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+	public BinderViewHolder onCreateViewHolder(ViewGroup parent, int viewType)
+	{
 		BinderViewHolder binderViewHolder = null;
-		switch (viewType) {
-			case WalletHolder.VIEW_TYPE: {
+		switch (viewType)
+		{
+			case WalletHolder.VIEW_TYPE:
+			{
 				WalletHolder h = new WalletHolder(R.layout.item_wallet_manage, parent);
 				h.setOnSetWalletDefaultListener(onSetWalletDefaultListener);
 				h.setOnWalletDeleteListener(onWalletDeleteListener);
@@ -51,9 +56,12 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> {
 	}
 
 	@Override
-	public void onBindViewHolder(BinderViewHolder holder, int position) {
-		switch (getItemViewType(position)) {
-			case WalletHolder.VIEW_TYPE:{
+	public void onBindViewHolder(BinderViewHolder holder, int position)
+	{
+		switch (getItemViewType(position))
+		{
+			case WalletHolder.VIEW_TYPE:
+			{
 				Wallet wallet = wallets[position];
 				Bundle bundle = new Bundle();
 				bundle.putBoolean(
@@ -61,17 +69,20 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> {
 						defaultWallet != null && defaultWallet.sameAddress(wallet.address));
 				bundle.putBoolean(WalletHolder.IS_LAST_ITEM, getItemCount() == 1);
 				holder.bind(wallet, bundle);
-			} break;
+			}
+			break;
 		}
 	}
 
 	@Override
-	public int getItemCount() {
+	public int getItemCount()
+	{
 		return wallets.length;
 	}
 
 	@Override
-	public int getItemViewType(int position) {
+	public int getItemViewType(int position)
+	{
 		return WalletHolder.VIEW_TYPE;
 	}
 
@@ -87,31 +98,35 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> {
 		notifyDataSetChanged();
 	}
 
-    public Wallet getDefaultWallet() {
-        return defaultWallet;
-    }
+	public Wallet getDefaultWallet()
+	{
+		return defaultWallet;
+	}
 
-    public void updateWalletBalances(Map<String, BigDecimal> balances)
-    {
-        for (Wallet wallet : wallets)
-        {
-        	if (balances.containsKey(wallet.address))
+	public void updateWalletBalances(Map<String, BigDecimal> balances)
+	{
+		for (Wallet wallet : wallets)
+		{
+			if (balances.containsKey(wallet.address))
 			{
 				wallet.setWalletBalance(balances.get(wallet.address));
 			}
-        }
-        notifyDataSetChanged();
-    }
+		}
+		notifyDataSetChanged();
+	}
 
-    public interface OnSetWalletDefaultListener {
+	public interface OnSetWalletDefaultListener
+	{
 		void onSetDefault(Wallet wallet);
 	}
 
-	public interface OnWalletDeleteListener {
+	public interface OnWalletDeleteListener
+	{
 		void onDelete(Wallet delete);
 	}
 
-    public interface OnExportWalletListener {
-	    void onExport(Wallet wallet);
-    }
+	public interface OnExportWalletListener
+	{
+		void onExport(Wallet wallet);
+	}
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
@@ -43,12 +43,12 @@ public class WalletsViewModel extends BaseViewModel
 	private final DeleteWalletInteract deleteWalletInteract;
 	private final FetchWalletsInteract fetchWalletsInteract;
 	private final FindDefaultWalletInteract findDefaultWalletInteract;
-    private final ExportWalletInteract exportWalletInteract;
-    private final FetchTokensInteract fetchTokensInteract;
+	private final ExportWalletInteract exportWalletInteract;
+	private final FetchTokensInteract fetchTokensInteract;
 	private final FindDefaultNetworkInteract findDefaultNetworkInteract;
 
 	private final ImportWalletRouter importWalletRouter;
-    private final HomeRouter homeRouter;
+	private final HomeRouter homeRouter;
 
 	private final MutableLiveData<Wallet[]> wallets = new MutableLiveData<>();
 	private final MutableLiveData<Wallet> defaultWallet = new MutableLiveData<>();
@@ -62,17 +62,18 @@ public class WalletsViewModel extends BaseViewModel
 	private NetworkInfo currentNetwork;
 	private Map<String, BigDecimal> walletBalances = new HashMap<>();
 
-    WalletsViewModel(
-            CreateWalletInteract createWalletInteract,
-            SetDefaultWalletInteract setDefaultWalletInteract,
-            DeleteWalletInteract deleteWalletInteract,
-            FetchWalletsInteract fetchWalletsInteract,
-            FindDefaultWalletInteract findDefaultWalletInteract,
-            ExportWalletInteract exportWalletInteract,
-            ImportWalletRouter importWalletRouter,
-            HomeRouter homeRouter,
+	WalletsViewModel(
+			CreateWalletInteract createWalletInteract,
+			SetDefaultWalletInteract setDefaultWalletInteract,
+			DeleteWalletInteract deleteWalletInteract,
+			FetchWalletsInteract fetchWalletsInteract,
+			FindDefaultWalletInteract findDefaultWalletInteract,
+			ExportWalletInteract exportWalletInteract,
+			ImportWalletRouter importWalletRouter,
+			HomeRouter homeRouter,
 			FetchTokensInteract fetchTokensInteract,
-			FindDefaultNetworkInteract findDefaultNetworkInteract) {
+			FindDefaultNetworkInteract findDefaultNetworkInteract)
+	{
 		this.createWalletInteract = createWalletInteract;
 		this.setDefaultWalletInteract = setDefaultWalletInteract;
 		this.deleteWalletInteract = deleteWalletInteract;
@@ -87,49 +88,62 @@ public class WalletsViewModel extends BaseViewModel
 		fetchWallets();
 	}
 
-	public LiveData<Wallet[]> wallets() {
+	public LiveData<Wallet[]> wallets()
+	{
 		return wallets;
 	}
 
-	public LiveData<Wallet> defaultWallet() {
+	public LiveData<Wallet> defaultWallet()
+	{
 		return defaultWallet;
 	}
 
-    public LiveData<Wallet> createdWallet() {
-        return createdWallet;
-    }
+	public LiveData<Wallet> createdWallet()
+	{
+		return createdWallet;
+	}
 
-    public LiveData<ErrorEnvelope> createWalletError() {
-        return createWalletError;
-    }
+	public LiveData<ErrorEnvelope> createWalletError()
+	{
+		return createWalletError;
+	}
 
-    public LiveData<String> exportedStore() {
-        return exportedStore;
-    }
+	public LiveData<String> exportedStore()
+	{
+		return exportedStore;
+	}
 
-    public LiveData<ErrorEnvelope> exportWalletError() {
-        return exportWalletError;
-    }
+	public LiveData<ErrorEnvelope> exportWalletError()
+	{
+		return exportWalletError;
+	}
 
-    public LiveData<ErrorEnvelope> deleteWalletError() {
-        return deleteWalletError;
-    }
+	public LiveData<ErrorEnvelope> deleteWalletError()
+	{
+		return deleteWalletError;
+	}
 
-    public LiveData<Map<String, BigDecimal>> updateBalance() { return updateBalance; }
+	public LiveData<Map<String, BigDecimal>> updateBalance()
+	{
+		return updateBalance;
+	}
 
-	public void setDefaultWallet(Wallet wallet) {
+	public void setDefaultWallet(Wallet wallet)
+	{
 		disposable = setDefaultWalletInteract
 				.set(wallet)
 				.subscribe(() -> onDefaultWalletChanged(wallet), this::onError);
 	}
 
-	public void deleteWallet(Wallet wallet) {
+	public void deleteWallet(Wallet wallet)
+	{
 		disposable = deleteWalletInteract
 				.delete(wallet)
 				.subscribe(this::onFetchWallets, this::onDeleteWalletError);
 	}
 
-	private void findNetwork() {
+	private void findNetwork()
+	{
 		progress.postValue(true);
 		disposable = findDefaultNetworkInteract
 				.find()
@@ -145,27 +159,32 @@ public class WalletsViewModel extends BaseViewModel
 				.subscribe(this::onFetchWallets, this::onError);
 	}
 
-	private void onFetchWallets(Wallet[] items) {
+	private void onFetchWallets(Wallet[] items)
+	{
 		progress.postValue(false);
 		wallets.postValue(items);
 		disposable = findDefaultWalletInteract
 				.find()
-				.subscribe(this::onDefaultWalletChanged, t -> {});
+				.subscribe(this::onDefaultWalletChanged, t -> {
+				});
 
 		getWalletsBalance(items);
 	}
 
-	private void onDefaultWalletChanged(Wallet wallet) {
+	private void onDefaultWalletChanged(Wallet wallet)
+	{
 		progress.postValue(false);
 		defaultWallet.postValue(wallet);
 	}
 
-	public void fetchWallets() {
+	public void fetchWallets()
+	{
 		progress.postValue(true);
 		findNetwork();
 	}
 
-	public void newWallet() {
+	public void newWallet()
+	{
 		progress.setValue(true);
 		createWalletInteract
 				.create()
@@ -175,19 +194,21 @@ public class WalletsViewModel extends BaseViewModel
 				}, this::onCreateWalletError);
 	}
 
-    public void exportWallet(Wallet wallet, String storePassword) {
-        exportWalletInteract
-                .export(wallet, storePassword)
-                .subscribe(exportedStore::postValue, this::onExportWalletError);
-    }
+	public void exportWallet(Wallet wallet, String storePassword)
+	{
+		exportWalletInteract
+				.export(wallet, storePassword)
+				.subscribe(exportedStore::postValue, this::onExportWalletError);
+	}
 
 	/**
 	 * Sequentially updates the wallet balances on the current network
+	 *
 	 * @param wallets
 	 */
 	private void getWalletsBalance(Wallet[] wallets)
 	{
-        walletBalances.clear();
+		walletBalances.clear();
 		disposable = fetchWalletList(wallets)
 				.flatMapIterable(wallet -> wallet) //iterate through each wallet
 				.flatMap(wallet -> fetchTokensInteract.fetchEth(currentNetwork, wallet)) //fetch wallet balance
@@ -196,15 +217,15 @@ public class WalletsViewModel extends BaseViewModel
 				.subscribe(this::updateList, this::onError, this::updateBalances);
 	}
 
-    private void updateBalances()
-    {
-        updateBalance.postValue(walletBalances);
-    }
-
-    private void updateList(Token token)
+	private void updateBalances()
 	{
-        walletBalances.put(token.getAddress(), token.balance);
-        updateBalance.postValue(walletBalances);
+		updateBalance.postValue(walletBalances);
+	}
+
+	private void updateList(Token token)
+	{
+		walletBalances.put(token.getAddress(), token.balance);
+		updateBalance.postValue(walletBalances);
 	}
 
 	private Observable<List<Wallet>> fetchWalletList(Wallet[] wallets)
@@ -214,31 +235,36 @@ public class WalletsViewModel extends BaseViewModel
 		});
 	}
 
-    private void onExportWalletError(Throwable throwable) {
-        //Crashlytics.logException(throwable);
-        exportWalletError.postValue(
-                new ErrorEnvelope(C.ErrorCode.UNKNOWN, TextUtils.isEmpty(throwable.getLocalizedMessage())
-                                ? throwable.getMessage() : throwable.getLocalizedMessage()));
-    }
-
-    private void onDeleteWalletError(Throwable throwable) {
-        //Crashlytics.logException(throwable);
-        deleteWalletError.postValue(
-                new ErrorEnvelope(C.ErrorCode.UNKNOWN, TextUtils.isEmpty(throwable.getLocalizedMessage())
-                                ? throwable.getMessage() : throwable.getLocalizedMessage()));
-    }
-
-    private void onCreateWalletError(Throwable throwable) {
-        //Crashlytics.logException(throwable);
-        progress.postValue(false);
-        createWalletError.postValue(new ErrorEnvelope(C.ErrorCode.UNKNOWN, throwable.getMessage()));
+	private void onExportWalletError(Throwable throwable)
+	{
+		//Crashlytics.logException(throwable);
+		exportWalletError.postValue(
+				new ErrorEnvelope(C.ErrorCode.UNKNOWN, TextUtils.isEmpty(throwable.getLocalizedMessage())
+						? throwable.getMessage() : throwable.getLocalizedMessage()));
 	}
 
-	public void importWallet(Activity activity) {
+	private void onDeleteWalletError(Throwable throwable)
+	{
+		//Crashlytics.logException(throwable);
+		deleteWalletError.postValue(
+				new ErrorEnvelope(C.ErrorCode.UNKNOWN, TextUtils.isEmpty(throwable.getLocalizedMessage())
+						? throwable.getMessage() : throwable.getLocalizedMessage()));
+	}
+
+	private void onCreateWalletError(Throwable throwable)
+	{
+		//Crashlytics.logException(throwable);
+		progress.postValue(false);
+		createWalletError.postValue(new ErrorEnvelope(C.ErrorCode.UNKNOWN, throwable.getMessage()));
+	}
+
+	public void importWallet(Activity activity)
+	{
 		importWalletRouter.openForResult(activity, IMPORT_REQUEST_CODE);
 	}
 
-    public void showHome(Context context) {
-        homeRouter.open(context, true);
-    }
+	public void showHome(Context context)
+	{
+		homeRouter.open(context, true);
+	}
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
@@ -204,6 +204,7 @@ public class WalletsViewModel extends BaseViewModel
     private void updateList(Token token)
 	{
         walletBalances.put(token.getAddress(), token.balance);
+        updateBalance.postValue(walletBalances);
 	}
 
 	private Observable<List<Wallet>> fetchWalletList(Wallet[] wallets)


### PR DESCRIPTION
Sometimes API return to check the wallet balances takes a while. 

- Updates the UI each time a value is received. 
- Check for null return from the API just in case of time-out etc.