### PR TITLE
Fix DApp sign transaction flow

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/C.java
+++ b/app/src/main/java/io/stormbird/wallet/C.java
@@ -55,6 +55,8 @@ public abstract class C {
     public static final String EXTRA_NETWORK_MAINNET = "NETWORK_MAINNET";
     public static final String EXTRA_ENS_DETAILS = "ENS_DETAILS";
     public static final String EXTRA_HAS_DEFINITION = "HAS_TOKEN_DEF";
+    public static final String EXTRA_SUCCESS = "TX_SUCCESS";
+    public static final String EXTRA_HEXDATA = "TX_HEX";
 
     public static final String PRUNE_ACTIVITY =
             "io.stormbird.wallet.PRUNE_ACTIVITY";
@@ -71,6 +73,9 @@ public abstract class C {
             "io.stormbird.wallet.PAGE_LOADED";
     public static final String RESET_TOOLBAR =
             "io.stormbird.wallet.RESET_TOOLBAR";
+    public static final String SIGN_DAPP_TRANSACTION =
+            "io.stormbird.wallet.SIGN_TRANSACTION";
+
     public static final String COINBASE_WIDGET_CODE = "88d6141a-ff60-536c-841c-8f830adaacfd";
     public static final String SHAPESHIFT_KEY = "c4097b033e02163da6114fbbc1bf15155e759ddfd8352c88c55e7fef162e901a800e7eaecf836062a0c075b2b881054e0b9aa2324be7bc3694578493faf59af4";
     public static final String CHANGELLY_REF_ID = "968d4f0f0bf9";

--- a/app/src/main/java/io/stormbird/wallet/entity/SignDappTransactionReceiver.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/SignDappTransactionReceiver.java
@@ -1,0 +1,46 @@
+package io.stormbird.wallet.entity;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import io.stormbird.wallet.C;
+import io.stormbird.wallet.web3.entity.Web3Transaction;
+
+import static io.stormbird.wallet.C.SIGN_DAPP_TRANSACTION;
+
+/**
+ * Created by James on 26/01/2019.
+ * Stormbird in Singapore
+ */
+public class SignDappTransactionReceiver extends BroadcastReceiver
+{
+    private final SignTransactionInterface signInterface;
+    public SignDappTransactionReceiver(Activity ctx, SignTransactionInterface signInterface)
+    {
+        ctx.registerReceiver(this, new IntentFilter(SIGN_DAPP_TRANSACTION));
+        this.signInterface = signInterface;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        if (intent != null && intent.getAction() != null)
+        {
+            //Bundle bundle = intent.getExtras();
+            switch (intent.getAction())
+            {
+                case SIGN_DAPP_TRANSACTION:
+                    Web3Transaction tx = intent.getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
+                    boolean success = intent.getBooleanExtra(C.EXTRA_SUCCESS, false);
+                    String txHex = intent.getStringExtra(C.EXTRA_HEXDATA);
+                    signInterface.signTransaction(tx, txHex, success);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/entity/SignTransactionInterface.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/SignTransactionInterface.java
@@ -1,0 +1,12 @@
+package io.stormbird.wallet.entity;
+
+import io.stormbird.wallet.web3.entity.Web3Transaction;
+
+/**
+ * Created by James on 26/01/2019.
+ * Stormbird in Singapore
+ */
+public interface SignTransactionInterface
+{
+    void signTransaction(Web3Transaction transaction, String txHex, boolean success);
+}

--- a/app/src/main/java/io/stormbird/wallet/entity/TransactionData.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TransactionData.java
@@ -1,0 +1,11 @@
+package io.stormbird.wallet.entity;
+
+/**
+ * Created by James on 26/01/2019.
+ * Stormbird in Singapore
+ */
+public class TransactionData
+{
+    public String txHash;
+    public String signature;
+}

--- a/app/src/main/java/io/stormbird/wallet/interact/CreateTransactionInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/CreateTransactionInteract.java
@@ -1,11 +1,7 @@
 package io.stormbird.wallet.interact;
 
 
-import io.stormbird.wallet.entity.MessagePair;
-import io.stormbird.wallet.entity.SignaturePair;
-import io.stormbird.wallet.entity.Ticket;
-import io.stormbird.wallet.entity.TradeInstance;
-import io.stormbird.wallet.entity.Wallet;
+import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.repository.PasswordStore;
 import io.stormbird.wallet.repository.TransactionRepositoryType;
 import io.stormbird.wallet.service.MarketQueueService;
@@ -67,6 +63,24 @@ public class CreateTransactionInteract
         return passwordStore.getPassword(from)
                 .flatMap(password ->
                                  transactionRepository.createTransaction(from, gasPrice, gasLimit, data, password)
+                                         .subscribeOn(Schedulers.computation())
+                                         .observeOn(AndroidSchedulers.mainThread()));
+    }
+
+    public Single<TransactionData> createWithSig(Wallet from, String to, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data)
+    {
+        return passwordStore.getPassword(from)
+                .flatMap(password ->
+                                 transactionRepository.createTransactionWithSig(from, to, subunitAmount, gasPrice, gasLimit, data, password)
+                                         .subscribeOn(Schedulers.computation())
+                                         .observeOn(AndroidSchedulers.mainThread()));
+    }
+
+    public Single<TransactionData> createWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data)
+    {
+        return passwordStore.getPassword(from)
+                .flatMap(password ->
+                                 transactionRepository.createTransactionWithSig(from, gasPrice, gasLimit, data, password)
                                          .subscribeOn(Schedulers.computation())
                                          .observeOn(AndroidSchedulers.mainThread()));
     }

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepository.java
@@ -91,6 +91,27 @@ public class TransactionRepository implements TransactionRepositoryType {
 	}
 
 	@Override
+	public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password) {
+		final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl));
+
+		TransactionData txData = new TransactionData();
+
+		return networkRepository.getLastTransactionNonce(web3j, from.address)
+				.flatMap(nonce -> accountKeystoreService.signTransaction(from, password, toAddress, subunitAmount, gasPrice, gasLimit, nonce.longValue(), data, networkRepository.getDefaultNetwork().chainId))
+				.flatMap(signedMessage -> Single.fromCallable( () -> {
+					txData.signature = Numeric.toHexString(signedMessage);
+					EthSendTransaction raw = web3j
+							.ethSendRawTransaction(Numeric.toHexString(signedMessage))
+							.send();
+					if (raw.hasError()) {
+						throw new Exception(raw.getError().getMessage());
+					}
+					txData.txHash = raw.getTransactionHash();
+					return txData;
+				})).subscribeOn(Schedulers.io());
+	}
+
+	@Override
 	public Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password) {
 		final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl));
 
