### PR TITLE
Fix QR test

### DIFF
--- a/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
+++ b/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
@@ -55,10 +55,7 @@ public class QRSelectionTest
         sr.nextBytes(keySeed);
         testKey = ECKeyPair.create(keySeed);
 
-        try
-        {
-            transactionRepository = new TransactionRepositoryType()
-            {
+        transactionRepository = new TransactionRepositoryType() {
 
                 @Override
                 public Observable<Transaction[]> fetchCachedTransactions(NetworkInfo network, Wallet wallet)
@@ -193,6 +190,8 @@ public class QRSelectionTest
                 qr.sigPair = new SignaturePair(messagePair.selection, sig, messagePair.message);
             }
 
+        try
+        {
             //now check we can recover all the selections and their signings
             for (QREncoding qr : qrList)
             {


### PR DESCRIPTION
Finally found the issue in this test that causes sporadic fails, sometimes giving false negatives to the Android builds.

The time value that the QR signature generator uses is implanted into the test array. If this crosses a 30 second boundary when checking the signatures then it will fail. Usually this isn't a problem but if the original signature was generated just before crossing a half minute or minute boundary then the check happens the other side of that boundary and the test fails. It doesn't happen often.

To fix, we can read the generated time from the test array instead of generating it.

Ironically - the method was working exactly right - if the checking time is different then of course the signature is going to be different.