### PR TITLE
Decouple transaction view display

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Transaction.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Transaction.java
@@ -35,7 +35,6 @@ public class Transaction implements Parcelable {
     public final String input;
     public final TransactionOperation[] operations;
     public final String error;
-    public final String contentHash;
 
     public boolean isConstructor = false;
 
@@ -66,8 +65,6 @@ public class Transaction implements Parcelable {
 		this.input = input;
 		this.gasUsed = gasUsed;
 		this.operations = operations;
-
-		this.contentHash = calculateContentHash();
 	}
 
 	protected Transaction(Parcel in)
@@ -85,7 +82,6 @@ public class Transaction implements Parcelable {
 		input = in.readString();
 		gasUsed = in.readString();
 		Parcelable[] parcelableArray = in.readParcelableArray(TransactionOperation.class.getClassLoader());
-		this.contentHash = in.readString();
 		TransactionOperation[] operations = null;
 		if (parcelableArray != null)
 		{
@@ -126,39 +122,5 @@ public class Transaction implements Parcelable {
 		dest.writeString(input);
 		dest.writeString(gasUsed);
 		dest.writeParcelableArray(operations, flags);
-		dest.writeString(contentHash);
-	}
-
-	private String calculateContentHash()
-	{
-		String operationContent = "";
-		String calcHash = "";
-		try
-		{
-			if (operations != null && operations.length > 0)
-			{
-				if (operations[0].contract instanceof ERC875ContractTransaction)
-				{
-					ERC875ContractTransaction ctx = (ERC875ContractTransaction) operations[0].contract;
-					operationContent = ctx.address + ctx.operation + ctx.getIndicesString() + ctx.type + ctx.name;
-				}
-				else
-				{
-					TransactionContract ctx = operations[0].contract;
-					String addend = "";
-					if (operations[0].viewType != null) addend = operations[0].viewType;
-					operationContent = ctx.address + ctx.totalSupply + ctx.name + addend;
-				}
-			}
-
-			calcHash = Hash.sha3String(to + hash + input + timeStamp + blockNumber + gasPrice + from + value + nonce + operationContent);
-		}
-		catch (Exception e)
-		{
-			e.printStackTrace();
-			calcHash = Hash.sha3String(to + hash + timeStamp + nonce);
-		}
-
-		return calcHash;
 	}
 }

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionMeta.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionMeta.java
@@ -1,0 +1,24 @@
+package io.stormbird.wallet.entity;
+
+/**
+ * Created by James on 3/12/2018.
+ * Stormbird in Singapore
+ */
+
+/**
+ * Cut down version of transaction which is used to populate the Transaction view adapter data.
+ * The actual transaction data is retrieved just-in-time from the database when the user looks at the transaction
+ * This saves a lot of memory - especially for a contract with a huge amount of transactions.
+ */
+
+public class TransactionMeta
+{
+    public final String hash;
+    public final long timeStamp;
+
+    public TransactionMeta(String hash, long timeStamp)
+    {
+        this.hash = hash;
+        this.timeStamp = timeStamp;
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -44,4 +44,9 @@ public class FetchTransactionsInteract {
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io());
     }
+
+    public Transaction fetchCached(String walletAddress, String hash)
+    {
+        return transactionRepository.fetchCachedTransaction(walletAddress, hash);
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionLocalSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionLocalSource.java
@@ -9,6 +9,7 @@ import io.reactivex.Single;
 
 public interface TransactionLocalSource {
 	Single<Transaction[]> fetchTransaction(NetworkInfo networkInfo, Wallet wallet);
+	Transaction fetchTransaction(NetworkInfo networkInfo, Wallet wallet, String hash);
 
 	Completable putTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] transactions);
 

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionMemoryCache.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionMemoryCache.java
@@ -33,7 +33,13 @@ public class TransactionMemoryCache implements TransactionLocalSource {
 		});
 	}
 
-    private String createKey(NetworkInfo networkInfo, Wallet wallet) {
+	@Override
+	public Transaction fetchTransaction(NetworkInfo networkInfo, Wallet wallet, String hash)
+	{
+		return null;
+	}
+
+	private String createKey(NetworkInfo networkInfo, Wallet wallet) {
         return networkInfo.name + wallet.address;
     }
 

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -61,6 +61,14 @@ public class TransactionRepository implements TransactionRepositoryType {
 	}
 
 	@Override
+	public Transaction fetchCachedTransaction(String walletAddr, String hash)
+	{
+		NetworkInfo networkInfo = networkRepository.getDefaultNetwork();
+		Wallet wallet = new Wallet(walletAddr);
+		return inDiskCache.fetchTransaction(networkInfo, wallet, hash);
+	}
+
+	@Override
 	public Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock, String userAddress) {
 		NetworkInfo networkInfo = networkRepository.getDefaultNetwork();
 		return fetchFromNetwork(networkInfo, wallet, lastBlock, userAddress)

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
@@ -22,4 +22,6 @@ public interface TransactionRepositoryType {
 	Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList);
 
     Single<Integer> queryInterfaceSpec(Token token);
+
+    Transaction fetchCachedTransaction(String walletAddr, String hash);
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
@@ -58,6 +58,26 @@ public class TransactionsRealmCache implements TransactionLocalSource {
 	}
 
     @Override
+    public Transaction fetchTransaction(NetworkInfo networkInfo, Wallet wallet, String hash)
+    {
+        try (Realm instance = realmManager.getRealmInstance(networkInfo, wallet))
+        {
+            RealmTransaction realmTx = instance.where(RealmTransaction.class)
+                    .equalTo("hash", hash)
+                    .findFirst();
+
+            if (realmTx != null)
+            {
+                return convert(realmTx);
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+
+    @Override
 	public Completable putTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] transactions) {
         return Completable.fromAction(() -> {
             Realm instance = null;

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionsRealmCache.java
@@ -27,6 +27,7 @@ import io.realm.Realm;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
 
+import static android.os.Parcelable.PARCELABLE_WRITE_RETURN_VALUE;
 import static io.stormbird.wallet.entity.TransactionOperation.ERC875_CONTRACT_TYPE;
 import static io.stormbird.wallet.entity.TransactionOperation.NORMAL_CONTRACT_TYPE;
 
@@ -74,6 +75,10 @@ public class TransactionsRealmCache implements TransactionLocalSource {
             {
                 return null;
             }
+        }
+        catch (Exception e)
+        {
+            return null;
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
@@ -80,7 +80,8 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         viewModel = ViewModelProviders.of(this, transactionsViewModelFactory)
                 .get(TransactionsViewModel.class);
 
-        adapter = new TransactionsAdapter(this::onTransactionClick, viewModel.getTokensService());
+        adapter = new TransactionsAdapter(this::onTransactionClick, viewModel.getTokensService(),
+                                          viewModel.provideTransactionsInteract());
         SwipeRefreshLayout refreshLayout = view.findViewById(R.id.refresh_layout);
         systemView = view.findViewById(R.id.system_view);
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/TransactionSortedItem.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/TransactionSortedItem.java
@@ -1,18 +1,17 @@
 package io.stormbird.wallet.ui.widget.entity;
 
 import android.text.format.DateUtils;
-
 import io.stormbird.wallet.entity.Transaction;
-import io.stormbird.wallet.entity.TransactionContract;
+import io.stormbird.wallet.entity.TransactionMeta;
 import io.stormbird.wallet.ui.widget.holder.TransactionHolder;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-public class TransactionSortedItem extends TimestampSortedItem<Transaction> {
+public class TransactionSortedItem extends TimestampSortedItem<TransactionMeta> {
 
-    public TransactionSortedItem(int viewType, Transaction value, int order) {
+    public TransactionSortedItem(int viewType, TransactionMeta value, int order) {
         super(viewType, value, 0, order);
     }
 
@@ -26,12 +25,11 @@ public class TransactionSortedItem extends TimestampSortedItem<Transaction> {
             //block - so the timestamp was the same. The display flickered between the two transactions.
             if (this.getTimestamp().equals(otherTimestamp.getTimestamp()))
             {
-                Transaction oldTx = value;
-                Transaction newTx = (Transaction) other.value;
+                TransactionMeta oldTx = value;
+                TransactionMeta newTx = (TransactionMeta) other.value;
 
-                // Note: This fails if the transaction is badly formed - this is intentional as we need to be certain that
-                //       All failure mechanisms have been removed
-                return oldTx.contentHash.compareTo(newTx.contentHash);
+                //just compare the transaction hash instead
+                return oldTx.hash.compareTo(newTx.hash);
             }
             else
             {
@@ -50,10 +48,9 @@ public class TransactionSortedItem extends TimestampSortedItem<Transaction> {
         {
             if (viewType == newItem.viewType)
             {
-                Transaction oldTx = value;
-                Transaction newTx = (Transaction) newItem.value;
+                TransactionMeta oldTx = value;
+                TransactionMeta newTx = (TransactionMeta) newItem.value;
 
-                //return oldTx.contentHash.equals(newTx.contentHash);
                 return oldTx.hash.equals(newTx.hash);
             }
             else
@@ -74,8 +71,8 @@ public class TransactionSortedItem extends TimestampSortedItem<Transaction> {
         {
             if (viewType == other.viewType && viewType == TransactionHolder.VIEW_TYPE)
             {
-                Transaction oldTx = value;
-                Transaction newTx = (Transaction) other.value;
+                TransactionMeta oldTx = value;
+                TransactionMeta newTx = (TransactionMeta) other.value;
 
                 return oldTx.hash.equals(newTx.hash);
             }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -8,38 +8,23 @@ import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.text.format.DateUtils;
 import android.util.Log;
-
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-import io.stormbird.wallet.entity.ERC875ContractTransaction;
-import io.stormbird.wallet.entity.NetworkInfo;
-import io.stormbird.wallet.entity.Token;
-import io.stormbird.wallet.entity.Transaction;
-import io.stormbird.wallet.entity.TransactionContract;
-import io.stormbird.wallet.entity.TransactionType;
-import io.stormbird.wallet.entity.Wallet;
-import io.stormbird.wallet.interact.AddTokenInteract;
-import io.stormbird.wallet.interact.FetchTokensInteract;
-import io.stormbird.wallet.interact.FetchTransactionsInteract;
-import io.stormbird.wallet.interact.FindDefaultNetworkInteract;
-import io.stormbird.wallet.interact.FindDefaultWalletInteract;
-import io.stormbird.wallet.interact.SetupTokensInteract;
+import io.stormbird.wallet.entity.*;
+import io.stormbird.wallet.interact.*;
 import io.stormbird.wallet.router.ExternalBrowserRouter;
 import io.stormbird.wallet.router.HomeRouter;
 import io.stormbird.wallet.router.TransactionDetailRouter;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.service.TokensService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.stormbird.wallet.entity.TransactionDecoder.isEndContract;
 
@@ -75,13 +60,10 @@ public class TransactionsViewModel extends BaseViewModel
     private Handler handler = new Handler();
 
     private boolean isVisible = false;
-    private Transaction[] txArray;
     private Map<String, Transaction> txMap = new ConcurrentHashMap<>();
     private List<Transaction> txContractList = new ArrayList<>();
     private int transactionCount;
     private boolean restoreRequired = false;
-    private boolean immediateCycleStart = false;//this is used to flag the need to start a new cycle,
-                                                // usually only seen when importing a new wallet with a lot of transactions on it
     private long latestBlock = 0;
 
     TransactionsViewModel(
@@ -133,7 +115,6 @@ public class TransactionsViewModel extends BaseViewModel
 
         fetchTransactionDisposable = null;
 
-        txArray = null;
         txMap.clear();
     }
 
@@ -209,7 +190,7 @@ public class TransactionsViewModel extends BaseViewModel
      */
     private void onTransactions(Transaction[] transactions) {
         Log.d(TAG, "Found " + transactions.length + " Cached transactions");
-        txArray = transactions;
+        updateDisplay(transactions);
 
         for (Transaction tx : transactions)
         {
@@ -227,13 +208,8 @@ public class TransactionsViewModel extends BaseViewModel
         if (restoreRequired)
         {
             latestBlock = 0;
-            txArray = new Transaction[0];
             txMap.clear();
             restoreRequired = false;
-        }
-        else
-        {
-            updateDisplay(txArray);
         }
 
         Log.d(TAG, "Fetching network transactions.");
@@ -251,7 +227,6 @@ public class TransactionsViewModel extends BaseViewModel
      * @param transactions
      */
     private void onUpdateTransactions(Transaction[] transactions) {
-        Log.d(TAG, "Found " + transactions.length + " Network transactions");
         //check against existing transactions
         List<Transaction> newTxs = new ArrayList<Transaction>();
         for (Transaction tx : transactions)
@@ -260,12 +235,18 @@ public class TransactionsViewModel extends BaseViewModel
             {
                 txMap.put(tx.hash, tx);
                 newTxs.add(tx);
+                if (Long.valueOf(tx.blockNumber) > latestBlock) latestBlock = Long.valueOf(tx.blockNumber);
             }
         }
 
         if (newTxs.size() > 0)
         {
-            updateDisplay(newTxs.toArray(new Transaction[0]));
+            Log.d(TAG, "Found " + transactions.length + " Network transactions");
+            //store new transactions, so they will appear in the transaction view, then update the view
+            disposable = fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), newTxs.toArray(new Transaction[0]))
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(this::updateDisplay, this::onError);
         }
     }
 
@@ -291,8 +272,7 @@ public class TransactionsViewModel extends BaseViewModel
         //stop the spinner
         progress.postValue(false);
         Log.d(TAG, "Enumerating tokens");
-        txArray = txMap.values().toArray(new Transaction[0]);
-        transactionCount += txArray.length;
+        transactionCount += txMap.size();
         txContractList.clear();
 
         if (wallet.getValue() != null)
@@ -303,6 +283,7 @@ public class TransactionsViewModel extends BaseViewModel
                     .flatMapIterable(token -> token)
                     .filter(token -> !token.isEthereum())
                     .filter(token -> !token.isTerminated())
+                    .filter(token -> !token.independentUpdate())//don't scan ERC721 transactions
                     .concatMap(token -> fetchTransactionsInteract.fetchNetworkTransactions(new Wallet(token.getAddress()), tokensService.getLatestBlock(token.getAddress()), wallet.getValue().address)) //single that fetches all the tx's from etherscan for each token from fetchSequential
                     .subscribeOn(Schedulers.io())
                     .observeOn(Schedulers.io())
@@ -346,7 +327,6 @@ public class TransactionsViewModel extends BaseViewModel
     {
         transactions.postValue(txContractList.toArray(new Transaction[0]));
         txContractList.clear();
-        immediateCycleStart = false;
 
         fetchTransactionDisposable = fetchTransactionsInteract.storeTransactions(network.getValue(), wallet.getValue(), txMap.values().toArray(new Transaction[0]))
                 .flatMap(transactions -> setupTokensInteract.getUnknownTokens(transactions, tokensService, txMap))
@@ -428,14 +408,8 @@ public class TransactionsViewModel extends BaseViewModel
 
     private void checkIfRegularUpdateNeeded()
     {
-        if (immediateCycleStart)
-        {
-            handler.removeCallbacks(startFetchTransactionsTask);
-            handler.postDelayed(
-                    startFetchTransactionsTask,
-                    100);
-        }
-        else if (!isVisible)
+        txMap.clear();
+        if (!isVisible)
         {
             //no longer any need to refresh
             Log.d(TAG, "Finish");
@@ -485,7 +459,7 @@ public class TransactionsViewModel extends BaseViewModel
         externalBrowserRouter.open(context, uri);
     }
 
-    private final Runnable startFetchTransactionsTask = () -> this.fetchTransactions(false);
+    private final Runnable startFetchTransactionsTask = this::fetchNetworkTransactions;
 
     //Called from the activity when it comes into view,
     //start updating transactions
@@ -580,5 +554,10 @@ public class TransactionsViewModel extends BaseViewModel
     public TokensService getTokensService()
     {
         return tokensService;
+    }
+
+    public FetchTransactionsInteract provideTransactionsInteract()
+    {
+        return fetchTransactionsInteract;
     }
 }

--- a/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
+++ b/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
@@ -172,6 +172,12 @@ public class MarketOrderTest
             {
                 return null;
             }
+
+            @Override
+            public Transaction fetchCachedTransaction(String walletAddr, String hash)
+            {
+                return null;
+            }
         };
 
         marketService = new MarketQueueService(null, null, transactionRepository, passwordStore);

--- a/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
+++ b/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
@@ -35,7 +35,7 @@ public class QRSelectionTest
     SignatureGenerateInteract signatureGenerateInteract;
 
 
-    final String CONTRACT_ADDR  = "0xbc9a1026a4bc6f0ba8bbe486d1d09da5732b39e4";
+    final String CONTRACT_ADDR = "0xbc9a1026a4bc6f0ba8bbe486d1d09da5732b39e4";
 
 
     private ECKeyPair testKey;
@@ -55,140 +55,148 @@ public class QRSelectionTest
         sr.nextBytes(keySeed);
         testKey = ECKeyPair.create(keySeed);
 
-        transactionRepository = new TransactionRepositoryType() {
+        transactionRepository = new TransactionRepositoryType()
+        {
 
-                @Override
-                public Observable<Transaction[]> fetchCachedTransactions(NetworkInfo network, Wallet wallet)
-                {
-                    return null;
-                }
-
-                @Override
-                public Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock, String userAddress)
-                {
-                    return null;
-                }
-
-                @Override
-                public Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password)
-                {
-                    return null;
-                }
-
-                @Override
-                public Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password)
-                {
-                    return null;
-                }
-
-                @Override
-                public Single<byte[]> getSignature(Wallet wallet, byte[] message, String password)
-                {
-                    return null;
-                }
-
-                @Override
-                public Single<byte[]> getSignatureFast(Wallet wallet, byte[] message, String pass)
-                {
-                    return Single.fromCallable(() -> {
-                        //sign using the local key
-                        Sign.SignatureData sigData = Sign.signMessage(message, testKey);
-
-                        byte[] sig = new byte[65];
-
-                        try {
-                            System.arraycopy(sigData.getR(), 0, sig, 0, 32);
-                            System.arraycopy(sigData.getS(), 0, sig, 32, 32);
-                            sig[64] = (byte) (int) sigData.getV();
-                        }
-                        catch (IndexOutOfBoundsException e)
-                        {
-                            throw new SalesOrderMalformed("Signature shorter than expected 256");
-                        }
-
-                        return sig;
-                    });
-                }
-
-                @Override
-                public void unlockAccount(Wallet signer, String signerPassword) throws Exception
-                {
-
-                }
-
-                @Override
-                public void lockAccount(Wallet signer, String signerPassword) throws Exception
-                {
-
-                }
-
-                @Override
-                public Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList)
-                {
-                    return null;
-                }
-
-                @Override
-                public Single<Integer> queryInterfaceSpec(Token token)
-                {
-                    return null;
-                }
-            };
-
-            signatureGenerateInteract = new SignatureGenerateInteract(null)
+            @Override
+            public Observable<Transaction[]> fetchCachedTransactions(NetworkInfo network, Wallet wallet)
             {
-                @Override
-                //TODO: Sign message here not in the additional field
-                public Single<MessagePair> getMessage(List<Integer> indexList, String contract)
-                {
-                    return Single.fromCallable(() -> {
-                        String selectionStr = SignaturePair.generateSelection(indexList);
-                        long currentTime = System.currentTimeMillis();
-                        long minsT = currentTime / (30 * 1000);
-                        int minsTime = (int) minsT;
-                        String plainMessage = selectionStr + "," + String.valueOf(minsTime) + "," + contract.toLowerCase();  //This is the plain text message that gets signed
-                        return new MessagePair(selectionStr, plainMessage);
-                    });
-                }
-            };
-
-            List<QREncoding> qrList = new ArrayList<>();
-
-            //test key address
-            String testAddress = "0x" + Keys.getAddress(testKey.getPublicKey());
-
-            //generate all ticket redeem combos up to index 256, then check signature and regenerate the selection
-            final int indicesCount = 8 * 2;
-            final int combinations = (int) Math.pow(2, indicesCount);
-
-            for (int i = 1; i < combinations; i += 1) // pick all the combinations, even though it slows the test down
-            {
-                QREncoding qr = new QREncoding();
-                qrList.add(qr);
-
-                //generate an entry
-                //1 generate the indices
-                //consume the bitfield
-                BigInteger k = BigInteger.valueOf(i);
-                int radix = k.getLowestSetBit();
-                while (!k.equals(BigInteger.ZERO))
-                {
-                    if (k.testBit(radix))
-                    {
-                        qr.indices.add(radix + 1);
-                        k = k.clearBit(radix);
-                    }
-                    radix++;
-                }
-
-                MessagePair messagePair = signatureGenerateInteract
-                        .getMessage(qr.indices, CONTRACT_ADDR).blockingGet();
-
-                byte[] sig = transactionRepository
-                        .getSignatureFast(null, messagePair.message.getBytes(), "hackintosh").blockingGet();
-
-                qr.sigPair = new SignaturePair(messagePair.selection, sig, messagePair.message);
+                return null;
             }
+
+            @Override
+            public Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock, String userAddress)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<byte[]> getSignature(Wallet wallet, byte[] message, String password)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<byte[]> getSignatureFast(Wallet wallet, byte[] message, String pass)
+            {
+                return Single.fromCallable(() -> {
+                    //sign using the local key
+                    Sign.SignatureData sigData = Sign.signMessage(message, testKey);
+
+                    byte[] sig = new byte[65];
+
+                    try
+                    {
+                        System.arraycopy(sigData.getR(), 0, sig, 0, 32);
+                        System.arraycopy(sigData.getS(), 0, sig, 32, 32);
+                        sig[64] = (byte) (int) sigData.getV();
+                    }
+                    catch (IndexOutOfBoundsException e)
+                    {
+                        throw new SalesOrderMalformed("Signature shorter than expected 256");
+                    }
+
+                    return sig;
+                });
+            }
+
+            @Override
+            public void unlockAccount(Wallet signer, String signerPassword) throws Exception
+            {
+
+            }
+
+            @Override
+            public void lockAccount(Wallet signer, String signerPassword) throws Exception
+            {
+
+            }
+
+            @Override
+            public Single<Transaction[]> storeTransactions(NetworkInfo networkInfo, Wallet wallet, Transaction[] txList)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<Integer> queryInterfaceSpec(Token token)
+            {
+                return null;
+            }
+
+            @Override
+            public Transaction fetchCachedTransaction(String walletAddr, String hash)
+            {
+                return null;
+            }
+        };
+
+        signatureGenerateInteract = new SignatureGenerateInteract(null)
+        {
+            @Override
+            //TODO: Sign message here not in the additional field
+            public Single<MessagePair> getMessage(List<Integer> indexList, String contract)
+            {
+                return Single.fromCallable(() -> {
+                    String selectionStr = SignaturePair.generateSelection(indexList);
+                    long currentTime = System.currentTimeMillis();
+                    long minsT = currentTime / (30 * 1000);
+                    int minsTime = (int) minsT;
+                    String plainMessage = selectionStr + "," + String.valueOf(minsTime) + "," + contract.toLowerCase();  //This is the plain text message that gets signed
+                    return new MessagePair(selectionStr, plainMessage);
+                });
+            }
+        };
+
+        List<QREncoding> qrList = new ArrayList<>();
+
+        //test key address
+        String testAddress = "0x" + Keys.getAddress(testKey.getPublicKey());
+
+        //generate all ticket redeem combos up to index 256, then check signature and regenerate the selection
+        final int indicesCount = 8 * 2;
+        final int combinations = (int) Math.pow(2, indicesCount);
+
+        for (int i = 1; i < combinations; i += 1) // pick all the combinations, even though it slows the test down
+        {
+            QREncoding qr = new QREncoding();
+            qrList.add(qr);
+
+            //generate an entry
+            //1 generate the indices
+            //consume the bitfield
+            BigInteger k = BigInteger.valueOf(i);
+            int radix = k.getLowestSetBit();
+            while (!k.equals(BigInteger.ZERO))
+            {
+                if (k.testBit(radix))
+                {
+                    qr.indices.add(radix + 1);
+                    k = k.clearBit(radix);
+                }
+                radix++;
+            }
+
+            MessagePair messagePair = signatureGenerateInteract
+                    .getMessage(qr.indices, CONTRACT_ADDR).blockingGet();
+
+            byte[] sig = transactionRepository
+                    .getSignatureFast(null, messagePair.message.getBytes(), "hackintosh").blockingGet();
+
+            qr.sigPair = new SignaturePair(messagePair.selection, sig, messagePair.message);
+        }
 
         try
         {
@@ -248,8 +256,9 @@ public class QRSelectionTest
 
     public static Sign.SignatureData sigFromBase64Fix(byte[] sig) throws Exception
     {
-        byte   subv = (byte)(sig[64] + 27);
-        if (subv > 30) subv -= 27;
+        byte subv = (byte) (sig[64] + 27);
+        if (subv > 30)
+            subv -= 27;
 
         byte[] subrRev = Arrays.copyOfRange(sig, 0, 32);
         byte[] subsRev = Arrays.copyOfRange(sig, 32, 64);


### PR DESCRIPTION
Refactor the transaction view so the transaction list and the transaction data are decoupled. The list now only stores Transaction meta-data, ie the hash and the timestamp. This update has been planned for quite a while.

- TransactionsViewModel fetches cached transactions then fetches any new transactions.
- All transactions are now stored in the adapter as a TransactionMeta object - only need hash and timestamp (as opposed to all the transaction data).
- When the transaction item comes into view (or just before it comes into view) the transaction data is retrieved from the database ready for the view element.

This gives improvements:
- Memory is reduced, only storing a small amount of data for each transaction on the list.
- Simplification of update code. Any transaction data update is obtained just by invalidating the view item and Android will just re-fetch the new data from the database.