### PR TITLE
Fix ERC721 transfer name

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/opensea/Asset.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/opensea/Asset.java
@@ -100,8 +100,15 @@ public class Asset implements Parcelable {
         return this;
     }
 
-    public String getName() {
-        return name;
+    public String getName()
+    {
+        String assetName;
+        if (name != null && !name.equals("null")) {
+            assetName = name;
+        } else {
+            assetName = "ID# " + String.valueOf(tokenId);
+        }
+        return assetName;
     }
 
     public void setName(String name) {

--- a/app/src/main/java/io/stormbird/wallet/ui/TokenDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TokenDetailActivity.java
@@ -124,11 +124,7 @@ public class TokenDetailActivity extends BaseActivity {
     }
 
     private void setNameAndDesc(Asset asset) {
-        if (asset.getName() != null && !asset.getName().equals("null")) {
-            name.setText(asset.getName());
-        } else {
-            name.setText(String.format("ID# %s", asset.getTokenId()));
-        }
+        name.setText(asset.getName());
         desc.setText(asset.getDescription());
     }
 


### PR DESCRIPTION
Fix for issue #419 , ERC721 tokens sometimes don't have a valid name so it needs to be created from the tokenID.