### PR TITLE
Fix for null transaction from dapp browser

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -300,7 +300,15 @@ public class DappBrowserFragment extends Fragment implements
     @Override
     public void onSignTransaction(Web3Transaction transaction, String url)
     {
-        viewModel.openConfirmation(getContext(), transaction, url);
+        if (transaction.payload == null || transaction.payload.length() < 1)
+        {
+            //display transaction error
+            onInvalidTransaction();
+        }
+        else
+        {
+            viewModel.openConfirmation(getContext(), transaction, url);
+        }
     }
 
     public static String hexToUtf8(String hex) {
@@ -320,6 +328,16 @@ public class DappBrowserFragment extends Fragment implements
         resultDialog.setIcon(AWalletAlertDialog.NONE);
         resultDialog.setTitle(R.string.title_dialog_sending);
         resultDialog.setMessage(R.string.transfer);
+        resultDialog.setProgressMode();
+        resultDialog.setCancelable(false);
+        resultDialog.show();
+    }
+
+    private void onInvalidTransaction() {
+        resultDialog = new AWalletAlertDialog(getActivity());
+        resultDialog.setIcon(AWalletAlertDialog.ERROR);
+        resultDialog.setTitle(getString(R.string.invalid_transaction));
+        resultDialog.setMessage(getString(R.string.contains_no_data));
         resultDialog.setProgressMode();
         resultDialog.setCancelable(false);
         resultDialog.show();

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,4 +11,6 @@
     <string name="allocate_to">Allocate To</string>
     <string name="approve">Approve</string>
     <string name="check_feemaster">Checking for gas free service</string>
+    <string name="invalid_transaction">Invalid Transaction</string>
+    <string name="contains_no_data">DApp transaction contains no data</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -337,4 +337,6 @@
     <string name="allocate_to">Allocate To</string>
     <string name="approve">Approve</string>
     <string name="check_feemaster">Checking for gas free service</string>
+    <string name="invalid_transaction">Invalid Transaction</string>
+    <string name="contains_no_data">DApp transaction contains no data</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -509,4 +509,6 @@
     <string name="allocate_to">Allocate To</string>
     <string name="approve">Approve</string>
     <string name="check_feemaster">Checking for gas free service</string>
+    <string name="invalid_transaction">Invalid Transaction</string>
+    <string name="contains_no_data">DApp transaction contains no data</string>
 </resources>


### PR DESCRIPTION
Fix a crash caused by Dapp trying to push a null or badly formed transaction.