### PR TITLE
Link Owner's Ethereum Address and Contract Address to etherscan

### DIFF
--- a/dmz/src/main/resources/templates/index.html
+++ b/dmz/src/main/resources/templates/index.html
@@ -79,9 +79,9 @@
             <br>
             <hr>
             <h5 class="mt-4 mb-2"><b>Owner's Ethereum Address</b></h5>
-            <h5 style="font-size: 12px;" class="mb-4" th:text="${link.ownerAddress}"/>
+             <a href="https://etherscan.io/address/${link.ownerAddress}"><h5 style="font-size: 12px;" class="mb-4" th:text="${link.ownerAddress}"/></h5>
             <h5 class="mb-2"><b>Contract Address</b></h6>
-            <h5 style="font-size: 12px;" th:text="${link.contractAddress}"/>
+            <a href="https://etherscan.io/token/${link.contractAddress}"><h5 style="font-size: 12px;" th:text="${link.contractAddress}"/></h5></a>
             <br>
           </div>
         </div>

--- a/dmz/src/main/resources/templates/index.html
+++ b/dmz/src/main/resources/templates/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
   xmlns:th="http://www.thymeleaf.org">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <head>
     <title th:text="${link.ticketCount} + ' ' + ${tokenName} + ' ' + ${tokenAvailable}"/>
     <link rel="stylesheet" th:href="@{css/bootstrap.min.css}"/>
@@ -79,9 +79,9 @@
             <br>
             <hr>
             <h5 class="mt-4 mb-2"><b>Owner's Ethereum Address</b></h5>
-             <a href="https://etherscan.io/address/${link.ownerAddress}"><h5 style="font-size: 12px;" class="mb-4" th:text="${link.ownerAddress}"/></h5>
-            <h5 class="mb-2"><b>Contract Address</b></h6>
-            <a href="https://etherscan.io/token/${link.contractAddress}"><h5 style="font-size: 12px;" th:text="${link.contractAddress}"/></h5></a>
+            <a href="https://etherscan.io/address/${link.ownerAddress}"><h5 style="font-size: 12px;" class="mb-4" th:text="${link.ownerAddress}"/></a>
+            <h5 class="mb-2"><b>Contract Address</b></h5>
+            <a href="https://etherscan.io/token/${link.contractAddress}"><h5 style="font-size: 12px;" th:text="${link.contractAddress}"/></a>
             <br>
           </div>
         </div>


### PR DESCRIPTION
Issue #406 In magic link HTML page, make Owner's Ethereum Address and Contract Address be <a> to etherscan.io