### PR TITLE
Find network for import

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/ContractResult.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/ContractResult.java
@@ -1,0 +1,17 @@
+package io.stormbird.wallet.entity;
+
+/**
+ * Created by James on 2/02/2019.
+ * Stormbird in Singapore
+ */
+public class ContractResult
+{
+    public String name;
+    public int chainId;
+
+    public ContractResult(String n, int chain)
+    {
+        name = n;
+        chainId = chain;
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -628,7 +628,8 @@ public class Token implements Parcelable
         int networkId = assetService.getNetworkId(getAddress());
         if (networkId >= 1)
         {
-            return assetService.getAssetDefinition(getAddress()).getTokenName();
+            if (tokenInfo.name != null) return tokenInfo.name;
+            else return assetService.getAssetDefinition(getAddress()).getTokenName();
         }
         else
         {

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
@@ -1,13 +1,6 @@
 package io.stormbird.wallet.interact;
 
-import io.stormbird.wallet.entity.MagicLinkParcel;
-import io.stormbird.wallet.entity.NetworkInfo;
-import io.stormbird.wallet.entity.OrderContractAddressPair;
-import io.stormbird.wallet.entity.Ticker;
-import io.stormbird.wallet.entity.Ticket;
-import io.stormbird.wallet.entity.Token;
-import io.stormbird.wallet.entity.TokenInfo;
-import io.stormbird.wallet.entity.Wallet;
+import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.repository.TokenRepositoryType;
 
 import java.math.BigDecimal;
@@ -78,9 +71,9 @@ public class FetchTokensInteract {
         return tokenRepository.fetchLatestBlockNumber();
     }
 
-    public Single<String> getContractName(String address, int chainId)
+    public Observable<ContractResult> getContractName(String address, int chainId)
     {
-        return tokenRepository.getTokenName(address, chainId);
+        return tokenRepository.getTokenName(address, chainId).toObservable();
     }
 
     public Observable<Token> updateDefaultBalance(Token token, NetworkInfo network, Wallet wallet)

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTokensInteract.java
@@ -78,6 +78,11 @@ public class FetchTokensInteract {
         return tokenRepository.fetchLatestBlockNumber();
     }
 
+    public Single<String> getContractName(String address, int chainId)
+    {
+        return tokenRepository.getTokenName(address, chainId);
+    }
+
     public Observable<Token> updateDefaultBalance(Token token, NetworkInfo network, Wallet wallet)
     {
         return tokenRepository.fetchActiveTokenBalance(token, network, wallet)

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -1137,23 +1137,25 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
-    public Single<String> getTokenName(String address, int chainId)
+    public Single<ContractResult> getTokenName(String address, int chainId)
     {
         return Single.fromCallable(() -> {
+            ContractResult contractResult = new ContractResult(INVALID_CONTRACT, chainId);
             org.web3j.abi.datatypes.Function function = nameOf();
             Wallet temp = new Wallet(null);
             String responseValue = callCustomNetSmartContractFunction(function, address, temp, chainId);
-            if (responseValue == null) return INVALID_CONTRACT;
+            if (responseValue == null) return contractResult;
 
             List<Type> response = FunctionReturnDecoder.decode(
                     responseValue, function.getOutputParameters());
             if (response.size() == 1)
             {
-                return (String) response.get(0).getValue();
+                contractResult.name = (String) response.get(0).getValue();
+                return contractResult;
             }
             else
             {
-                return INVALID_CONTRACT;
+                return contractResult;
             }
         });
     }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -25,6 +25,7 @@ public interface TokenRepositoryType {
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
     Observable<Token> fetchActiveTokenBalance(Token token, NetworkInfo network, Wallet wallet);
     Observable<Token[]> fetchAll(String walletAddress);
+    Single<String>    getTokenName(String address, int chainId);
     Completable setEnable(Wallet wallet, Token token, boolean isEnabled);
     Observable<TokenInfo> update(String address);
     Single<TokenInfo[]> update(String[] address);

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -25,7 +25,7 @@ public interface TokenRepositoryType {
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
     Observable<Token> fetchActiveTokenBalance(Token token, NetworkInfo network, Wallet wallet);
     Observable<Token[]> fetchAll(String walletAddress);
-    Single<String>    getTokenName(String address, int chainId);
+    Single<ContractResult> getTokenName(String address, int chainId);
     Completable setEnable(Wallet wallet, Token token, boolean isEnabled);
     Observable<TokenInfo> update(String address);
     Single<TokenInfo[]> update(String[] address);

--- a/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
@@ -141,7 +141,7 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         {
             //TODO: attempt to determine which network the contract is on.
             //TODO: Use Etherscan to ping the networks sequentially
-            viewModel.loadToken();
+            viewModel.checkTokenNetwork(contractAddress);
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
@@ -139,8 +139,6 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         }
         else
         {
-            //TODO: attempt to determine which network the contract is on.
-            //TODO: Use Etherscan to ping the networks sequentially
             viewModel.checkTokenNetwork(contractAddress);
         }
     }


### PR DESCRIPTION
On token import, if the wallet isn't by default set to the right network, or if there's no Token Definition for the token being imported, the wallet will scan the networks to try to find the contract.

Check order is:

1. Is there an XML definition for the contract? If yes, use this network.
2. Check for 'name' for the target contract on the current network. 
3. Try 'name' for the target contract on all known networks. If found switch to that network.

Now user doesn't need to pre-select the network, improving UX flow for any magiclink operation.