@@ -105,6 +126,28 @@ public class TransactionRepository implements TransactionRepositoryType {
 						throw new Exception(raw.getError().getMessage());
 					}
 					return raw.getTransactionHash();
+				})).subscribeOn(Schedulers.io());
+	}
+
+	@Override
+	public Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password) {
+		final Web3j web3j = Web3jFactory.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl));
+
+		TransactionData txData = new TransactionData();
+
+		return networkRepository.getLastTransactionNonce(web3j, from.address)
+				.flatMap(nonce -> getRawTransaction(nonce, gasPrice, gasLimit, BigInteger.ZERO, data))
+				.flatMap(rawTx -> signEncodeRawTransaction(rawTx, password, from, networkRepository.getDefaultNetwork().chainId))
+				.flatMap(signedMessage -> Single.fromCallable( () -> {
+					txData.signature = Numeric.toHexString(signedMessage);
+					EthSendTransaction raw = web3j
+							.ethSendRawTransaction(Numeric.toHexString(signedMessage))
+							.send();
+					if (raw.hasError()) {
+						throw new Exception(raw.getError().getMessage());
+					}
+					txData.txHash = raw.getTransactionHash();
+					return txData;
 				})).subscribeOn(Schedulers.io());
 	}
 

--- a/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TransactionRepositoryType.java
@@ -12,6 +12,8 @@ public interface TransactionRepositoryType {
 	Observable<Transaction[]> fetchNetworkTransaction(Wallet wallet, long lastBlock, String userAddress);
 	Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password);
 	Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password);
