### PR TITLE
If opensea query fails ensure token update uses cached values.

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/opensea/OpenseaServiceError.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/opensea/OpenseaServiceError.java
@@ -1,0 +1,18 @@
+package io.stormbird.wallet.entity.opensea;
+
+import io.stormbird.wallet.entity.ErrorEnvelope;
+
+/**
+ * Created by James on 20/12/2018.
+ * Stormbird in Singapore
+ */
+
+public class OpenseaServiceError extends Exception {
+    public final ErrorEnvelope error;
+
+    public OpenseaServiceError(String message) {
+        super(message);
+
+        error = new ErrorEnvelope(message);
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
@@ -235,7 +235,6 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
     public void onResume() {
         super.onResume();
         viewModel.setVisibility(isVisible);
-        viewModel.prepare();
     }
 
     private void onTokens(Token[] tokens)

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -190,7 +190,7 @@ public class WalletViewModel extends BaseViewModel implements Runnable
     /**
      * Stage 2: Fetch opensea tokens (if on mainnet)
      */
-    private void fetchFromOpensea()
+    private void fetchFromOpensea() throws Exception
     {
         List<Token> serviceList = tokensService.getAllLiveTokens();
         tokenCache = serviceList.toArray(new Token[0]);
@@ -220,7 +220,10 @@ public class WalletViewModel extends BaseViewModel implements Runnable
         //update the display list for token removals
         List<String> removedTokens = tokensService.getRemovedTokensOfClass(tokens, ERC721Token.class);
 
-        if (!removedTokens.isEmpty()) removeTokens.postValue(removedTokens); //remove from UI
+        if (!removedTokens.isEmpty())
+        {
+            removeTokens.postValue(removedTokens); //remove from UI
+        }
 
         tokensService.clearBalanceOf(ERC721Token.class);
 
@@ -240,9 +243,9 @@ public class WalletViewModel extends BaseViewModel implements Runnable
 
     private void onOpenseaError(Throwable throwable)
     {
-        if (!BuildConfig.DEBUG) Crashlytics.logException(throwable);
-        throwable.printStackTrace();
-        onError(throwable);
+        //This is expected to happen - opensea gets a lot of activity
+        //proceed using the stored data until we no longer get an error
+        onFetchTokensCompletable();
     }
 
     private void storedTokens(Token[] tokens)


### PR DESCRIPTION
Fix token appearance issues seen during demos at Cryptomas.