### PR TITLE
Fix UI experience for using ENS names

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -524,7 +524,7 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
         toAddressEditText.dismissDropDown();
         layoutENSResolve.setVisibility(View.VISIBLE);
         textENS.setText(address);
-        KeyboardUtils.hideKeyboard(getCurrentFocus());
+        if (toAddressEditText.hasFocus()) KeyboardUtils.hideKeyboard(getCurrentFocus()); //user was waiting for ENS, not in the middle of typing a value etc
         checkIfWaitingForENS();
         toAddressError.setVisibility(View.GONE);
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
@@ -787,13 +787,14 @@ public class TransferTicketDetailActivity extends BaseActivity implements Runnab
         }
     }
 
+    //TODO: This could be abstracted into an ENS class
     private void onENSSuccess(String address)
     {
         waitingForENS = false;
         toAddressEditText.dismissDropDown();
         layoutENSResolve.setVisibility(View.VISIBLE);
         textENS.setText(address);
-        KeyboardUtils.hideKeyboard(getCurrentFocus());
+        if (toAddressEditText.hasFocus()) KeyboardUtils.hideKeyboard(getCurrentFocus()); //user was waiting for ENS, not in the middle of typing a value etc
         checkIfWaitingForENS();
         toAddressError.setVisibility(View.GONE);
     }


### PR DESCRIPTION
Only auto-hide keyboard if user was waiting for ENS to resolve (ie the user is still focused on the address input when ENS returns a positive value).