### PR TITLE
Fix import tokens interface issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "io.stormbird.wallet"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 21
-        versionName "1.0.15"
+        versionCode 22
+        versionName "1.1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "io.stormbird.wallet"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 22
-        versionName "1.1.0"
+        versionCode 21
+        versionName "1.0.15"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true
 

--- a/app/src/main/java/io/stormbird/wallet/di/ImportTokenModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/ImportTokenModule.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 import io.stormbird.wallet.interact.AddTokenInteract;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FetchTokensInteract;
+import io.stormbird.wallet.interact.FetchTransactionsInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.interact.SetupTokensInteract;
@@ -40,9 +41,10 @@ public class ImportTokenModule {
             FeeMasterService feeMasterService,
             AddTokenInteract addTokenInteract,
             EthereumNetworkRepositoryType ethereumNetworkRepository,
-            AssetDefinitionService assetDefinitionService) {
+            AssetDefinitionService assetDefinitionService,
+            FetchTransactionsInteract fetchTransactionsInteract) {
         return new ImportTokenViewModelFactory(
-                findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService, addTokenInteract, ethereumNetworkRepository, assetDefinitionService);
+                findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService, addTokenInteract, ethereumNetworkRepository, assetDefinitionService, fetchTransactionsInteract);
     }
 
     @Provides
