### PR TITLE
Use cached balances for ERC20 and ERC875 in case of network error

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -517,7 +517,7 @@ public class Token implements Parcelable
     public void displayTicketHolder(TicketRange range, View activity, AssetDefinitionService assetService, Context ctx) { }
     public List<BigInteger> getArrayBalance() { return new ArrayList<>(); }
     public void addToBurnList(List<Uint16> burnList) { }
-    public List<Integer> getBurnList() { return null; }
+    public List<Integer> getBurnList() { return new ArrayList<>(); }
     public boolean isMatchedInXML() { return false; }
 
     public String getOperationName(Transaction transaction, Context ctx)


### PR DESCRIPTION
In the event of any network error (eg phone in flight mode, infura issue etc) use the previously cached balance for ERC875 and ERC20 tokens.

Also tidy up abstraction in same function and remove now redundant code relating to token balance check (as per the TODO).