### PR TITLE
Fix URLs for xDAI network

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/EthereumNetworkRepository.java
@@ -71,11 +71,11 @@ public class EthereumNetworkRepository implements EthereumNetworkRepositoryType 
 			new NetworkInfo(XDAI_NETWORK_NAME,
 					xDAI_SYMBOL,
 					XDAI_RPC_URL,
-					"https://blockscout.com/poa/dai/api",
+					"https://blockscout.com/poa/dai/tx/",
 					100,
 					false,
 					"https://dai.poa.network",
-					"https://blockscout.com/poa/dai/tx"),
+					"https://blockscout.com/poa/dai/"),
 	};
 
 	private final PreferenceRepositoryType preferences;


### PR DESCRIPTION
Correct the definitions for API URLs so the history and transaction/contract lookup works correctly.

Fixes #515 and #516 