### PR TITLE
Fix for differing timezone usages in XML file

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/TicketRangeElement.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TicketRangeElement.java
@@ -1,10 +1,13 @@
 package io.stormbird.wallet.entity;
 
 import java.math.BigInteger;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
 
 import io.stormbird.token.entity.NonFungibleToken;
+import io.stormbird.token.util.DateTime;
+import io.stormbird.token.util.DateTimeFactory;
 import io.stormbird.wallet.service.AssetDefinitionService;
 
 public class TicketRangeElement
@@ -25,7 +28,18 @@ public class TicketRangeElement
             if (nft.getAttribute("category") != null) category = (short) nft.getAttribute("category").value.intValue();
             if (nft.getAttribute("match") != null) match = (short) nft.getAttribute("match").value.intValue();
             if (nft.getAttribute("venue") != null) venue = (short) nft.getAttribute("venue").value.intValue();
-            if (nft.getAttribute("time") != null) time = nft.getAttribute("time").value.longValue();
+            if (nft.getAttribute("time") != null)
+            {
+                try
+                {
+                    DateTime eventTime = DateTimeFactory.getDateTime(nft.getAttribute("time"));
+                    time = eventTime.toEpochSecond();
+                }
+                catch (ParseException e)
+                {
+                    time = 0;
+                }
+            }
         }
     }
 

--- a/dmz/src/main/java/io/stormbird/token/web/AppSiteController.java
+++ b/dmz/src/main/java/io/stormbird/token/web/AppSiteController.java
@@ -1,7 +1,7 @@
 package io.stormbird.token.web;
 
 import io.stormbird.token.tools.TokenDefinition;
-import io.stormbird.token.util.ZonedDateTime;
+import io.stormbird.token.util.DateTimeFactory;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.*;
@@ -159,7 +159,7 @@ public class AppSiteController {
             sides += " - " + token.getAttribute("countryB").text;
             model.addAttribute("ticketSides", sides);
             model.addAttribute("ticketDate",
-                    new ZonedDateTime(token.getAttribute("time")).format(dateFormat));
+                               DateTimeFactory.getDateTime(token.getAttribute("time")).format(dateFormat));
             model.addAttribute("ticketMatch", token.getAttribute("match").text);
             model.addAttribute("ticketCategory", token.getAttribute("category").text);
             break; // we only need 1 token's info. rest assumed to be the same

--- a/lib/src/main/java/io/stormbird/token/entity/NonFungibleToken.java
+++ b/lib/src/main/java/io/stormbird/token/entity/NonFungibleToken.java
@@ -1,11 +1,9 @@
 package io.stormbird.token.entity;
 
 import io.stormbird.token.tools.TokenDefinition;
-import io.stormbird.token.util.ZonedDateTime;
 
 import java.math.BigInteger;
 import java.util.HashMap;
-import java.util.TimeZone;
 
 /**
  * Created by weiwu on 1/3/18.  Each NonFungibleToken is a

--- a/lib/src/main/java/io/stormbird/token/util/DateTime.java
+++ b/lib/src/main/java/io/stormbird/token/util/DateTime.java
@@ -1,0 +1,50 @@
+package io.stormbird.token.util;
+
+import io.stormbird.token.entity.NonFungibleToken;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Created by James on 11/02/2019.
+ * Stormbird in Singapore
+ */
+public abstract class DateTime
+{
+    protected long time;
+    protected TimeZone timezone;
+    protected boolean isZoned = false;
+
+    public int getHour() {
+        /* you can't just do this:
+        return new Date(time + offset).getHours() - 1;
+        because Date applies the local (the JRE's) timezone
+         */
+        SimpleDateFormat format = new SimpleDateFormat("H");
+        return Integer.valueOf(format(format));
+    }
+
+    public int getMinute() {
+        SimpleDateFormat format = new SimpleDateFormat("m");
+        return Integer.valueOf(format(format));
+    }
+
+    public String format(DateFormat format) {
+        format.setTimeZone(timezone);
+        return format.format(new Date(time));
+    }
+
+    public boolean isZoned()
+    {
+        return isZoned;
+    }
+
+    /* EVERY FUNCTION BELOW ARE SET OUT IN JAVA8 */
+
+    public long toEpochSecond() {
+        return time/1000L;
+    }
+}

