### PR TITLE
Catch NullPointerException in TabUtils

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/util/TabUtils.java
+++ b/app/src/main/java/io/stormbird/wallet/util/TabUtils.java
@@ -41,6 +41,8 @@ public class TabUtils {
             }
         } catch (Resources.NotFoundException nfe) {
             Log.e(TabUtils.class.getSimpleName(), nfe.getMessage(), nfe);
+        } catch (NullPointerException npe) {
+            Log.e(TabUtils.class.getSimpleName(), npe.getMessage(), npe);
         }
     }
 


### PR DESCRIPTION
Fixed issue reported by Crashlytics causing the app to crash when trying to change the tab font dynamically.