### PR TITLE
Serialise network calls

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -85,7 +85,7 @@ public class AssetDefinitionService
         {
             assetDefinitions.clear();
             loadContracts(context.getFilesDir(), false);
-            checkDownloadedFiles();
+            //checkDownloadedFiles();
         }
         catch (IOException|SAXException e)
         {
@@ -510,7 +510,7 @@ public class AssetDefinitionService
                 .filter(this::isValidXML)
                 .map(this::convertToAddress)
                 .filter(this::notOverriden)
-                .flatMap(this::fetchXMLFromServer)
+                .concatMap(this::fetchXMLFromServer)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::handleFile, this::onError);

--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -85,7 +85,7 @@ public class AssetDefinitionService
         {
             assetDefinitions.clear();
             loadContracts(context.getFilesDir(), false);
-            //checkDownloadedFiles();
+            checkDownloadedFiles();
         }
         catch (IOException|SAXException e)
         {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -303,7 +303,7 @@ public class TransactionsViewModel extends BaseViewModel
                     .flatMapIterable(token -> token)
                     .filter(token -> !token.isEthereum())
                     .filter(token -> !token.isTerminated())
-                    .flatMap(token -> fetchTransactionsInteract.fetchNetworkTransactions(new Wallet(token.getAddress()), tokensService.getLatestBlock(token.getAddress()), wallet.getValue().address)) //single that fetches all the tx's from etherscan for each token from fetchSequential
+                    .concatMap(token -> fetchTransactionsInteract.fetchNetworkTransactions(new Wallet(token.getAddress()), tokensService.getLatestBlock(token.getAddress()), wallet.getValue().address)) //single that fetches all the tx's from etherscan for each token from fetchSequential
                     .subscribeOn(Schedulers.io())
                     .observeOn(Schedulers.io())
                     .subscribe(this::onContractTransactions, this::onError, this::siftUnknownTransactions);

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -261,7 +261,7 @@ public class WalletViewModel extends BaseViewModel
         checkTokensDisposable = Observable.fromCallable(tokensService::getAllTokens)
                 .flatMapIterable(token -> token)
                 .filter(token -> (token.tokenInfo.name == null && !token.isTerminated()))
-                .flatMap(token -> fetchTokensInteract.getTokenInfo(token.getAddress(), false))
+                .concatMap(token -> fetchTokensInteract.getTokenInfo(token.getAddress(), false))
                 .filter(tokenInfo -> (tokenInfo.name != null))
                 .subscribeOn(Schedulers.io())
                 .subscribe(addTokenInteract::addS, this::tkError,
@@ -288,8 +288,8 @@ public class WalletViewModel extends BaseViewModel
                     .doOnNext(l -> Observable.fromCallable(tokensService::getAllTokens)
                             .flatMapIterable(token -> token)
                             .filter(token -> (token.tokenInfo.name != null && !token.isTerminated() && !token.independentUpdate()))
-                            .flatMap(token -> fetchTokensInteract.updateDefaultBalance(token, info, wallet))
-                            .flatMap(token -> addTokenInteract.addTokenFunctionData(token, assetDefinitionService))
+                            .concatMap(token -> fetchTokensInteract.updateDefaultBalance(token, info, wallet))
+                            .concatMap(token -> addTokenInteract.addTokenFunctionData(token, assetDefinitionService))
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe(this::onTokenBalanceUpdate, this::onError, this::onFetchTokensBalanceCompletable)).subscribe();


### PR DESCRIPTION
After a lot of research into reactivex, found the correct way to fully serialise the calls to network without stalling - use combination of 'flatMapIterable' and 'concatMap'. This is the golden combination that keeps the thread count low and the code simple.