### PR TITLE
Add disambiguating error message.

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -304,9 +304,15 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
             amount = amountEditText.getText().toString();
         }
 
-        if (!isValidAmount(amount) || !isBalanceEnough(amount)) {
+        if (!isValidAmount(amount)) {
             amountError.setVisibility(View.VISIBLE);
             amountError.setText(R.string.error_invalid_amount);
+            isValid = false;
+        }
+
+        if (!isBalanceEnough(amount)) {
+            amountError.setVisibility(View.VISIBLE);
+            amountError.setText(R.string.error_insufficient_funds);
             isValid = false;
         }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -21,4 +21,5 @@
     <string name="no_recent_transactions_subtext_tokens">tokens</string>
     <string name="invalid_transaction">Invalid Transaction</string>
     <string name="contains_no_data">DApp transaction contains no data</string>
+    <string name="error_insufficient_funds">Insufficient Funds</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -347,4 +347,5 @@
     <string name="no_recent_transactions_subtext_tokens">tokens</string>
     <string name="invalid_transaction">Invalid Transaction</string>
     <string name="contains_no_data">DApp transaction contains no data</string>
+    <string name="error_insufficient_funds">资金不够</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,4 +523,5 @@
     <string name="no_recent_transactions_subtext_tokens">tokens</string>
     <string name="invalid_transaction">Invalid Transaction</string>
     <string name="contains_no_data">DApp transaction contains no data</string>
+    <string name="error_insufficient_funds">Insufficient Funds</string>
 </resources>


### PR DESCRIPTION
add extra 'insufficient funds' message because a generic error message is too ambiguous.

Changed because of confusion during testing.