### PR TITLE
Add facility for trusted apps to pass intents.

### DIFF
--- a/app/src/main/res/values/trusted_apps.xml
+++ b/app/src/main/res/values/trusted_apps.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="TrustedApps">
+        <item>org.telegram.messenger,tg:join?invite=</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Add trusted app intents for dapp browser so known applications can be used with dapp browser eg Telegram.

Resolves Issue #530 