### PR TITLE
Fix startup init order

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/di/RepositoriesModule.java
+++ b/app/src/main/java/io/stormbird/wallet/di/RepositoriesModule.java
@@ -128,7 +128,8 @@ public class RepositoriesModule {
             TokenLocalSource tokenLocalSource,
             TransactionLocalSource inDiskCache,
             TickerService tickerService,
-			AssetDefinitionService assetDefinitionService) {
+			AssetDefinitionService assetDefinitionService,
+			TransactionRepositoryType transactionRepository) {
 	    return new TokenRepository(
 	            ethereumNetworkRepository,
 	            walletRepository,
@@ -136,7 +137,8 @@ public class RepositoriesModule {
                 tokenLocalSource,
                 inDiskCache,
                 tickerService,
-				assetDefinitionService);
+				assetDefinitionService,
+				transactionRepository);
     }
 
 	@Singleton

--- a/app/src/main/java/io/stormbird/wallet/entity/FragmentMessenger.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/FragmentMessenger.java
@@ -1,0 +1,10 @@
+package io.stormbird.wallet.entity;
+
+/**
+ * Created by James on 1/02/2019.
+ * Stormbird in Singapore
+ */
+public interface FragmentMessenger
+{
+    void TokensReady();
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
@@ -55,7 +55,7 @@ import dagger.android.support.AndroidSupportInjection;
 
 import static io.stormbird.wallet.C.ErrorCode.EMPTY_COLLECTION;
 
-public class TransactionsFragment extends Fragment implements View.OnClickListener, TokenInterface, Runnable
+public class TransactionsFragment extends Fragment implements View.OnClickListener, TokenInterface
 {
     @Inject
     TransactionsViewModelFactory transactionsViewModelFactory;
@@ -177,7 +177,6 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     private void onDefaultWallet(Wallet wallet)
     {
         adapter.setDefaultWallet(wallet);
-        handler.postDelayed(this, 1000); //delay to allow token service list to load
     }
 
     private void onDefaultNetwork(NetworkInfo networkInfo)
@@ -226,6 +225,11 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         viewModel.openDeposit(view.getContext(), uri);
     }
 
+    public void tokensReady()
+    {
+        viewModel.forceUpdateTransactionView();
+    }
+
     @Override
     public void resetTokens()
     {
@@ -255,11 +259,5 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         adapter.clear();
         list.setAdapter(adapter);
         viewModel.abortAndRestart(false);
-    }
-
-    @Override
-    public void run()
-    {
-        viewModel.forceUpdateTransactionView();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
@@ -1,6 +1,7 @@
 package io.stormbird.wallet.ui;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -26,13 +27,9 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import dagger.android.support.AndroidSupportInjection;
+import io.stormbird.wallet.C;
 import io.stormbird.wallet.R;
-import io.stormbird.wallet.entity.ErrorEnvelope;
-import io.stormbird.wallet.entity.NetworkInfo;
-import io.stormbird.wallet.entity.Token;
-import io.stormbird.wallet.entity.TokenInterface;
-import io.stormbird.wallet.entity.TokensReceiver;
-import io.stormbird.wallet.entity.Wallet;
+import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.widget.adapter.TokensAdapter;
 import io.stormbird.wallet.util.TabUtils;
@@ -61,10 +58,22 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
     private SystemView systemView;
     private ProgressView progressView;
     private TokensAdapter adapter;
+    private FragmentMessenger homeMessager;
     private int networkId = 0;
 
     private Wallet wallet;
     private boolean isVisible;
+
+    @SuppressLint("ValidFragment")
+    public WalletFragment(FragmentMessenger messenger)
+    {
+        homeMessager = messenger;
+    }
+
+    public WalletFragment()
+    {
+
+    }
 
     @Nullable
     @Override
@@ -100,6 +109,7 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
         viewModel.tokenUpdate().observe(this, this::onToken);
         viewModel.endUpdate().observe(this, this::checkTokens);
         viewModel.checkAddr().observe(this, this::updateTitle);
+        viewModel.tokensReady().observe(this, this::tokensReady);
         //viewModel.refreshTokens().observe(this, this::refreshTokens);
 
         adapter = new TokensAdapter(getContext(), this::onTokenClick, viewModel.getAssetDefinitionService());
@@ -307,6 +317,11 @@ public class WalletFragment extends Fragment implements View.OnClickListener, To
     private void refreshTokens(Boolean aBoolean)
     {
         viewModel.fetchTokens();
+    }
+
+    private void tokensReady(Boolean dummy)
+    {
+        homeMessager.TokensReady();
     }
 
     @Override

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransactionsViewModel.java
@@ -288,7 +288,7 @@ public class TransactionsViewModel extends BaseViewModel
                     .filter(token -> !token.isTerminated())
                     .filter(token -> !token.independentUpdate())//don't scan ERC721 transactions
                     .concatMap(this::checkSpec)
-                    .filter(token -> token.checkIntrinsicType()) //Don't scan tokens that appear to be setup incorrectly
+                    .filter(Token::checkIntrinsicType) //Don't scan tokens that appear to be setup incorrectly
                     .concatMap(token -> fetchTransactionsInteract.fetchNetworkTransactions(new Wallet(token.getAddress()), tokensService.getLatestBlock(token.getAddress()), wallet.getValue().address)) //single that fetches all the tx's from etherscan for each token from fetchSequential
                     .subscribeOn(Schedulers.io())
                     .observeOn(Schedulers.io())
@@ -303,6 +303,8 @@ public class TransactionsViewModel extends BaseViewModel
     private Observable<Token> checkSpec(Token token)
     {
         return Observable.fromCallable(() -> {
+            if (token.checkIntrinsicType()) return token;
+
             ContractType fromService = tokensService.getInterfaceSpec(token.getAddress());
             token.setInterfaceSpec(fromService);
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -41,6 +41,7 @@ public class WalletViewModel extends BaseViewModel implements Runnable
     private final MutableLiveData<Token> tokenUpdate = new MutableLiveData<>();
     private final MutableLiveData<Boolean> checkTokens = new MutableLiveData<>();
     private final MutableLiveData<List<String>> removeTokens = new MutableLiveData<>();
+    private final MutableLiveData<Boolean> tokensReady = new MutableLiveData<>();
 
     private final MutableLiveData<String> checkAddr = new MutableLiveData<>();
 
@@ -121,6 +122,7 @@ public class WalletViewModel extends BaseViewModel implements Runnable
     public LiveData<Boolean> endUpdate() { return checkTokens; }
     public LiveData<String> checkAddr() { return checkAddr; }
     public LiveData<List<String>> removeTokens() { return removeTokens; }
+    public LiveData<Boolean> tokensReady() { return tokensReady; }
 
     @Override
     protected void onCleared() {
@@ -250,6 +252,7 @@ public class WalletViewModel extends BaseViewModel implements Runnable
     {
         progress.postValue(false);
         tokens.postValue(tokenCache);
+        tokensReady.postValue(true);
 
         if (updateTokens != null && !updateTokens.isDisposed())
         {


### PR DESCRIPTION
A strange bug was found where token types would change very rarely after re-starting the app. This was diagnosed as being a race condition between the tokens getting loaded into the service by the wallet fragment and the transaction refresh fragment using those loaded tokens.

This is a small refactor to simplify the code and fix the issue.