### PR TITLE
Fix app refresh after wallet import

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -37,11 +37,7 @@ import io.stormbird.token.tools.Numeric;
 import io.stormbird.wallet.BuildConfig;
 import io.stormbird.wallet.C;
 import io.stormbird.wallet.R;
-import io.stormbird.wallet.entity.DAppFunction;
-import io.stormbird.wallet.entity.NetworkInfo;
-import io.stormbird.wallet.entity.URLLoadInterface;
-import io.stormbird.wallet.entity.URLLoadReceiver;
-import io.stormbird.wallet.entity.Wallet;
+import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.ui.widget.adapter.AutoCompleteUrlAdapter;
 import io.stormbird.wallet.ui.widget.entity.ItemClickListener;
 import io.stormbird.wallet.util.Utils;
@@ -180,7 +176,6 @@ public class DappBrowserFragment extends Fragment implements
         }
         web3.setChainId(networkInfo.chainId);
         String rpcURL = networkInfo.rpcServerUrl;
-        if (networkInfo.backupNodeUrl != null) rpcURL = networkInfo.backupNodeUrl;
         web3.setRpcUrl(rpcURL);
         web3.setWalletAddress(new Address(wallet.address));
 

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
@@ -185,7 +185,6 @@ public class WalletsActivity extends BaseActivity implements
             showToolbar();
             if (resultCode == RESULT_OK)
             {
-                viewModel.fetchWallets();
                 Snackbar.make(systemView, getString(R.string.toast_message_wallet_imported), Snackbar.LENGTH_SHORT)
                         .show();
                 onScanBlockReceived(0); //reset scan block
@@ -193,13 +192,10 @@ public class WalletsActivity extends BaseActivity implements
 				Wallet importedWallet = data.getParcelableExtra(C.Key.WALLET);
 				if (importedWallet != null)
 				{
+				    isSetDefault = true;
+				    walletChange = true;
 					viewModel.setDefaultWallet(importedWallet);
 				}
-                if (adapter.getItemCount() <= 1) {
-                    viewModel.showHome(this);
-                }
-
-                sendBroadcast(new Intent(RESET_WALLET));
             }
         } else if (requestCode == SHARE_REQUEST_CODE) {
             if (resultCode == RESULT_OK) {


### PR DESCRIPTION
Fix for #452 . 

Fixed by simplifying the code and using the same method that's called when a wallet change is selected.

Also use the primary RPC URL for dapp browser.