### PR TITLE
Ensure correct balance update

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
@@ -114,13 +114,13 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 	@Override
 	public String getActiveRPC()
 	{
-		if (currentActiveRPC != null)
+		if (defaultNetwork != null)
 		{
-			return currentActiveRPC;
+			return defaultNetwork.rpcServerUrl;
 		}
 		else
 		{
-			return defaultNetwork.rpcServerUrl;
+			return NETWORKS[0].rpcServerUrl; //default to mainnet if no current default
 		}
 	}
 

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -260,7 +260,7 @@ public class TokenRepository implements TokenRepositoryType {
                     List<Token> result = new ArrayList<>();
                     result.addAll(Arrays.asList(ERC721Tokens));
                     result.addAll(Arrays.asList(tokens));
-                    return result.toArray(new Token[result.size()]);
+                    return result.toArray(new Token[0]);
                 });
     }
 
@@ -273,7 +273,7 @@ public class TokenRepository implements TokenRepositoryType {
                     List<Token> result = new ArrayList<>();
                     result.add(ethToken);
                     result.addAll(Arrays.asList(tokens));
-                    return result.toArray(new Token[result.size()]);
+                    return result.toArray(new Token[0]);
                 });
     }
 
@@ -856,22 +856,7 @@ public class TokenRepository implements TokenRepositoryType {
      */
     @Override
     public Single<Token> getEthBalance(NetworkInfo network, Wallet wallet) {
-        return walletRepository.balanceInWei(wallet)
-                .map(balance -> {
-                    if (balance.equals(BigDecimal.valueOf(-1)))
-                    {
-                        //network error - retrieve from cache
-                        Token b = localSource.getTokenBalance(network, wallet, wallet.address);
-                        if (b != null) balance = b.balance;
-                        else balance = BigDecimal.ZERO;
-                    }
-                    TokenInfo info = new TokenInfo(wallet.address, network.name, network.symbol, 18, true);
-                    Token eth = new Token(info, balance, System.currentTimeMillis());
-                    eth.setIsEthereum();
-                    //store token and balance
-                    localSource.updateTokenBalance(network, wallet, eth);
-                    return eth;
-                });
+        return attachEth(network, wallet);
     }
 
     @Override

--- a/app/src/main/java/io/stormbird/wallet/repository/WalletRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/WalletRepository.java
@@ -123,7 +123,7 @@ public class WalletRepository implements WalletRepositoryType
 			try {
 				return new BigDecimal(Web3jFactory
 						.build(new org.web3j.protocol.http.HttpService(networkRepository.getActiveRPC()))
-						.ethGetBalance(wallet.address, DefaultBlockParameterName.LATEST)
+						.ethGetBalance(wallet.address, DefaultBlockParameterName.PENDING)
 						.send()
 						.getBalance());
 			}

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
@@ -242,7 +242,6 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
 
     private void onTokens(Token[] tokens)
     {
-        for (Token t : tokens) if(t.hasPositiveBalance()) Log.d(TAG, t.getAddress() + " : " + t.getFullName());
         adapter.setTokens(tokens);
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TokensAdapter.java
@@ -243,7 +243,9 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
 
         for (Token token : tokens)
         {
-            if (!token.isTerminated() && !token.isBad() && (token.isEthereum() || token.hasPositiveBalance()))
+            if (token != null &&  //Add token to display list if it's the base currency, or if it has balance
+                    (token.isEthereum() ||
+                            (!token.isTerminated() && !token.isBad() && token.hasPositiveBalance())))
             {
                 Log.d(TAG,"ADDING: " + token.getFullName());
                 checkLiveToken(token);

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.crashlytics.android.Crashlytics;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -168,7 +169,7 @@ public class WalletViewModel extends BaseViewModel
             updateTokens = fetchTokensInteract.fetchStoredWithEth(defaultNetwork.getValue(), defaultWallet.getValue())
                     .subscribeOn(Schedulers.newThread())
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(this::onTokens, this::onError, this::fetchFromOpensea);
+                    .subscribe(this::onTokens, this::onTokenFetchError, this::fetchFromOpensea);
         }
         else
         {
@@ -177,12 +178,20 @@ public class WalletViewModel extends BaseViewModel
         }
     }
 
+    private void onTokenFetchError(Throwable throwable)
+    {
+        //We encountered an unknown issue during token fetch
+        //This is most likely due to a balance recording error
+        //log the exception for reference
+        Crashlytics.logException(throwable);
+        throwable.printStackTrace();
+        onError(throwable);
+    }
+
     private void onTokens(Token[] tokens)
     {
         tokensService.addTokens(tokens);
     }
-
-    private boolean firstRunDebugTest = true;
 
     private void fetchFromOpensea()
     {
@@ -200,12 +209,19 @@ public class WalletViewModel extends BaseViewModel
                     //openseaService.getTokens("0x51A9f155405Ea594d881fE9c1f1eb38F003B0A57") //"0xbc8dAfeacA658Ae0857C80D8Aa6dE4D487577c63"
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(this::gotOpenseaTokens, this::onError);
+                    .subscribe(this::gotOpenseaTokens, this::onOpenseaError);
         }
         else
         {
             onFetchTokensCompletable();
         }
+    }
+
+    private void onOpenseaError(Throwable throwable)
+    {
+        Crashlytics.logException(throwable);
+        throwable.printStackTrace();
+        onError(throwable);
     }
 
     private void gotOpenseaTokens(Token[] tokens)
@@ -239,7 +255,6 @@ public class WalletViewModel extends BaseViewModel
     private void storedTokens(Token[] tokens)
     {
         Log.d("WVM", "Stored " + tokens.length);
-        //if (updateTokens != null && !updateTokens.isDisposed()) updateTokens.dispose();
         onFetchTokensCompletable();
     }
 
@@ -270,7 +285,12 @@ public class WalletViewModel extends BaseViewModel
 
     private void tkError(Throwable throwable)
     {
+        Crashlytics.logException(throwable);
+        throwable.printStackTrace();
+        onError(throwable);
         if (checkTokensDisposable != null) checkTokensDisposable.dispose();
+        //restart a refresh
+        fetchTokens();
     }
 
     private void updateTokenBalances()


### PR DESCRIPTION
This PR addresses issue #310 . 

The token-fetch/balance-update cycle was analysed from start to finish to find any areas where errors can occur.

Potential issues involving dealing with network timeouts, database read fails and theoretical Android JVM memory recovery were found. The code for these has been refactored for cleaner code that is better able to proceed even if it fails due to background resources changing.

The areas where problems are likely to show have had crashalytics logs attached so we should be able to get some feedback if these are triggering.