+	Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password);
+	Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password);
 	Single<byte[]> getSignature(Wallet wallet, byte[] message, String password);
 	Single<byte[]> getSignatureFast(Wallet wallet, byte[] message, String password);
 	void unlockAccount(Wallet signer, String signerPassword) throws Exception;

--- a/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
@@ -425,7 +425,7 @@ public class ConfirmationActivity extends BaseActivity {
             {
                 Intent intent = new Intent(C.SIGN_DAPP_TRANSACTION);
                 intent.putExtra(C.EXTRA_WEB3TRANSACTION, transaction);
-                intent.putExtra(C.EXTRA_HEXDATA, "0x0000");
+                intent.putExtra(C.EXTRA_HEXDATA, "0x0000"); //Placeholder signature - transaction failed
                 intent.putExtra(C.EXTRA_SUCCESS, false);
                 sendBroadcast(intent);
             }

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -60,7 +60,7 @@ import static io.stormbird.wallet.entity.CryptoFunctions.sigFromByteArray;
 
 public class DappBrowserFragment extends Fragment implements
         OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
-        URLLoadInterface, ItemClickListener
+        URLLoadInterface, ItemClickListener, SignTransactionInterface
 {
     private static final String TAG = DappBrowserFragment.class.getSimpleName();
 
@@ -81,6 +81,8 @@ public class DappBrowserFragment extends Fragment implements
     private AutoCompleteUrlAdapter adapter;
     private URLLoadReceiver URLReceiver;
 
+    private SignDappTransactionReceiver transactionReceiver;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -97,6 +99,9 @@ public class DappBrowserFragment extends Fragment implements
             String url = getArguments().getString("url");
             loadUrl(url);
         }
+
+        transactionReceiver = new SignDappTransactionReceiver(getActivity(), this);
+
         return view;
     }
 
@@ -304,6 +309,7 @@ public class DappBrowserFragment extends Fragment implements
         {
             //display transaction error
             onInvalidTransaction();
+            web3.onSignCancel(transaction);
         }
         else
         {
@@ -446,6 +452,19 @@ public class DappBrowserFragment extends Fragment implements
         catch (SignatureException e)
         {
             e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void signTransaction(Web3Transaction transaction, String txHex, boolean success)
+    {
+        if (success)
+        {
+            web3.onSignTransactionSuccessful(transaction, txHex);
+        }
+        else
+        {
+            web3.onSignCancel(transaction);
         }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/DappBrowserViewModel.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.content.Context;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.reactivex.Observable;
@@ -24,7 +25,7 @@ import java.util.ArrayList;
 import static io.stormbird.wallet.C.DAPP_DEFAULT_URL;
 import static io.stormbird.wallet.ui.ImportTokenActivity.getUsdString;
 
-public class DappBrowserViewModel extends BaseViewModel {
+public class DappBrowserViewModel extends BaseViewModel  {
     private final MutableLiveData<NetworkInfo> defaultNetwork = new MutableLiveData<>();
     private final MutableLiveData<Wallet> defaultWallet = new MutableLiveData<>();
     private final MutableLiveData<GasSettings> gasSettings = new MutableLiveData<>();

--- a/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
+++ b/app/src/test/java/io/stormbird/wallet/MarketOrderTest.java
@@ -120,6 +120,18 @@ public class MarketOrderTest
             }
 
             @Override
+            public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password)
+            {
+                return null;
+            }
+
+            @Override
             public Single<byte[]> getSignature(Wallet wallet, byte[] message, String password) {
                 return null;
             }

--- a/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
+++ b/app/src/test/java/io/stormbird/wallet/QRSelectionTest.java
@@ -78,6 +78,18 @@ public class QRSelectionTest
             }
 
             @Override
+            public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, String password)
+            {
+                return null;
+            }
+
+            @Override
+            public Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, String password)
+            {
+                return null;
+            }
+
+            @Override
             public Single<byte[]> getSignature(Wallet wallet, byte[] message, String password)
             {
                 return null;


### PR DESCRIPTION
Fix from testing with sample putestm.dingheng.xyz.

After confirming and pushing the transaction, execution should resume on the website, and the JS intercept callback should go back to the website.