--- a/lib/src/main/java/io/stormbird/token/util/DateTimeFactory.java
+++ b/lib/src/main/java/io/stormbird/token/util/DateTimeFactory.java
@@ -1,0 +1,86 @@
+package io.stormbird.token.util;
+
+import io.stormbird.token.entity.NonFungibleToken;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by James on 11/02/2019.
+ * Stormbird in Singapore
+ */
+public abstract class DateTimeFactory
+{
+    public static DateTime getDateTime(long unixTime, TimeZone timezone)
+    {
+        return new ZonedDateTime(unixTime, timezone);
+    }
+
+    public static DateTime getDateTime(NonFungibleToken.Attribute timeAttr) throws ParseException, IllegalArgumentException
+    {
+        String eventTimeText = timeAttr.text;
+        if (eventTimeText != null)
+        {
+            //there was a specific timezone set in the XML definition file, use this
+            return initZonedTime(eventTimeText);
+        }
+        else
+        {
+            //No timezone specified, assume time in GMT
+            return new GeneralDateTime(timeAttr);
+        }
+    }
+
+    public static DateTime getDateTime(String time) throws ParseException, IllegalArgumentException
+    {
+        return initZonedTime(time);
+    }
+
+    public static DateTime getCurrentTime()
+    {
+        return new GeneralDateTime(String.valueOf(System.currentTimeMillis()));
+    }
+
+    private static DateTime initZonedTime(String time) throws ParseException, IllegalArgumentException
+    {
+        Pattern p = Pattern.compile("(\\+\\d{4}|\\-\\d{4})");
+        Matcher m = p.matcher(time);
+        if (m.find())
+        {
+            return new ZonedDateTime(time, m);
+        }
+        else if (isNumeric(time))
+        {
+            return new GeneralDateTime(time);
+        }
+        else
+        {
+            //drop through, use current time
+            return new GeneralDateTime(String.valueOf(System.currentTimeMillis()));
+        }
+    }
+
+    private static boolean isNumeric(String testStr)
+    {
+        boolean result = false;
+        if (testStr != null && testStr.length() > 0)
+        {
+            result = true;
+            for (int i = 0; i < testStr.length(); i++)
+            {
+                char c = testStr.charAt(i);
+                if (!Character.isDigit(c))
+                {
+                    result = false;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/lib/src/main/java/io/stormbird/token/util/GeneralDateTime.java
+++ b/lib/src/main/java/io/stormbird/token/util/GeneralDateTime.java
@@ -1,0 +1,25 @@
+package io.stormbird.token.util;
+
+import io.stormbird.token.entity.NonFungibleToken;
+
+import java.util.TimeZone;
+
+/**
+ * Created by James on 11/02/2019.
+ * Stormbird in Singapore
+ */
+class GeneralDateTime extends DateTime
+{
+    GeneralDateTime(NonFungibleToken.Attribute timeAttr)
+    {
+        this.timezone = TimeZone.getTimeZone("GMT");
+        time = timeAttr.value.longValue()*1000;
+    }
+
+    GeneralDateTime(String time)
+    {
+        this.timezone = TimeZone.getTimeZone("GMT");
+        Long timeConv = Long.valueOf(time);
+        this.time = timeConv*1000;
+    }
+}

--- a/lib/src/main/java/io/stormbird/token/util/ZonedDateTime.java
+++ b/lib/src/main/java/io/stormbird/token/util/ZonedDateTime.java
@@ -1,22 +1,16 @@
 package io.stormbird.token.util;
 
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import io.stormbird.token.entity.NonFungibleToken;
-
 /*
  * by Weiwu, 2018. Modeled after Java8's ZonedDateTime, intended to be
  * replaced by Java8's ZonedDateTime as soon as Android 8.0 gets popular
  */
-public class ZonedDateTime {
-    private long time;
-    private TimeZone timezone;
+class ZonedDateTime extends DateTime
+{
     //private final SimpleDateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX");
 
 
@@ -35,111 +29,19 @@ public class ZonedDateTime {
      * is, the number of seconds since Epoch as the Epoch happens at UTC.
      * Apparently timezone offset is applied in format()
      */
-    public ZonedDateTime(long unixTime, TimeZone timezone) {
+    ZonedDateTime(long unixTime, TimeZone timezone) {
         this.time = unixTime * 1000L;
         this.timezone = timezone;
+        isZoned = true;
     }
 
-    public ZonedDateTime(NonFungibleToken.Attribute timeAttr) throws ParseException, IllegalArgumentException
-    {
-        String eventTimeText = timeAttr.text;
-        if (eventTimeText != null)
-        {
-            //there was a specific timezone set in the XML definition file, use this
-            initZonedTime(eventTimeText);
-        }
-        else
-        {
-            //No timezone specified, assume time in GMT
-            this.timezone = TimeZone.getTimeZone("GMT");
-            time = timeAttr.value.longValue()*1000;
-        }
-    }
-
-    private void initZonedTime(String time) throws ParseException, IllegalArgumentException
+    ZonedDateTime(String time, Matcher m) throws ParseException, IllegalArgumentException
     {
         SimpleDateFormat isoFormat = new SimpleDateFormat("yyyyMMddHHmmssZZZZ");
-        Pattern p = Pattern.compile("(\\+\\d{4}|\\-\\d{4})");
-        Matcher m = p.matcher(time);
-        if (m.find()) {
-            this.timezone = TimeZone.getTimeZone("GMT"+m.group(1));
-            isoFormat.setTimeZone(this.timezone);
-            Date date = isoFormat.parse(time);
-            this.time = date.getTime();
-        }
-        else if (isNumeric(time)){
-            //useful for debug, but leads to unexpected errors in unexpected places right before important demos
-            //throw new IllegalArgumentException("not Generalised Time");
-            //No timezone specified, assume time in GMT
-            this.timezone = TimeZone.getTimeZone("GMT");
-            Long timeConv = Long.valueOf(time);
-            this.time = timeConv*1000;
-        }
-        else
-        {
-            //drop through, use current time
-            this.timezone = TimeZone.getTimeZone("GMT");
-            this.time = System.currentTimeMillis();
-        }
-
-
-
-//        DateTimeFormatter generalizedTime = DateTimeFormatter.ofPattern ( "uuuuMMddHHmmss[,S][.S]X" );
-//        OffsetDateTime odt = OffsetDateTime.parse ( time , generalizedTime );
-    }
-
-    private boolean isNumeric(String testStr)
-    {
-        boolean result = false;
-        if (testStr != null && testStr.length() > 0)
-        {
-            result = true;
-            for (int i = 0; i < testStr.length(); i++)
-            {
-                char c = testStr.charAt(i);
-                if (!Character.isDigit(c))
-                {
-                    result = false;
-                    break;
-                }
-            }
-        }
-
-        return result;
-    }
-
-    /* Creating ZonedDateTime from GeneralizedTime */
-    public ZonedDateTime(String time) throws ParseException, IllegalArgumentException
-    {
-        initZonedTime(time);
-    }
-
-    /* EVERY FUNCTION BELOW ARE SET OUT IN JAVA8 */
-
-    public long toEpochSecond() {
-        return time/1000L;
-    }
-
-    public int getHour() {
-        /* you can't just do this:
-        return new Date(time + offset).getHours() - 1;
-        because Date applies the local (the JRE's) timezone
-         */
-        SimpleDateFormat format = new SimpleDateFormat("H");
-        return Integer.valueOf(format(format));
-    }
-
-    public int getMinute() {
-        SimpleDateFormat format = new SimpleDateFormat("m");
-        return Integer.valueOf(format(format));
-    }
-
-    /*public String toString() {
-        return format(ISO8601);
-    }*/
-
-    public String format(DateFormat format) {
-        format.setTimeZone(timezone);
-        return format.format(new Date(time));
+        this.timezone = TimeZone.getTimeZone("GMT"+m.group(1));
+        isoFormat.setTimeZone(this.timezone);
+        Date date = isoFormat.parse(time);
+        this.time = date.getTime();
+        isZoned = true;
     }
 }

--- a/lib/src/main/java/io/stormbird/token/util/ZonedDateTime.java
+++ b/lib/src/main/java/io/stormbird/token/util/ZonedDateTime.java
@@ -64,15 +64,48 @@ public class ZonedDateTime {
         if (m.find()) {
             this.timezone = TimeZone.getTimeZone("GMT"+m.group(1));
             isoFormat.setTimeZone(this.timezone);
-        }else{
-            throw new IllegalArgumentException("not Generalised Time");
+            Date date = isoFormat.parse(time);
+            this.time = date.getTime();
+        }
+        else if (isNumeric(time)){
+            //useful for debug, but leads to unexpected errors in unexpected places right before important demos
+            //throw new IllegalArgumentException("not Generalised Time");
+            //No timezone specified, assume time in GMT
+            this.timezone = TimeZone.getTimeZone("GMT");
+            Long timeConv = Long.valueOf(time);
+            this.time = timeConv*1000;
+        }
+        else
+        {
+            //drop through, use current time
+            this.timezone = TimeZone.getTimeZone("GMT");
+            this.time = System.currentTimeMillis();
         }
 
-        Date date = isoFormat.parse(time);
-        this.time = date.getTime();
+
 
 //        DateTimeFormatter generalizedTime = DateTimeFormatter.ofPattern ( "uuuuMMddHHmmss[,S][.S]X" );
 //        OffsetDateTime odt = OffsetDateTime.parse ( time , generalizedTime );
+    }
+
+    private boolean isNumeric(String testStr)
+    {
+        boolean result = false;
+        if (testStr != null && testStr.length() > 0)
+        {
+            result = true;
+            for (int i = 0; i < testStr.length(); i++)
+            {
+                char c = testStr.charAt(i);
+                if (!Character.isDigit(c))
+                {
+                    result = false;
+                    break;
+                }
+            }
+        }
+
+        return result;
     }
 
     /* Creating ZonedDateTime from GeneralizedTime */

--- a/lib/src/test/java/io/stormbird/token/util/ZonedDateTimeTest.java
+++ b/lib/src/test/java/io/stormbird/token/util/ZonedDateTimeTest.java
@@ -44,19 +44,19 @@ public class ZonedDateTimeTest {
 
     @Test
     public void ZonedDateTimeCanBeCreatedFromGeneralizedTime() throws ParseException {
-        ZonedDateTime timeInMoscow = new ZonedDateTime(GeneralizedTime);
+        DateTime timeInMoscow = DateTimeFactory.getDateTime(GeneralizedTime);
         //assertEquals(ISO8601, timeInMoscow.toString()); //TODO: ZonedDatTime.toString isn't implemented - needs to explicitly overloaded for this test to work
         assertEquals(unixTime, timeInMoscow.toEpochSecond());
         assertEquals(3, timeInMoscow.getHour());
         assertEquals(0, timeInMoscow.getMinute());
 
-        ZonedDateTime timeInMoscow2 = new ZonedDateTime("19700101030101+0300");
+        DateTime timeInMoscow2 = DateTimeFactory.getDateTime("19700101030101+0300");
         //assertEquals("1970-01-01T03:01+03:00", timeInMoscow2.toString()); //TODO: ZonedDatTime.toString isn't implemented - needs to explicitly overloaded for this test to work
         assertEquals(61, timeInMoscow2.toEpochSecond());
         assertEquals(3, timeInMoscow2.getHour());
         assertEquals(1, timeInMoscow2.getMinute());
 
-        ZonedDateTime timeInAzores = new ZonedDateTime("19700101030000-0100");
+        DateTime timeInAzores = DateTimeFactory.getDateTime("19700101030000-0100");
         //assertEquals("1970-01-01T03:00-01:00", timeInAzores.toString()); //TODO: ZonedDatTime.toString isn't implemented - needs to explicitly overloaded for this test to work
         assertEquals(14400, timeInAzores.toEpochSecond()); //this time is relatively 4 hrs from Moscow
         assertEquals(3, timeInAzores.getHour());


### PR DESCRIPTION
This PR fixes an issue with Timezone usage in TBML files. If time is given without timezone information, the library should not just throw an exception. This is useful for development but not useful elsewhere.

The code was changed to make a demo possible which used the FIFA world cup tickets. There is another possible fix where any time used in any token is given in the XML file.

If there's no explicit time given in the XML file, any time read should be considered to be UTC, and displayed in the user's current time zone, which is what this patch amends.