@@ -76,5 +78,10 @@ public class ImportTokenModule {
             TokenRepositoryType tokenRepository,
             WalletRepositoryType walletRepository) {
         return new AddTokenInteract(walletRepository, tokenRepository);
+    }
+
+    @Provides
+    FetchTransactionsInteract provideFetchTransactionsInteract(TransactionRepositoryType transactionRepository) {
+        return new FetchTransactionsInteract(transactionRepository);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
@@ -8,6 +8,7 @@ import io.stormbird.wallet.repository.PasswordStore;
 import io.stormbird.wallet.repository.TransactionRepositoryType;
 import io.stormbird.wallet.repository.WalletRepositoryType;
 import io.stormbird.wallet.router.AssetDisplayRouter;
+import io.stormbird.wallet.router.ConfirmationRouter;
 import io.stormbird.wallet.router.TransferTicketDetailRouter;
 import io.stormbird.wallet.router.TransferTicketRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
@@ -36,9 +37,10 @@ public class TransferTicketDetailModule {
             FeeMasterService feeMasterService,
             AssetDisplayRouter assetDisplayRouter,
             AssetDefinitionService assetDefinitionService,
-            TokensService tokensService) {
+            TokensService tokensService,
+            ConfirmationRouter confirmationRouter) {
         return new TransferTicketDetailViewModelFactory(
-                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService);
+                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
     }
 
     @Provides
@@ -65,5 +67,10 @@ public class TransferTicketDetailModule {
     @Provides
     AssetDisplayRouter provideAssetDisplayRouter() {
         return new AssetDisplayRouter();
+    }
+
+    @Provides
+    ConfirmationRouter provideConfirmationRouter() {
+        return new ConfirmationRouter();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/TransferTicketDetailModule.java
@@ -1,6 +1,7 @@
 package io.stormbird.wallet.di;
 
 import io.stormbird.wallet.interact.CreateTransactionInteract;
+import io.stormbird.wallet.interact.FetchTransactionsInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.repository.EthereumNetworkRepositoryType;
@@ -10,9 +11,7 @@ import io.stormbird.wallet.repository.WalletRepositoryType;
 import io.stormbird.wallet.router.AssetDisplayRouter;
 import io.stormbird.wallet.router.ConfirmationRouter;
 import io.stormbird.wallet.router.TransferTicketDetailRouter;
-import io.stormbird.wallet.router.TransferTicketRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
-import io.stormbird.wallet.service.FeeMasterService;
 import io.stormbird.wallet.service.MarketQueueService;
 import io.stormbird.wallet.service.TokensService;
 import io.stormbird.wallet.viewmodel.TransferTicketDetailViewModelFactory;
@@ -34,13 +33,13 @@ public class TransferTicketDetailModule {
             MarketQueueService marketQueueService,
             CreateTransactionInteract createTransactionInteract,
             TransferTicketDetailRouter transferTicketDetailRouter,
-            FeeMasterService feeMasterService,
+            FetchTransactionsInteract fetchTransactionsInteract,
             AssetDisplayRouter assetDisplayRouter,
             AssetDefinitionService assetDefinitionService,
             TokensService tokensService,
             ConfirmationRouter confirmationRouter) {
         return new TransferTicketDetailViewModelFactory(
-                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
+                findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, fetchTransactionsInteract, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
     }
 
     @Provides
@@ -72,5 +71,10 @@ public class TransferTicketDetailModule {
     @Provides
     ConfirmationRouter provideConfirmationRouter() {
         return new ConfirmationRouter();
+    }
+
+    @Provides
+    FetchTransactionsInteract provideFetchTransactionsInteract(TransactionRepositoryType transactionRepository) {
+        return new FetchTransactionsInteract(transactionRepository);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/ConfirmationType.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/ConfirmationType.java
@@ -10,5 +10,6 @@ public enum ConfirmationType
     ERC20,
     ERC875,
     MARKET,
-    WEB3TRANSACTION
+    WEB3TRANSACTION,
+    ERC721
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/ERC721Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/ERC721Token.java
@@ -144,6 +144,14 @@ public class ERC721Token extends Token implements Parcelable
     @Override
     public String getFullBalance()
     {
-        return String.valueOf(tokenBalance.size());
+        boolean firstItem = true;
+        StringBuilder sb = new StringBuilder();
+        for (Asset item : tokenBalance)
+        {
+            if (!firstItem) sb.append(",");
+            sb.append(item.getTokenId());
+            firstItem = false;
+        }
+        return sb.toString();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/ERC721Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/ERC721Token.java
@@ -5,8 +5,18 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.view.View;
 
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Bool;
+import org.web3j.abi.datatypes.Function;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Uint256;
+
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import io.stormbird.wallet.R;
@@ -98,6 +108,25 @@ public class ERC721Token extends Token implements Parcelable
 
         holder.balanceEth.setVisibility(View.VISIBLE);
         holder.arrayBalance.setVisibility(View.GONE);
+    }
+
+    @Override
+    public Function getTransferFunction(String to, String tokenId)
+    {
+        Function function = null;
+        try
+        {
+            BigInteger tokenIdBI = new BigInteger(tokenId);
+            List<Type> params = Arrays.asList(new Address(to), new Uint256(tokenIdBI));
+            List<TypeReference<?>> returnTypes = Collections.<TypeReference<?>>emptyList();
+            function = new Function("transfer", params, returnTypes);
+        }
+        catch (NumberFormatException e)
+        {
+            e.printStackTrace();
+        }
+
+        return function;
     }
 
     @Override

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -807,6 +807,7 @@ public class Ticket extends Token implements Parcelable
                 Collections.<TypeReference<?>>emptyList());
     }
 
+    @Override
     public boolean isOldSpec()
     {
         switch (interfaceSpec)
@@ -818,6 +819,7 @@ public class Ticket extends Token implements Parcelable
         }
     }
 
+    @Override
     public boolean unspecifiedSpec()
     {
         switch (interfaceSpec)

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -245,7 +245,7 @@ public class Ticket extends Token implements Parcelable
     }
 
     @Override
-    public int[] getTicketIndicies(String ticketIds)
+    public int[] getTicketIndices(String ticketIds)
     {
         List<Integer> indexList = ticketIdStringToIndexList(ticketIds);
         int[] indicies = new int[indexList.size()];

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -54,7 +54,7 @@ public class Ticket extends Token implements Parcelable
     public final List<BigInteger> balanceArray;
     private List<Integer> burnIndices;
     private boolean isMatchedInXML = false;
-    private InterfaceType interfaceSpec = InterfaceType.UsingUint256;
+    private InterfaceType interfaceSpec = InterfaceType.NotSpecified;
 
     public Ticket(TokenInfo tokenInfo, List<BigInteger> balances, List<Integer> burned, long blancaTime) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime);
@@ -812,6 +812,17 @@ public class Ticket extends Token implements Parcelable
         switch (interfaceSpec)
         {
             case UsingUint16:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean unspecifiedSpec()
+    {
+        switch (interfaceSpec)
+        {
+            case NotSpecified:
                 return true;
             default:
                 return false;

--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -244,6 +244,7 @@ public class Ticket extends Token implements Parcelable
         return intArrayToString(range.tokenIds, false);
     }
 
+    @Override
     public int[] getTicketIndicies(String ticketIds)
     {
         List<Integer> indexList = ticketIdStringToIndexList(ticketIds);
@@ -323,6 +324,7 @@ public class Ticket extends Token implements Parcelable
      * @param integerString CSV string of hex ticket id's
      * @return
      */
+    @Override
     public List<BigInteger> stringHexToBigIntegerList(String integerString)
     {
         List<BigInteger> idList = new ArrayList<>();
@@ -778,7 +780,7 @@ public class Ticket extends Token implements Parcelable
     {
         if (token instanceof Ticket)
         {
-            this.interfaceSpec = InterfaceType.values()[((Ticket)token).interfaceOrdinal()];
+            this.interfaceSpec = InterfaceType.values()[token.interfaceOrdinal()];
         }
         super.patchAuxData(token);
     }
@@ -843,6 +845,7 @@ public class Ticket extends Token implements Parcelable
         return super.checkRealmBalanceChange(realmToken);
     }
 
+    @Override
     public int interfaceOrdinal()
     {
         return interfaceSpec.ordinal();

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -466,6 +466,7 @@ public class Token implements Parcelable
 
     public void setInterfaceSpec(int b) { }
     public boolean isOldSpec() { return false; }
+    public boolean unspecifiedSpec() { return false; }
     public void setInterfaceSpecFromRealm(RealmToken ordinal)
     {
 

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -262,6 +262,11 @@ public class Token implements Parcelable
         return null;
     }
 
+    public String intArrayToString(List<BigInteger> idList, boolean keepZeros)
+    {
+        return "";
+    }
+
     public List<Integer> stringIntsToIntegerList(String userList)
     {
         List<Integer> idList = new ArrayList<>();
@@ -370,6 +375,16 @@ public class Token implements Parcelable
 
     }
 
+    public List<BigInteger> stringHexToBigIntegerList(String integerString)
+    {
+        return null;
+    }
+
+    public int interfaceOrdinal()
+    {
+        return 0;
+    }
+
     private Map<String, String> restoreAuxData(String data)
     {
         Map<String, String> aux = null;
@@ -402,6 +417,11 @@ public class Token implements Parcelable
 
             realmToken.setAuxData(auxDataStr.toString());
         }
+    }
+
+    public void checkIsMatchedInXML(AssetDefinitionService assetService)
+    {
+
     }
 
     public void restoreAuxDataFromRealm(RealmToken realmToken)
@@ -490,5 +510,15 @@ public class Token implements Parcelable
     public Function getTransferFunction(String to, String tokenId)
     {
         return null;
+    }
+
+    public boolean checkBalanceChange(Token token)
+    {
+        return !getFullBalance().equals(token.getFullBalance());
+    }
+
+    public int[] getTicketIndicies(String ticketIds)
+    {
+        return new int[0];
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -14,6 +14,7 @@ import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.widget.holder.TokenHolder;
 import io.stormbird.wallet.viewmodel.BaseViewModel;
 
+import org.web3j.abi.datatypes.Function;
 import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
@@ -484,5 +485,10 @@ public class Token implements Parcelable
     public boolean requiresAuxRefresh()
     {
         return (requiresAuxRefresh);
+    }
+
+    public Function getTransferFunction(String to, String tokenId)
+    {
+        return null;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -518,7 +518,12 @@ public class Token implements Parcelable
         return !getFullBalance().equals(token.getFullBalance());
     }
 
-    public int[] getTicketIndicies(String ticketIds)
+    /**
+     * Baseclass placeholder which should never be called. Returns empty array to avoid error
+     * @param ticketIds
+     * @return
+     */
+    public int[] getTicketIndices(String ticketIds)
     {
         return new int[0];
     }

--- a/app/src/main/java/io/stormbird/wallet/entity/opensea/Asset.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/opensea/Asset.java
@@ -43,6 +43,8 @@ public class Asset implements Parcelable {
     @Expose
     private List<Trait> traits = null;
 
+    public boolean isChecked;
+
     protected Asset(Parcel in) {
         tokenId = in.readString();
         imagePreviewUrl = in.readString();

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -1,6 +1,7 @@
 package io.stormbird.wallet.interact;
 
 import io.stormbird.wallet.entity.NetworkInfo;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.repository.TransactionRepositoryType;
@@ -35,5 +36,12 @@ public class FetchTransactionsInteract {
     public Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList)
     {
         return transactionRepository.storeTransactions(networkInfo, wallet, txList);
+    }
+
+    public Single<Integer> queryInterfaceSpec(Token token)
+    {
+        return transactionRepository.queryInterfaceSpec(token)
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io());
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -1210,6 +1210,13 @@ public class TokenRepository implements TokenRepositoryType {
         return Numeric.hexStringToByteArray(Numeric.cleanHexPrefix(encodedFunction));
     }
 
+    public static byte[] createERC721TransferFunction(String to, Token token, String tokenId)
+    {
+        Function function = token.getTransferFunction(to, tokenId);
+        String encodedFunction = FunctionEncoder.encode(function);
+        return Numeric.hexStringToByteArray(Numeric.cleanHexPrefix(encodedFunction));
+    }
+
     public static byte[] createTrade(Token token, BigInteger expiry, List<BigInteger> ticketIndices, int v, byte[] r, byte[] s)
     {
         Function function = ((Ticket)token).getTradeFunction(expiry, ticketIndices, v, r, s);

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -24,6 +24,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import io.stormbird.wallet.entity.NetworkInfo;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.service.AccountKeystoreService;
@@ -225,5 +226,12 @@ public class TransactionRepository implements TransactionRepositoryType {
 		}
 
 		return result;
+	}
+
+	@Override
+	public Single<Integer> queryInterfaceSpec(Token token)
+	{
+		NetworkInfo networkInfo = networkRepository.getDefaultNetwork();
+		return blockExplorerClient.checkConstructorArgs(networkInfo, token.getAddress());
 	}
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
@@ -1,6 +1,7 @@
 package io.stormbird.wallet.repository;
 
 import io.stormbird.wallet.entity.NetworkInfo;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.Wallet;
 
@@ -19,4 +20,6 @@ public interface TransactionRepositoryType {
 	void unlockAccount(Wallet signer, String signerPassword) throws Exception;
 	void lockAccount(Wallet signer, String signerPassword) throws Exception;
 	Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList);
+
+    Single<Integer> queryInterfaceSpec(Token token);
 }

--- a/app/src/main/java/io/stormbird/wallet/router/ConfirmationRouter.java
+++ b/app/src/main/java/io/stormbird/wallet/router/ConfirmationRouter.java
@@ -66,4 +66,19 @@ public class ConfirmationRouter {
         intent.putExtra(C.EXTRA_CONTRACT_NAME, requesterURL);
         context.startActivity(intent);
     }
+
+    public void openERC721Transfer(Context context, String to, String tokenId, String contractAddress, String name, String tokenName)
+    {
+        Intent intent = new Intent(context, ConfirmationActivity.class);
+        intent.putExtra(C.EXTRA_TO_ADDRESS, to);
+        intent.putExtra(C.EXTRA_CONTRACT_ADDRESS, contractAddress);
+        intent.putExtra(C.EXTRA_DECIMALS, 0);
+        intent.putExtra(C.EXTRA_SYMBOL, tokenName);
+        intent.putExtra(C.EXTRA_AMOUNT, tokenId);
+        intent.putExtra(C.EXTRA_SENDING_TOKENS, true);
+        intent.putExtra(C.TOKEN_TYPE, ConfirmationType.ERC721.ordinal());
+        intent.putExtra(C.EXTRA_TOKENID_LIST, tokenId);
+        intent.putExtra(C.EXTRA_CONTRACT_NAME, name);
+        context.startActivity(intent);
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -1,6 +1,7 @@
 package io.stormbird.wallet.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -227,5 +228,27 @@ public class TokensService
                 ((ERC721Token)t).tokenBalance.clear();
             }
         }
+    }
+
+    public List<String> getRemovedTokensOfClass(Token[] tokens, Class<?> tokenClass)
+    {
+        List<Token> newTokens = Arrays.asList(tokens);
+        List<Token> oldTokens = getAllClass(tokenClass);
+
+        List<String> removedTokens = new ArrayList<>();
+
+        if (oldTokens.size() > newTokens.size())
+        {
+            //tokens were removed
+            for (Token t : oldTokens)
+            {
+                if (!newTokens.contains(t))
+                {
+                    removedTokens.add(t.getAddress());
+                }
+            }
+        }
+
+        return removedTokens;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TransactionsNetworkClientType.java
@@ -10,4 +10,6 @@ import io.stormbird.wallet.entity.WalletUpdate;
 public interface TransactionsNetworkClientType {
     Observable<Transaction[]> fetchLastTransactions(NetworkInfo networkInfo, Wallet wallet, long lastBlock, String userAddress);
     Single<WalletUpdate> scanENSTransactionsForWalletNames(Wallet[] wallets, long lastBlock);
+
+    Single<Integer> checkConstructorArgs(NetworkInfo networkInfo, String address);
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/AssetDisplayActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/AssetDisplayActivity.java
@@ -83,15 +83,15 @@ public class AssetDisplayActivity extends BaseActivity implements View.OnClickLi
         adapter = new TicketAdapter(this::onTicketIdClick, token, viewModel.getAssetDefinitionService(), viewModel.getOpenseaService());
         if (token instanceof ERC721Token)
         {
-            adapter.setERC721Contract(token);
-            findViewById(R.id.layoutButtons).setVisibility(View.GONE);
+            findViewById(R.id.button_use).setVisibility(View.GONE);
+            findViewById(R.id.button_sell).setVisibility(View.GONE);
         }
         else
         {
             findViewById(R.id.button_use).setOnClickListener(this);
             findViewById(R.id.button_sell).setOnClickListener(this);
-            findViewById(R.id.button_transfer).setOnClickListener(this);
         }
+        findViewById(R.id.button_transfer).setOnClickListener(this);
 
         list.setLayoutManager(new LinearLayoutManager(this));
         list.setAdapter(adapter);

--- a/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
@@ -69,6 +69,7 @@ public class ConfirmationActivity extends BaseActivity {
     private TextView websiteText;
     private Button sendButton;
     private TextView title;
+    private TextView labelAmount;
 
     private BigDecimal amount;
     private int decimals;
@@ -106,6 +107,7 @@ public class ConfirmationActivity extends BaseActivity {
         websiteLabel = findViewById(R.id.label_website);
         websiteText = findViewById(R.id.text_website);
         title = findViewById(R.id.title_confirm);
+        labelAmount = findViewById(R.id.label_amount);
         sendButton.setOnClickListener(view -> onSend());
 
         transaction = getIntent().getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
@@ -169,6 +171,17 @@ public class ConfirmationActivity extends BaseActivity {
                 BigDecimal ethAmount = Convert.fromWei(transaction.value.toString(10), Convert.Unit.ETHER);
                 amountString = getEthString(ethAmount.doubleValue()) + " " + ETH_SYMBOL;
                 //handle web3 transaction signing
+                break;
+            case ERC721:
+                String contractName = getIntent().getStringExtra(C.EXTRA_CONTRACT_NAME);
+                title.setText(R.string.confirm_erc721_transfer);
+                contractAddrText.setVisibility(View.VISIBLE);
+                contractAddrLabel.setVisibility(View.VISIBLE);
+                String contractTxt = contractAddress + " " + contractName;
+                labelAmount.setText(R.string.asset_name);
+                contractAddrText.setText(contractTxt);
+                amountString = symbol;
+                tokenTransfer = true;
                 break;
             default:
                 amountString = "-" + BalanceUtils.subunitToBase(amount.toBigInteger(), decimals).toPlainString() + " " + symbol;
@@ -281,6 +294,15 @@ public class ConfirmationActivity extends BaseActivity {
                 //price in eth
                 BigInteger wei = Convert.toWei("2470", Convert.Unit.FINNEY).toBigInteger();
                 viewModel.generateSalesOrders(amountStr, contractAddress, wei, valueText.getText().toString());
+                break;
+
+            case ERC721:
+                viewModel.createERC721Transfer(
+                        toAddressText.getText().toString(),
+                        contractAddress,
+                        amountStr,
+                        gasSettings.gasPrice,
+                        gasSettings.gasLimit);
                 break;
 
             default:

--- a/app/src/main/java/io/stormbird/wallet/ui/SellDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SellDetailActivity.java
@@ -428,11 +428,11 @@ public class SellDetailActivity extends BaseActivity {
         //1. validate price
         BigInteger price = getPriceInWei();
         //2. get quantity
-        int quantity = ticket.getTicketIndicies(prunedIds).length;
+        int quantity = ticket.getTicketIndices(prunedIds).length;
 
         if (price.doubleValue() > 0.0 && prunedIds != null && quantity > 0) {
             //get the specific ID's, pick from the start of the run
-            int[] prunedIndices = ticket.getTicketIndicies(prunedIds);
+            int[] prunedIndices = ticket.getTicketIndices(prunedIds);
             BigInteger totalValue = price.multiply(BigInteger.valueOf(quantity)); //in wei
             viewModel.generateUniversalLink(prunedIndices, ticket.getAddress(), totalValue, UTCTimeStamp);
         }
@@ -446,7 +446,7 @@ public class SellDetailActivity extends BaseActivity {
         //1. validate price
         BigInteger price = getPriceInWei();
         //2. get indicies
-        int[] prunedIndices = ticket.getTicketIndicies(prunedIds);
+        int[] prunedIndices = ticket.getTicketIndices(prunedIds);
         int quantity = Integer.parseInt(textQuantity.getText().toString());
 
         if (price.doubleValue() > 0.0 && prunedIndices != null && quantity > 0) {

--- a/app/src/main/java/io/stormbird/wallet/ui/TokenDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TokenDetailActivity.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 
 import io.stormbird.wallet.R;
+import io.stormbird.wallet.entity.ERC721Token;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.opensea.Asset;
 import io.stormbird.wallet.entity.opensea.Trait;
@@ -63,18 +64,23 @@ public class TokenDetailActivity extends BaseActivity {
             Asset asset = getIntent().getExtras().getParcelable("asset");
             Token token = getIntent().getExtras().getParcelable("token");
             title.setText(String.format("%s %s", "1", token.getFullName()));
-            setupPage(asset);
+            setupPage(asset, token);
         } else {
             finish();
         }
     }
 
-    private void setupPage(Asset asset) {
+    private void setupPage(Asset asset, Token token) {
         setImage(asset);
         setDetails(asset);
         setNameAndDesc(asset);
         setExternalLink(asset);
         setTraits(asset);
+
+        if (token instanceof ERC721Token)
+        {
+            findViewById(R.id.button_transfer).setVisibility(View.GONE);
+        }
     }
 
     private void setTraits(Asset asset) {

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.FinishReceiver;
 import io.stormbird.wallet.entity.Ticket;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.ui.widget.adapter.TicketSaleAdapter;
 import io.stormbird.wallet.util.BalanceUtils;
 import io.stormbird.wallet.viewmodel.TransferTicketViewModel;
@@ -48,7 +49,7 @@ public class TransferTicketActivity extends BaseActivity
     public TextView ids;
     public TextView selected;
 
-    private Ticket ticket;
+    private Token token;
     private TicketSaleAdapter adapter;
 
     @Override
@@ -56,7 +57,7 @@ public class TransferTicketActivity extends BaseActivity
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
 
-        ticket = getIntent().getParcelableExtra(TICKET);
+        token = getIntent().getParcelableExtra(TICKET);
 
         toolbar();
 
@@ -91,8 +92,8 @@ public class TransferTicketActivity extends BaseActivity
     {
         RecyclerView list = findViewById(R.id.listTickets);
 
-        adapter = new TicketSaleAdapter(this::onTicketIdClick, ticket, viewModel.getAssetDefinitionService());
-        adapter.setTransferTicket(ticket);
+        adapter = new TicketSaleAdapter(this::onTicketIdClick, token, viewModel.getAssetDefinitionService());
+        adapter.setTransferTicket(token);
         list.setLayoutManager(new LinearLayoutManager(this));
         list.setAdapter(adapter);
     }
@@ -105,7 +106,7 @@ public class TransferTicketActivity extends BaseActivity
     @Override
     protected void onResume() {
         super.onResume();
-        viewModel.prepare(ticket);
+        viewModel.prepare(token);
     }
 
     @Override
@@ -130,9 +131,9 @@ public class TransferTicketActivity extends BaseActivity
                 idList.addAll(tr.tokenIds);
             }
 
-            String idListStr = ticket.intArrayToString(idList, false); //list of B32 ID's
-            List<Integer> idSendList = ticket.ticketIdStringToIndexList(idListStr); //convert string list of b32 to Indexes
-            String indexList = ticket.integerListToString(idSendList, true);
+            String idListStr = ((Ticket)token).intArrayToString(idList, false); //list of B32 ID's
+            List<Integer> idSendList = token.ticketIdStringToIndexList(idListStr); //convert string list of b32 to Indexes
+            String indexList = token.integerListToString(idSendList, true);
 
             //confirm other address
             //confirmation screen

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
@@ -152,7 +152,7 @@ public class TransferTicketActivity extends BaseActivity
                 idList.addAll(tr.tokenIds);
             }
 
-            String idListStr = ((Ticket)token).intArrayToString(idList, false); //list of B32 ID's
+            String idListStr = token.intArrayToString(idList, false); //list of B32 ID's
             viewModel.openSellDialog(this, idListStr);
         }
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
@@ -650,7 +650,7 @@ public class TransferTicketDetailActivity extends BaseActivity
     private void handleERC875Transfer(final String to)
     {
         //how many tickets are we selling?
-        int quantity = ((Ticket)token).stringHexToBigIntegerList(prunedIds).size();
+        int quantity = token.stringHexToBigIntegerList(prunedIds).size();
         int ticketName = (quantity > 1) ? R.string.tickets : R.string.ticket;
 
         String qty = String.valueOf(quantity) + " " +

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -335,7 +334,7 @@ public class TransferTicketDetailActivity extends BaseActivity
                 break;
             case TRANSFER_USING_LINK:
                 //generate link
-                viewModel.generateUniversalLink(((Ticket)token).getTicketIndicies(ticketIds), token.getAddress(), calculateExpiryTime());
+                viewModel.generateUniversalLink(((Ticket)token).getTicketIndices(ticketIds), token.getAddress(), calculateExpiryTime());
                 break;
             case TRANSFER_TO_ADDRESS:
                 //transfer using eth

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
@@ -106,6 +106,8 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
         list.setLayoutManager(new LinearLayoutManager(getContext()));
         list.setAdapter(adapter);
 
+        viewModel.removeTokens().observe(this, adapter::onRemoveTokens);
+
         refreshLayout.setOnRefreshListener(this::refreshList);
 
         tokenReceiver = new TokensReceiver(getActivity(), this);

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
@@ -61,6 +61,7 @@ public class TicketAdapter extends TokensAdapter {
         //setTicket(ticket);
         if (token instanceof Ticket) setTokenRange(token, ticketIds);
         openseaService = opensea;
+        if (token instanceof ERC721Token) setERC721Contract(token);
     }
 
     @Override

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
@@ -7,7 +7,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.stormbird.token.entity.NonFungibleToken;
 import io.stormbird.token.entity.TicketRange;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.ERC721Token;
@@ -116,7 +115,7 @@ public class TicketAdapter extends TokensAdapter {
         items.beginBatchedUpdates();
         items.clear();
 
-        List<BigInteger> idList = ((Ticket)t).stringHexToBigIntegerList(ticketIds);
+        List<BigInteger> idList = t.stringHexToBigIntegerList(ticketIds);
         List<TicketRangeElement> sortedList = generateSortedList(assetService, token, idList); //generate sorted list
         addSortedItems(sortedList, t, TokenIdSortedItem.VIEW_TYPE); //insert sorted items into view
 
@@ -134,6 +133,7 @@ public class TicketAdapter extends TokensAdapter {
 
     private void addRanges(Token t)
     {
+        currentRange = null;
         List<TicketRangeElement> sortedList = generateSortedList(assetService, t, ((Ticket)t).balanceArray);
         addSortedItems(sortedList, t, TokenIdSortedItem.VIEW_TYPE);
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
@@ -49,6 +49,7 @@ public class TicketAdapter extends TokensAdapter {
         token = t;
         openseaService = opensea;
         if (t instanceof Ticket) setToken(t);
+        if (t instanceof ERC721Token) setERC721Contract(t);
     }
 
     public TicketAdapter(OnTicketIdClickListener onTicketIdClick, Token token, String ticketIds, AssetDefinitionService service, OpenseaService opensea)

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import io.stormbird.token.entity.TicketRange;
 import io.stormbird.wallet.R;
+import io.stormbird.wallet.entity.ERC721Token;
 import io.stormbird.wallet.entity.Ticket;
 import io.stormbird.wallet.entity.TicketRangeElement;
 import io.stormbird.wallet.entity.Token;
@@ -20,6 +21,8 @@ import io.stormbird.wallet.ui.widget.entity.TicketSaleSortedItem;
 import io.stormbird.wallet.ui.widget.entity.TokenIdSortedItem;
 import io.stormbird.wallet.ui.widget.entity.TransferHeaderSortedItem;
 import io.stormbird.wallet.ui.widget.holder.BinderViewHolder;
+import io.stormbird.wallet.ui.widget.holder.OpenseaHolder;
+import io.stormbird.wallet.ui.widget.holder.OpenseaSelectHolder;
 import io.stormbird.wallet.ui.widget.holder.QuantitySelectorHolder;
 import io.stormbird.wallet.ui.widget.holder.RedeemTicketHolder;
 import io.stormbird.wallet.ui.widget.holder.SalesOrderHeaderHolder;
@@ -80,6 +83,9 @@ public class TicketSaleAdapter extends TicketAdapter {
             case TransferHeaderHolder.VIEW_TYPE: {
                 holder = new TransferHeaderHolder(R.layout.item_redeem_ticket, parent);
             } break;
+            case OpenseaHolder.VIEW_TYPE: {
+                holder = new OpenseaSelectHolder(R.layout.item_opensea_token, parent, token);
+            } break;
         }
 
         return holder;
@@ -89,9 +95,25 @@ public class TicketSaleAdapter extends TicketAdapter {
         items.beginBatchedUpdates();
         items.clear();
         items.add(new TransferHeaderSortedItem(t));
-        addRanges(t);
+        addTokens(t);
 
         items.endBatchedUpdates();
+    }
+
+    private void addTokens(Token t)
+    {
+        if (t instanceof ERC721Token)
+        {
+            setERC721Contract(t);
+        }
+        else if (t instanceof Ticket)
+        {
+            addRanges(t);
+        }
+        else
+        {
+            System.out.println("*** UNKNOWN TOKEN IN LIST **");
+        }
     }
 
     private void addRanges(Token t)

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
@@ -14,6 +14,7 @@ import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.widget.OnTicketIdClickListener;
 import io.stormbird.wallet.ui.widget.OnTokenCheckListener;
+import io.stormbird.wallet.ui.widget.entity.AssetSortedItem;
 import io.stormbird.wallet.ui.widget.entity.MarketSaleHeaderSortedItem;
 import io.stormbird.wallet.ui.widget.entity.QuantitySelectorSortedItem;
 import io.stormbird.wallet.ui.widget.entity.RedeemHeaderSortedItem;
@@ -85,6 +86,7 @@ public class TicketSaleAdapter extends TicketAdapter {
             } break;
             case OpenseaHolder.VIEW_TYPE: {
                 holder = new OpenseaSelectHolder(R.layout.item_opensea_token, parent, token);
+                ((OpenseaSelectHolder)holder).setOnTokenCheckListener(onTokenCheckListener);
             } break;
         }
 
@@ -141,6 +143,24 @@ public class TicketSaleAdapter extends TicketAdapter {
 
         addRanges(t);
         items.endBatchedUpdates();
+    }
+
+    //TODO: Make this into a single templated fetch
+    public List<String> getERC721Checked()
+    {
+        List<String> checkedItems = new ArrayList<>();
+        for (int i = 0; i < items.size(); i++)
+        {
+            if (items.get(i) instanceof AssetSortedItem)
+            {
+                AssetSortedItem thisItem = (AssetSortedItem) items.get(i);
+                if (thisItem.value.isChecked)
+                {
+                    checkedItems.add(thisItem.value.getTokenId());
+                }
+            }
+        }
+        return checkedItems;
     }
 
     public List<TicketRange> getCheckedItems()

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
@@ -121,6 +121,7 @@ public class TicketSaleAdapter extends TicketAdapter {
     private void addRanges(Token t)
     {
         //first sort the balance array
+        currentRange = null;
         List<TicketRangeElement> sortedList = generateSortedList(assetService, token, ((Ticket)t).balanceArray);
         addSortedItems(sortedList, t, TicketSaleSortedItem.VIEW_TYPE);
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TokensAdapter.java
@@ -1,7 +1,6 @@
 package io.stormbird.wallet.ui.widget.adapter;
 
 import android.content.Context;
-import android.support.v7.util.DiffUtil;
 import android.support.v7.util.SortedList;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -12,14 +11,13 @@ import android.view.animation.AnimationUtils;
 
 import org.web3j.utils.Numeric;
 
-import io.stormbird.token.tools.TokenDefinition;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
 import io.stormbird.wallet.R;
-import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Ticket;
 import io.stormbird.wallet.entity.Token;
-import io.stormbird.wallet.entity.TokenDiffCallback;
-import io.stormbird.wallet.entity.Transaction;
-import io.stormbird.wallet.entity.TransactionDiffCallback;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.widget.OnTokenClickListener;
 import io.stormbird.wallet.ui.widget.entity.SortedItem;
@@ -28,16 +26,6 @@ import io.stormbird.wallet.ui.widget.entity.TotalBalanceSortedItem;
 import io.stormbird.wallet.ui.widget.holder.BinderViewHolder;
 import io.stormbird.wallet.ui.widget.holder.TokenHolder;
 import io.stormbird.wallet.ui.widget.holder.TotalBalanceHolder;
-
-import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.text.Collator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-
-import static io.stormbird.wallet.C.ETH_SYMBOL;
 
 public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     private static final String TAG = "TKNADAPTER";
@@ -394,12 +382,45 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     {
         if (t instanceof Ticket)
         {
-            ((Ticket)t).checkIsMatchedInXML(assetService);
+            t.checkIsMatchedInXML(assetService);
         }
     }
 
     public void setClear()
     {
         needsRefresh = true;
+    }
+
+    public void onRemoveTokens(List<String> tokens)
+    {
+        List<Integer> removeList = new ArrayList<>();
+
+        for (int i = 0; i < items.size(); i++)
+        {
+            Object si = items.get(i);
+            if (si instanceof TokenSortedItem)
+            {
+                TokenSortedItem tsi = (TokenSortedItem)si;
+                Token thisToken = tsi.value;
+                if (tokens.contains(thisToken.getAddress()))
+                {
+                    removeList.add(i);
+                }
+            }
+        }
+
+        items.beginBatchedUpdates();
+        if (!removeList.isEmpty())
+        {
+            //remove in reverse order so indices stay the same
+            for (int i = removeList.size() - 1; i >= 0; i--)
+            {
+                int index = removeList.get(i);
+                TokenSortedItem tsi = (TokenSortedItem)items.get(index);
+                items.remove(tsi);
+                notifyItemChanged(index);
+            }
+        }
+        items.endBatchedUpdates();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
@@ -6,10 +6,12 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatRadioButton;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
 
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.opensea.Asset;
+import io.stormbird.wallet.ui.widget.OnTokenCheckListener;
 
 /**
  * Created by James on 12/11/2018.
@@ -18,6 +20,7 @@ import io.stormbird.wallet.entity.opensea.Asset;
 public class OpenseaSelectHolder extends OpenseaHolder
 {
     private final AppCompatRadioButton select;
+    private OnTokenCheckListener onTokenCheckListener;
 
     public OpenseaSelectHolder(int resId, ViewGroup parent, Token token)
     {
@@ -30,5 +33,21 @@ public class OpenseaSelectHolder extends OpenseaHolder
     {
         super.bind(asset, addition);
         select.setVisibility(View.VISIBLE);
+
+        select.setChecked(asset.isChecked);
+
+        select.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener()
+        {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean b)
+            {
+                asset.isChecked = b;
+            }
+        });
+    }
+
+    public void setOnTokenCheckListener(OnTokenCheckListener onTokenCheckListener)
+    {
+        this.onTokenCheckListener = onTokenCheckListener;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
@@ -1,0 +1,34 @@
+package io.stormbird.wallet.ui.widget.holder;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.AppCompatRadioButton;
+import android.view.View;
+import android.view.ViewGroup;
+
+import io.stormbird.wallet.R;
+import io.stormbird.wallet.entity.Token;
+import io.stormbird.wallet.entity.opensea.Asset;
+
+/**
+ * Created by James on 12/11/2018.
+ * Stormbird in Singapore
+ */
+public class OpenseaSelectHolder extends OpenseaHolder
+{
+    private final AppCompatRadioButton select;
+
+    public OpenseaSelectHolder(int resId, ViewGroup parent, Token token)
+    {
+        super(resId, parent, token);
+        select = findViewById(R.id.radioBox);
+    }
+
+    @Override
+    public void bind(@Nullable Asset asset, @NonNull Bundle addition)
+    {
+        super.bind(asset, addition);
+        select.setVisibility(View.VISIBLE);
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TransactionHolder.java
@@ -186,6 +186,7 @@ public class TransactionHolder extends BinderViewHolder<Transaction> implements 
             typeIcon.setImageResource(R.drawable.ic_error);
             typeIcon.setColorFilter(ContextCompat.getColor(getContext(), R.color.red),
                                     PorterDuff.Mode.SRC_ATOP);
+            value.setText("");
         }
         else
         {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
@@ -159,4 +159,14 @@ public class ConfirmationViewModel extends BaseViewModel {
                                this::onError);
         }
     }
+
+    public void createERC721Transfer(String to, String contractAddress, String tokenId, BigInteger gasPrice, BigInteger gasLimit)
+    {
+        progress.postValue(true);
+        Token token = tokensService.getToken(contractAddress);
+        final byte[] data = TokenRepository.createERC721TransferFunction(to, token, tokenId);
+        disposable = createTransactionInteract
+                .create(defaultWallet.getValue(), token.getAddress(), BigInteger.valueOf(0), gasPrice, gasLimit, data)
+                .subscribe(this::onCreateTransaction, this::onError);
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
@@ -343,8 +343,8 @@ public class ImportTokenViewModel extends BaseViewModel
         {
             //establish the interface spec
             disposable = fetchTransactionsInteract.queryInterfaceSpec(importToken)
-                    .observeOn(Schedulers.io())
                     .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(this::onInterfaceSpec, this::onError);
         }
         else

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModel.java
@@ -20,6 +20,7 @@ import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.AddTokenInteract;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FetchTokensInteract;
+import io.stormbird.wallet.interact.FetchTransactionsInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.interact.SetupTokensInteract;
@@ -64,6 +65,7 @@ public class ImportTokenViewModel extends BaseViewModel
     private final AddTokenInteract addTokenInteract;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final AssetDefinitionService assetDefinitionService;
+    private final FetchTransactionsInteract fetchTransactionsInteract;
 
     private CryptoFunctions cryptoFunctions;
     private ParseMagicLink parser;
@@ -83,6 +85,7 @@ public class ImportTokenViewModel extends BaseViewModel
     private Ticket importToken;
     private List<BigInteger> availableBalance = new ArrayList<>();
     private double ethToUsd = 0;
+    private TicketRange currentRange;
 
     @Nullable
     private Disposable getBalanceDisposable;
@@ -97,7 +100,8 @@ public class ImportTokenViewModel extends BaseViewModel
                          FeeMasterService feeMasterService,
                          AddTokenInteract addTokenInteract,
                          EthereumNetworkRepositoryType ethereumNetworkRepository,
-                         AssetDefinitionService assetDefinitionService) {
+                         AssetDefinitionService assetDefinitionService,
+                         FetchTransactionsInteract fetchTransactionsInteract) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.createTransactionInteract = createTransactionInteract;
@@ -107,6 +111,7 @@ public class ImportTokenViewModel extends BaseViewModel
         this.addTokenInteract = addTokenInteract;
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.assetDefinitionService = assetDefinitionService;
+        this.fetchTransactionsInteract = fetchTransactionsInteract;
     }
 
     private void initParser()
@@ -171,6 +176,7 @@ public class ImportTokenViewModel extends BaseViewModel
         this.wallet.setValue(wallet);
         try
         {
+            currentRange = null;
             importOrder = parser.parseUniversalLink(univeralImportLink);
             //ecrecover the owner
             importOrder.ownerAddress = parser.getOwnerKey(importOrder);
@@ -322,14 +328,37 @@ public class ImportTokenViewModel extends BaseViewModel
         else if (balanceChange(newBalance))
         {
             availableBalance = newBalance;
-            TicketRange range = new TicketRange(availableBalance.get(0), importToken.getAddress());
+            currentRange = new TicketRange(availableBalance.get(0), importToken.getAddress());
             for (int i = 1; i < availableBalance.size(); i++)
             {
-                range.tokenIds.add(availableBalance.get(i));
+                currentRange.tokenIds.add(availableBalance.get(i));
             }
-            importRange.setValue(range);
+            determineInterface();
+        }
+    }
+
+    private void determineInterface()
+    {
+        if (importToken.unspecifiedSpec())
+        {
+            //establish the interface spec
+            disposable = fetchTransactionsInteract.queryInterfaceSpec(importToken)
+                    .observeOn(Schedulers.io())
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(this::onInterfaceSpec, this::onError);
+        }
+        else
+        {
+            importRange.setValue(currentRange);
             regularBalanceCheck();
         }
+    }
+
+    private void onInterfaceSpec(Integer spec)
+    {
+        importToken.setInterfaceSpec(spec);
+        importRange.setValue(currentRange);
+        regularBalanceCheck();
     }
 
     private long checkExpiry()

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ImportTokenViewModelFactory.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 ;import io.stormbird.wallet.interact.AddTokenInteract;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FetchTokensInteract;
+import io.stormbird.wallet.interact.FetchTransactionsInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.interact.SetupTokensInteract;
@@ -29,6 +30,7 @@ public class ImportTokenViewModelFactory implements ViewModelProvider.Factory {
     private final AddTokenInteract addTokenInteract;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final AssetDefinitionService assetDefinitionService;
+    private final FetchTransactionsInteract fetchTransactionsInteract;
 
     public ImportTokenViewModelFactory(FindDefaultNetworkInteract findDefaultNetworkInteract,
                                        FindDefaultWalletInteract findDefaultWalletInteract,
@@ -38,7 +40,8 @@ public class ImportTokenViewModelFactory implements ViewModelProvider.Factory {
                                        FeeMasterService feeMasterService,
                                        AddTokenInteract addTokenInteract,
                                        EthereumNetworkRepositoryType ethereumNetworkRepository,
-                                       AssetDefinitionService assetDefinitionService) {
+                                       AssetDefinitionService assetDefinitionService,
+                                       FetchTransactionsInteract fetchTransactionsInteract) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.createTransactionInteract = createTransactionInteract;
@@ -48,12 +51,13 @@ public class ImportTokenViewModelFactory implements ViewModelProvider.Factory {
         this.addTokenInteract = addTokenInteract;
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.assetDefinitionService = assetDefinitionService;
+        this.fetchTransactionsInteract = fetchTransactionsInteract;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new ImportTokenViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService, addTokenInteract, ethereumNetworkRepository, assetDefinitionService);
+        return (T) new ImportTokenViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, createTransactionInteract, fetchTokensInteract, setupTokensInteract, feeMasterService, addTokenInteract, ethereumNetworkRepository, assetDefinitionService, fetchTransactionsInteract);
     }
 }
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.util.Log;
 
 import io.stormbird.wallet.entity.CryptoFunctions;
+import io.stormbird.wallet.entity.ERC721Token;
 import io.stormbird.wallet.entity.ErrorEnvelope;
 import io.stormbird.wallet.entity.GasSettings;
 import io.stormbird.wallet.entity.NetworkInfo;
@@ -13,11 +14,13 @@ import io.stormbird.wallet.entity.Ticket;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TokenInfo;
 import io.stormbird.wallet.entity.Wallet;
+import io.stormbird.wallet.entity.opensea.Asset;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.repository.TokenRepository;
 import io.stormbird.wallet.router.AssetDisplayRouter;
+import io.stormbird.wallet.router.ConfirmationRouter;
 import io.stormbird.wallet.router.TransferTicketDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.FeeMasterService;
@@ -56,6 +59,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
     private final AssetDisplayRouter assetDisplayRouter;
     private final AssetDefinitionService assetDefinitionService;
     private final TokensService tokensService;
+    private final ConfirmationRouter confirmationRouter;
 
     private CryptoFunctions cryptoFunctions;
     private ParseMagicLink parser;
@@ -70,7 +74,8 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
                                   FeeMasterService feeMasterService,
                                   AssetDisplayRouter assetDisplayRouter,
                                   AssetDefinitionService assetDefinitionService,
-                                  TokensService tokensService) {
+                                  TokensService tokensService,
+                                  ConfirmationRouter confirmationRouter) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.marketQueueService = marketQueueService;
@@ -80,6 +85,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
         this.assetDisplayRouter = assetDisplayRouter;
         this.assetDefinitionService = assetDefinitionService;
         this.tokensService = tokensService;
+        this.confirmationRouter = confirmationRouter;
     }
 
     public LiveData<Wallet> defaultWallet() {
@@ -98,7 +104,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
         }
     }
 
-    public void prepare(Ticket ticket)
+    public void prepare(Token token)
     {
         disposable = findDefaultNetworkInteract
                 .find()
@@ -166,9 +172,9 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
         }
     }
 
-    public void openTransferState(Context context, Ticket ticket, String ticketIds, int transferStatus)
+    public void openTransferState(Context context, Token token, String ticketIds, int transferStatus)
     {
-        transferTicketDetailRouter.openTransfer(context, ticket, ticketIds, defaultWallet.getValue(), transferStatus);
+        transferTicketDetailRouter.openTransfer(context, token, ticketIds, defaultWallet.getValue(), transferStatus);
     }
 
     public void createTicketTransfer(String to, String contractAddress, String indexList, BigInteger gasPrice, BigInteger gasLimit)
@@ -218,5 +224,20 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
     public void showAssets(Context ctx, Ticket ticket, boolean isClearStack)
     {
         assetDisplayRouter.open(ctx, ticket, isClearStack);
+    }
+
+    public void openConfirm(Context ctx, String to, Token token, String tokenId)
+    {
+        //first find the asset within the token
+        Asset asset = null;
+        for (Asset a : ((ERC721Token)token).tokenBalance)
+        {
+            if (a.getTokenId().equals(tokenId)) { asset = a; break; }
+        }
+
+        if (asset != null )
+        {
+            confirmationRouter.openERC721Transfer(ctx, to, tokenId, token.getAddress(), token.getFullName(), asset.getName());
+        }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.ViewModelProvider;
 import android.support.annotation.NonNull;
 
 import io.stormbird.wallet.interact.CreateTransactionInteract;
+import io.stormbird.wallet.interact.FetchTransactionsInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.router.AssetDisplayRouter;
@@ -26,7 +27,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
     private MarketQueueService marketQueueService;
     private CreateTransactionInteract createTransactionInteract;
     private TransferTicketDetailRouter transferTicketDetailRouter;
-    private FeeMasterService feeMasterService;
+    private FetchTransactionsInteract fetchTransactionsInteract;
     private AssetDisplayRouter assetDisplayRouter;
     private AssetDefinitionService assetDefinitionService;
     private TokensService tokensService;
@@ -37,7 +38,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
                                                 MarketQueueService marketQueueService,
                                                 CreateTransactionInteract createTransactionInteract,
                                                 TransferTicketDetailRouter transferTicketDetailRouter,
-                                                FeeMasterService feeMasterService,
+                                                FetchTransactionsInteract fetchTransactionsInteract,
                                                 AssetDisplayRouter assetDisplayRouter,
                                                 AssetDefinitionService assetDefinitionService,
                                                 TokensService tokensService,
@@ -47,7 +48,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
         this.marketQueueService = marketQueueService;
         this.createTransactionInteract = createTransactionInteract;
         this.transferTicketDetailRouter = transferTicketDetailRouter;
-        this.feeMasterService = feeMasterService;
+        this.fetchTransactionsInteract = fetchTransactionsInteract;
         this.assetDisplayRouter = assetDisplayRouter;
         this.assetDefinitionService = assetDefinitionService;
         this.tokensService = tokensService;
@@ -57,7 +58,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
+        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, fetchTransactionsInteract, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
     }
 }
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModelFactory.java
@@ -8,6 +8,7 @@ import io.stormbird.wallet.interact.CreateTransactionInteract;
 import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
 import io.stormbird.wallet.interact.FindDefaultWalletInteract;
 import io.stormbird.wallet.router.AssetDisplayRouter;
+import io.stormbird.wallet.router.ConfirmationRouter;
 import io.stormbird.wallet.router.TransferTicketDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.FeeMasterService;
@@ -29,6 +30,7 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
     private AssetDisplayRouter assetDisplayRouter;
     private AssetDefinitionService assetDefinitionService;
     private TokensService tokensService;
+    private ConfirmationRouter confirmationRouter;
 
     public TransferTicketDetailViewModelFactory(FindDefaultNetworkInteract findDefaultNetworkInteract,
                                                 FindDefaultWalletInteract findDefaultWalletInteract,
@@ -38,7 +40,8 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
                                                 FeeMasterService feeMasterService,
                                                 AssetDisplayRouter assetDisplayRouter,
                                                 AssetDefinitionService assetDefinitionService,
-                                                TokensService tokensService) {
+                                                TokensService tokensService,
+                                                ConfirmationRouter confirmationRouter) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
         this.findDefaultWalletInteract = findDefaultWalletInteract;
         this.marketQueueService = marketQueueService;
@@ -48,12 +51,13 @@ public class TransferTicketDetailViewModelFactory implements ViewModelProvider.F
         this.assetDisplayRouter = assetDisplayRouter;
         this.assetDefinitionService = assetDefinitionService;
         this.tokensService = tokensService;
+        this.confirmationRouter = confirmationRouter;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService);
+        return (T) new TransferTicketDetailViewModel(findDefaultNetworkInteract, findDefaultWalletInteract, marketQueueService, createTransactionInteract, transferTicketDetailRouter, feeMasterService, assetDisplayRouter, assetDefinitionService, tokensService, confirmationRouter);
     }
 }
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketViewModel.java
@@ -19,6 +19,8 @@ import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import io.stormbird.wallet.service.AssetDefinitionService;
 
+import static io.stormbird.wallet.ui.TransferTicketDetailActivity.TRANSFER_TO_ADDRESS;
+
 public class TransferTicketViewModel extends BaseViewModel {
     private static final long CHECK_BALANCE_INTERVAL = 10;
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
@@ -101,6 +103,15 @@ public class TransferTicketViewModel extends BaseViewModel {
         try {
             Token ticket = this.ticket().getValue();
             transferTicketDetailRouter.open(context, ticket, ticketIDs, defaultWallet.getValue());
+        } catch (Exception e) {
+
+        }
+    }
+
+    public void openTransferDirectDialog(Context context, String tokenId) {
+        try {
+            Token token = this.ticket().getValue();
+            transferTicketDetailRouter.openTransfer(context, token, tokenId, defaultWallet.getValue(), TRANSFER_TO_ADDRESS);
         } catch (Exception e) {
 
         }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -47,6 +47,7 @@ public class WalletViewModel extends BaseViewModel
     private final MutableLiveData<BigDecimal> total = new MutableLiveData<>();
     private final MutableLiveData<Token> tokenUpdate = new MutableLiveData<>();
     private final MutableLiveData<Boolean> checkTokens = new MutableLiveData<>();
+    private final MutableLiveData<List<String>> removeTokens = new MutableLiveData<>();
 
     private final MutableLiveData<String> checkAddr = new MutableLiveData<>();
 
@@ -119,6 +120,7 @@ public class WalletViewModel extends BaseViewModel
     public LiveData<Token> tokenUpdate() { return tokenUpdate; }
     public LiveData<Boolean> endUpdate() { return checkTokens; }
     public LiveData<String> checkAddr() { return checkAddr; }
+    public LiveData<List<String>> removeTokens() { return removeTokens; }
 
     @Override
     protected void onCleared() {
@@ -162,6 +164,7 @@ public class WalletViewModel extends BaseViewModel
 
         if (defaultNetwork.getValue() != null && defaultWallet.getValue() != null)
         {
+            tokenCache = null;
             updateTokens = fetchTokensInteract.fetchStoredWithEth(defaultNetwork.getValue(), defaultWallet.getValue())
                     .subscribeOn(Schedulers.newThread())
                     .observeOn(AndroidSchedulers.mainThread())
@@ -178,6 +181,8 @@ public class WalletViewModel extends BaseViewModel
     {
         tokensService.addTokens(tokens);
     }
+
+    private boolean firstRunDebugTest = true;
 
     private void fetchFromOpensea()
     {
@@ -207,6 +212,11 @@ public class WalletViewModel extends BaseViewModel
     {
         if (updateTokens != null) updateTokens.dispose();
 
+        //update the display list for token removals
+        List<String> removedTokens = tokensService.getRemovedTokensOfClass(tokens, ERC721Token.class);
+
+        if (!removedTokens.isEmpty()) removeTokens.postValue(removedTokens); //remove from UI
+
         tokensService.clearBalanceOf(ERC721Token.class);
 
         for (Token t : tokens)
@@ -224,12 +234,13 @@ public class WalletViewModel extends BaseViewModel
 
         tokenList = tokensService.getAllLiveTokens();
         tokenCache = tokenList.toArray(new Token[0]);
-        onFetchTokensCompletable();
     }
 
     private void storedTokens(Token[] tokens)
     {
+        Log.d("WVM", "Stored " + tokens.length);
         //if (updateTokens != null && !updateTokens.isDisposed()) updateTokens.dispose();
+        onFetchTokensCompletable();
     }
 
     private void onFetchTokensCompletable()

--- a/app/src/main/res/layout/activity_token_detail.xml
+++ b/app/src/main/res/layout/activity_token_detail.xml
@@ -12,10 +12,26 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <Button
+            android:id="@+id/button_transfer"
+            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:background="@drawable/selector_button"
+            android:fontFamily="@font/font_regular"
+            android:gravity="center"
+            android:paddingBottom="15dp"
+            android:paddingTop="15dp"
+            android:text="@string/action_transfer"
+            android:textAllCaps="false"
+            android:textColor="@color/button_text_color"
+            android:textSize="20sp" />
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="?actionBarSize"
+            android:layout_above="@id/button_transfer"
             android:background="@drawable/background_card">
 
             <RelativeLayout
@@ -186,21 +202,6 @@
             </RelativeLayout>
         </ScrollView>
 
-        <Button
-            android:id="@+id/button_transfer"
-            style="@style/Widget.AppCompat.Button.Borderless.Colored"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:background="@drawable/selector_button"
-            android:fontFamily="@font/font_regular"
-            android:gravity="center"
-            android:paddingBottom="15dp"
-            android:paddingTop="15dp"
-            android:text="@string/action_transfer"
-            android:textAllCaps="false"
-            android:textColor="@color/button_text_color"
-            android:textSize="20sp" />
     </RelativeLayout>
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,4 +5,6 @@
     <string name="currency">Monedas</string>
     <string name="assets">Activos</string>
     <string name="ens_address">ENS Address</string>
+    <string name="confirm_erc721_transfer">Confirm Token Transfer</string>
+    <string name="asset_name">Asset Name</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -331,4 +331,6 @@
     <string name="free_import_with_gas">免费导入(免除 gas 费用)</string>
     <string name="toolbar_header_browser">DApp 浏览器</string>
     <string name="ens_address">ENS 地址</string>
+    <string name="confirm_erc721_transfer">Confirm Token Transfer</string>
+    <string name="asset_name">Asset Name</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,7 +407,7 @@
     <string name="title_select_ticket_quantity">Select Ticket Quantity:</string>
     <string name="title_select_transfer_method">Select Transfer Method:</string>
     <string name="title_set_universal_link_expiry">Set MagicLink Expiry:</string>
-    <string name="title_input_wallet_address">Input Wallet Address:</string>
+    <string name="title_input_wallet_address">Input Transfer Address:</string>
     <string name="title_import">Import Wallet</string>
     <string name="action_import">Import</string>
     <string name="prompt_password">Password</string>
@@ -503,4 +503,6 @@
     <string name="free_import_with_gas">Free Import (with gas fee)</string>
     <string name="confirm_dapp_transaction">Confirm DApp transaction"</string>
     <string name="ens_address">ENS Address</string>
+    <string name="confirm_erc721_transfer">Confirm Token Transfer</string>
+    <string name="asset_name">Asset Name</string>
 </resources>

--- a/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
+++ b/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 
 import io.stormbird.wallet.entity.BaseViewCallback;
 import io.stormbird.wallet.entity.NetworkInfo;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TradeInstance;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.Wallet;
@@ -162,6 +163,12 @@ public class MarketOrderTest
 
             @Override
             public Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<Integer> queryInterfaceSpec(Token token)
             {
                 return null;
             }

--- a/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
+++ b/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 import io.stormbird.wallet.entity.MessagePair;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.SignaturePair;
+import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.Transaction;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.interact.SignatureGenerateInteract;
@@ -118,6 +119,12 @@ public class QRSelectionTest
             {
                 return null;
             }
+
+            @Override
+            public Single<Integer> queryInterfaceSpec(Token token)
+            {
+                return null;
+            }
         };
 
         signatureGenerateInteract = new SignatureGenerateInteract(null)
@@ -198,6 +205,10 @@ public class QRSelectionTest
                 //check the signature corresponds to the test address
                 String addressHex = "0x" + ecRecoverAddress(sPair.message.getBytes(), sigData);
                 assertTrue(selectionRecreate.equals(qr.indices));
+                if (!addressHex.equals(testAddress))
+                {
+                    System.out.println("Mismatch: " + addressHex + " : " + testAddress);
+                }
                 assertTrue(addressHex.equals(testAddress));
             }
         }


### PR DESCRIPTION
This PR ensures that we're using the correct Interface before doing transfers/trade and import tokens. ERC875 tokens could be using the older interface spec.