### PR TITLE
Add Dapp QR reader

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/FragmentMessenger.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/FragmentMessenger.java
@@ -7,4 +7,5 @@ package io.stormbird.wallet.entity;
 public interface FragmentMessenger
 {
     void TokensReady();
+    void AddToken(String address);
 }

--- a/app/src/main/java/io/stormbird/wallet/router/AddTokenRouter.java
+++ b/app/src/main/java/io/stormbird/wallet/router/AddTokenRouter.java
@@ -3,12 +3,14 @@ package io.stormbird.wallet.router;
 import android.content.Context;
 import android.content.Intent;
 
+import io.stormbird.wallet.C;
 import io.stormbird.wallet.ui.AddTokenActivity;
 
 public class AddTokenRouter {
 
-    public void open(Context context) {
+    public void open(Context context, String address) {
         Intent intent = new Intent(context, AddTokenActivity.class);
+        intent.putExtra(C.EXTRA_CONTRACT_ADDRESS, address);
         context.startActivity(intent);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
+import io.stormbird.wallet.C;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.Address;
 import io.stormbird.wallet.entity.ErrorEnvelope;
@@ -53,6 +54,7 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
     public InputView symbolInputView;
     public InputView decimalsInputView;
     public InputView nameInputview;
+    private String contractAddress;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -67,6 +69,8 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
         symbolInputView = findViewById(R.id.input_symbol);
         decimalsInputView = findViewById(R.id.input_decimal);
         nameInputview = findViewById(R.id.input_name);
+
+        contractAddress = getIntent().getStringExtra(C.EXTRA_CONTRACT_ADDRESS);
 
         progressLayout = findViewById(R.id.layout_progress);
 
@@ -114,6 +118,17 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
         });
 
         setTitle(R.string.empty);
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        if (contractAddress != null)
+        {
+            inputAddressView.setAddress(contractAddress.toLowerCase());
+            contractAddress = null;
+        }
     }
 
     private void showProgress(Boolean shouldShowProgress) {

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -31,6 +31,8 @@ import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.ui.widget.adapter.AutoCompleteUrlAdapter;
 import io.stormbird.wallet.ui.widget.entity.ItemClickListener;
+import io.stormbird.wallet.ui.zxing.FullScannerFragment;
+import io.stormbird.wallet.ui.zxing.QRScanningActivity;
 import io.stormbird.wallet.util.Utils;
 import io.stormbird.wallet.viewmodel.DappBrowserViewModel;
 import io.stormbird.wallet.viewmodel.DappBrowserViewModelFactory;
@@ -46,7 +48,6 @@ import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign;
 
 import javax.inject.Inject;
-
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -57,6 +58,7 @@ import java.util.List;
 import static io.stormbird.wallet.C.DAPP_DEFAULT_URL;
 import static io.stormbird.wallet.C.RESET_TOOLBAR;
 import static io.stormbird.wallet.entity.CryptoFunctions.sigFromByteArray;
+import static io.stormbird.wallet.ui.HomeActivity.DAPP_BARCODE_READER_REQUEST_CODE;
 
 public class DappBrowserFragment extends Fragment implements
         OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
@@ -462,6 +464,73 @@ public class DappBrowserFragment extends Fragment implements
         else
         {
             web3.onSignCancel(transaction);
+        }
+    }
+
+    public void scanQR()
+    {
+        //scanning intent
+        Intent intent = new Intent(getContext(), QRScanningActivity.class);
+        startActivityForResult(intent, DAPP_BARCODE_READER_REQUEST_CODE);
+    }
+
+    public void handleQRCode(int resultCode, Intent data, FragmentMessenger messenger)
+    {
+        //result
+        String qrCode = null;
+        if (resultCode == FullScannerFragment.SUCCESS && data != null)
+        {
+            qrCode = data.getStringExtra(FullScannerFragment.BarcodeObject);
+        }
+
+        if (qrCode != null)
+        {
+            //detect if this is an address
+            if (isAddressValid(qrCode))
+            {
+                DisplayAddressFound(qrCode, messenger);
+            }
+            else
+            {
+                //attempt to go to site
+                loadUrl(qrCode);
+            }
+        }
+        else
+        {
+            Toast.makeText(getContext(), R.string.toast_invalid_code, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void DisplayAddressFound(String address, FragmentMessenger messenger)
+    {
+        resultDialog = new AWalletAlertDialog(getActivity());
+        resultDialog.setIcon(AWalletAlertDialog.ERROR);
+        resultDialog.setTitle(getString(R.string.address_found));
+        resultDialog.setMessage(getString(R.string.is_address));
+        resultDialog.setButtonText(R.string.dialog_load_as_contract);
+        resultDialog.setButtonListener(v -> {
+            messenger.AddToken(address);
+            resultDialog.dismiss();
+        });
+        resultDialog.setSecondaryButtonText(R.string.action_cancel);
+        resultDialog.setSecondaryButtonListener(v -> {
+            resultDialog.dismiss();
+        });
+        resultDialog.setCancelable(true);
+        resultDialog.show();
+    }
+
+    private boolean isAddressValid(String address)
+    {
+        try
+        {
+            new org.web3j.abi.datatypes.Address(address);
+            return true;
+        }
+        catch (Exception e)
+        {
+            return false;
         }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
@@ -43,6 +43,7 @@ import io.stormbird.wallet.BuildConfig;
 import io.stormbird.wallet.C;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.*;
+import io.stormbird.wallet.ui.zxing.QRScanningActivity;
 import io.stormbird.wallet.util.RootUtil;
 import io.stormbird.wallet.viewmodel.BaseNavigationActivity;
 import io.stormbird.wallet.viewmodel.HomeViewModel;
@@ -58,6 +59,7 @@ import static io.stormbird.wallet.widget.AWalletBottomNavigationView.MARKETPLACE
 import static io.stormbird.wallet.widget.AWalletBottomNavigationView.SETTINGS;
 import static io.stormbird.wallet.widget.AWalletBottomNavigationView.TRANSACTIONS;
 import static io.stormbird.wallet.widget.AWalletBottomNavigationView.WALLET;
+import static io.stormbird.wallet.widget.InputAddressView.BARCODE_READER_REQUEST_CODE;
 
 public class HomeActivity extends BaseNavigationActivity implements View.OnClickListener, DownloadInterface, FragmentMessenger
 {
@@ -79,6 +81,8 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
     public static final int RC_DOWNLOAD_EXTERNAL_WRITE_PERM = 222;
     public static final int RC_ASSET_EXTERNAL_WRITE_PERM = 223;
+
+    public static final int DAPP_BARCODE_READER_REQUEST_CODE = 1;
 
     public HomeActivity()
     {
@@ -253,7 +257,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_add: {
-                viewModel.showAddToken(this);
+                viewModel.showAddToken(this, null);
             }
             break;
             case android.R.id.home: {
@@ -280,6 +284,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             }
             case R.id.action_share: {
                 dappBrowserFragment.share();
+                return true;
+            }
+            case R.id.action_scan: {
+                Intent intent = new Intent(this, QRScanningActivity.class);
+                startActivityForResult(intent, DAPP_BARCODE_READER_REQUEST_CODE);
+                return true;
             }
         }
         return super.onOptionsItemSelected(item);
@@ -411,6 +421,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public void TokensReady()
     {
         transactionsFragment.tokensReady();
+    }
+
+    @Override
+    public void AddToken(String address)
+    {
+        viewModel.showAddToken(this, address);
     }
 
     private class ScreenSlidePagerAdapter extends FragmentStatePagerAdapter {
@@ -597,8 +613,17 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
         super.onActivityResult(requestCode, resultCode, data);
+        switch (requestCode)
+        {
+            case DAPP_BARCODE_READER_REQUEST_CODE:
+                dappBrowserFragment.handleQRCode(resultCode, data, this);
+                break;
+            default:
+                break;
+        }
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/HomeViewModel.java
@@ -160,8 +160,8 @@ public class HomeViewModel extends BaseViewModel {
         externalBrowserRouter.open(context, uri);
     }
 
-    public void showAddToken(Context context) {
-        addTokenRouter.open(context);
+    public void showAddToken(Context context, String address) {
+        addTokenRouter.open(context, address);
     }
 
     public void setLocale(HomeActivity activity)

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -310,7 +310,7 @@ public class WalletViewModel extends BaseViewModel implements Runnable
 //    }
 
     public void showAddToken(Context context) {
-        addTokenRouter.open(context);
+        addTokenRouter.open(context, null);
     }
 
     @Override

--- a/app/src/main/res/menu/menu_bookmarks.xml
+++ b/app/src/main/res/menu/menu_bookmarks.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
@@ -21,5 +22,12 @@
         android:icon="@drawable/ic_dapp_share"
         android:orderInCategory="20"
         android:title="@string/action_share"
+        app:showAsAction="withText" />
+
+    <item
+        android:id="@+id/action_scan"
+        android:icon="@mipmap/qr_code_icon"
+        android:orderInCategory="25"
+        android:title="@string/action_scan_dapp"
         app:showAsAction="withText" />
 </menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -22,4 +22,9 @@
     <string name="contains_no_data">DApp transaction contains no data</string>
     <string name="error_insufficient_funds">Insufficient Funds</string>
     <string name="ssl_cert_invalid">Invalid SSL Certificate. This site may be unsafe. Proceed?</string>
+    <string name="action_scan_dapp">Scan QR Code</string>
+    <string name="toast_invalid_code">Invalid Scan Result</string>
+    <string name="address_found">Ethereum Address</string>
+    <string name="is_address">Just scanned an Ethereum address. Do you want to try to load this as a Token?</string>
+    <string name="dialog_load_as_contract">Load Token</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -286,4 +286,9 @@
     <string name="contains_no_data">DApp transaction contains no data</string>
     <string name="error_insufficient_funds">资金不够</string>
     <string name="ssl_cert_invalid">Invalid SSL Certificate. This site may be unsafe. Proceed?</string>
+    <string name="action_scan_dapp">Scan QR Code</string>
+    <string name="toast_invalid_code">Invalid Scan Result</string>
+    <string name="address_found">Ethereum Address</string>
+    <string name="is_address">Just scanned an Ethereum address. Do you want to try to load this as a Token?</string>
+    <string name="dialog_load_as_contract">Load Token</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,4 +422,9 @@
     <string name="error_insufficient_funds">Insufficient Funds</string>
     <string name="ssl_cert_invalid">Invalid SSL Certificate. This site may be unsafe. Proceed?</string>
     <string name="dust_value"><![CDATA[< 0.00001]]></string>
+    <string name="action_scan_dapp">Scan QR Code</string>
+    <string name="toast_invalid_code">Invalid Scan Result</string>
+    <string name="address_found">Ethereum Address</string>
+    <string name="is_address">Just scanned an Ethereum address. Do you want to try to load this as a Token?</string>
+    <string name="dialog_load_as_contract">Load Token</string>
 </resources>


### PR DESCRIPTION
This PR adds the feature to scan QR addresses to take user directly to a Dapp.

It includes an address sensor - if the scanned item is an Ethereum address, it will give the user the option to check for a token at that address. The intention being that user is trying to load something - not trying to send something, so if they're scanning an address from the Dapp page it's most likely they're trying to load a token.

As requested in #556 