### PR TITLE
Erc721 transfer ui fix

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/widget/OnOpenseaAssetCheckListener.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/OnOpenseaAssetCheckListener.java
@@ -1,0 +1,12 @@
+package io.stormbird.wallet.ui.widget;
+
+import io.stormbird.wallet.entity.opensea.Asset;
+
+/**
+ * Created by James on 2/01/2019.
+ * Stormbird in Singapore
+ */
+public interface OnOpenseaAssetCheckListener
+{
+    void onAssetCheck (Asset asset);
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketAdapter.java
@@ -41,7 +41,7 @@ public class TicketAdapter extends TokensAdapter {
         token = t;
         openseaService = opensea;
         if (t instanceof Ticket) setToken(t);
-        if (t instanceof ERC721Token) setERC721Tokens(t);
+        if (t instanceof ERC721Token) setERC721Tokens(t, null);
     }
 
     public TicketAdapter(OnTokenClickListener tokenClickListener, Token token, String ticketIds, AssetDefinitionService service, OpenseaService opensea)
@@ -50,7 +50,7 @@ public class TicketAdapter extends TokensAdapter {
         this.token = token;
         if (token instanceof Ticket) setTokenRange(token, ticketIds);
         openseaService = opensea;
-        if (token instanceof ERC721Token) setERC721Tokens(token);
+        if (token instanceof ERC721Token) setERC721Tokens(token, ticketIds);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class TicketAdapter extends TokensAdapter {
         return holder;
     }
 
-    protected void setERC721Tokens(Token token)
+    protected void setERC721Tokens(Token token, String ticketId)
     {
         if (!(token instanceof ERC721Token)) return;
         items.beginBatchedUpdates();
@@ -91,7 +91,10 @@ public class TicketAdapter extends TokensAdapter {
         // populate the ERC721 items
         for (Asset asset : ((ERC721Token)token).tokenBalance)
         {
-            items.add(new AssetSortedItem(asset, weight++));
+            if (ticketId == null || ticketId.equals(asset.getTokenId()))
+            {
+                items.add(new AssetSortedItem(asset, weight++));
+            }
         }
         items.endBatchedUpdates();
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/TicketSaleAdapter.java
@@ -11,6 +11,7 @@ import io.stormbird.wallet.entity.ERC721Token;
 import io.stormbird.wallet.entity.Ticket;
 import io.stormbird.wallet.entity.TicketRangeElement;
 import io.stormbird.wallet.entity.Token;
+import io.stormbird.wallet.entity.opensea.Asset;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.widget.OnTokenCheckListener;
 import io.stormbird.wallet.ui.widget.OnTokenClickListener;
@@ -41,6 +42,7 @@ public class TicketSaleAdapter extends TicketAdapter {
 
     private OnTokenCheckListener onTokenCheckListener;
     private TicketRange selectedTicketRange;
+    private Asset selectedAsset;
     private QuantitySelectorHolder quantitySelector;
 
     /* Context ctx is used to initialise assetDefinition in the super class */
@@ -86,7 +88,7 @@ public class TicketSaleAdapter extends TicketAdapter {
             } break;
             case OpenseaHolder.VIEW_TYPE: {
                 holder = new OpenseaSelectHolder(R.layout.item_opensea_token, parent, token);
-                ((OpenseaSelectHolder)holder).setOnTokenCheckListener(onTokenCheckListener);
+                ((OpenseaSelectHolder)holder).setOnTokenCheckListener(this::onOpenseaCheck);
             } break;
         }
 
@@ -106,7 +108,7 @@ public class TicketSaleAdapter extends TicketAdapter {
     {
         if (t instanceof ERC721Token)
         {
-            setERC721Tokens(t);
+            setERC721Tokens(t, null);
         }
         else if (t instanceof Ticket)
         {
@@ -208,6 +210,17 @@ public class TicketSaleAdapter extends TicketAdapter {
         {
             return 0;
         }
+    }
+
+    private void onOpenseaCheck(Asset asset)
+    {
+        if (selectedAsset != null)
+        {
+            selectedAsset.isChecked = false;
+        }
+        asset.isChecked = true;
+        selectedAsset = asset;
+        notifyDataSetChanged();
     }
 
     private void onTokenCheck(TicketRange range) {

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaSelectHolder.java
@@ -8,10 +8,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 
+import android.widget.LinearLayout;
+import io.stormbird.token.entity.TicketRange;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.opensea.Asset;
+import io.stormbird.wallet.ui.widget.OnOpenseaAssetCheckListener;
 import io.stormbird.wallet.ui.widget.OnTokenCheckListener;
+
+import java.math.BigInteger;
 
 /**
  * Created by James on 12/11/2018.
@@ -20,11 +25,13 @@ import io.stormbird.wallet.ui.widget.OnTokenCheckListener;
 public class OpenseaSelectHolder extends OpenseaHolder
 {
     private final AppCompatRadioButton select;
-    private OnTokenCheckListener onTokenCheckListener;
+    private OnOpenseaAssetCheckListener onTokenCheckListener;
+    private final LinearLayout ticketLayout;
 
     public OpenseaSelectHolder(int resId, ViewGroup parent, Token token)
     {
         super(resId, parent, token);
+        ticketLayout = findViewById(R.id.layout_select_ticket);
         select = findViewById(R.id.radioBox);
     }
 
@@ -34,6 +41,7 @@ public class OpenseaSelectHolder extends OpenseaHolder
         super.bind(asset, addition);
         select.setVisibility(View.VISIBLE);
 
+        select.setOnCheckedChangeListener(null); //have to invalidate listener first otherwise we trigger cached listener and create infinite loop
         select.setChecked(asset.isChecked);
 
         select.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener()
@@ -41,12 +49,19 @@ public class OpenseaSelectHolder extends OpenseaHolder
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b)
             {
-                asset.isChecked = b;
+                if (b)
+                {
+                    onTokenCheckListener.onAssetCheck(asset);
+                }
             }
+        });
+
+        ticketLayout.setOnClickListener(v -> {
+            select.setChecked(true);
         });
     }
 
-    public void setOnTokenCheckListener(OnTokenCheckListener onTokenCheckListener)
+    public void setOnTokenCheckListener(OnOpenseaAssetCheckListener onTokenCheckListener)
     {
         this.onTokenCheckListener = onTokenCheckListener;
     }


### PR DESCRIPTION
While transferring ERC721 assets it was noticed that if you have multiple assets the selection system is broken. This PR does two things:

- After selecting an asset to transfer the transfer detail/address view now only shows the asset you selected.
- While selecting the asset to transfer the radio buttons now work as expected.