### PR TITLE
Re-check all TENZ-ID entries on wallet swipe-refresh 

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
@@ -110,7 +110,7 @@ public class WalletsActivity extends BaseActivity implements
     {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
         long lastBlockChecked = pref.getLong(ENS_SCAN_BLOCK, 0);
-        viewModel.swipeRefreshWallets(lastBlockChecked);
+        viewModel.swipeRefreshWallets(0); //check all records
     }
 
     private void onScanBlockReceived(long blockNumber)


### PR DESCRIPTION
On swipe wallet refresh, re-check all TENZ-ID entries to refresh ENS database. This is a precaution against the database being lost.