### PR TITLE
Use Round Down for balances

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -215,7 +215,7 @@ public class Token implements Parcelable
         BigDecimal decimalDivisor = new BigDecimal(Math.pow(10, tokenInfo.decimals));
         BigDecimal ethBalance = tokenInfo.decimals > 0
                 ? balance.divide(decimalDivisor) : balance;
-        ethBalance = ethBalance.setScale(4, RoundingMode.HALF_UP).stripTrailingZeros();
+        ethBalance = ethBalance.setScale(4, RoundingMode.HALF_DOWN).stripTrailingZeros();
         String value = ethBalance.compareTo(BigDecimal.ZERO) == 0 ? "0" : ethBalance.toPlainString();
         if (ethBalance.compareTo(BigDecimal.ZERO) == 0 && balance.compareTo(BigDecimal.ZERO) > 0)
         {
@@ -592,7 +592,7 @@ public class Token implements Parcelable
         BigDecimal value = new BigDecimal(valueStr);
         value = value.divide(new BigDecimal(Math.pow(10, decimals)));
         int scale = 4;
-        return value.setScale(scale, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString();
+        return value.setScale(scale, RoundingMode.HALF_DOWN).stripTrailingZeros().toPlainString();
     }
 
     public String getTransactionValue(Transaction transaction, Context context)

--- a/app/src/main/java/io/stormbird/wallet/entity/Wallet.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Wallet.java
@@ -59,7 +59,7 @@ public class Wallet implements Parcelable {
 	public void setWalletBalance(BigDecimal balanceBD)
 	{
 		 balance = weiToEth(balanceBD)
-				.setScale(4, RoundingMode.HALF_UP)
+				.setScale(4, RoundingMode.HALF_DOWN)
 				.stripTrailingZeros().toPlainString();
 	}
 }

--- a/app/src/main/java/io/stormbird/wallet/interact/GetDefaultWalletBalance.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/GetDefaultWalletBalance.java
@@ -35,7 +35,7 @@ public class GetDefaultWalletBalance {
                     balances.put(
                             ethereumNetworkRepository.getDefaultNetwork().symbol,
                             weiToEth(ethBalance)
-                                    .setScale(4, RoundingMode.HALF_UP)
+                                    .setScale(4, RoundingMode.HALF_DOWN)
                                 .stripTrailingZeros().toPlainString());
                     return Single.just(balances);
                 })

--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -439,7 +439,7 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
         BigDecimal decimalDivisor = new BigDecimal(Math.pow(10, tokenInfo.decimals));
         BigDecimal ethBalance = tokenInfo.decimals > 0
                 ? token.balance.divide(decimalDivisor) : token.balance;
-        ethBalance = ethBalance.setScale(4, RoundingMode.HALF_UP).stripTrailingZeros();
+        ethBalance = ethBalance.setScale(4, RoundingMode.HALF_DOWN).stripTrailingZeros();
         String value = ethBalance.compareTo(BigDecimal.ZERO) == 0 ? "0" : ethBalance.toPlainString();
         tokenBalanceText.setText(value);
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
@@ -131,7 +131,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
         String converted = ethBalance.compareTo(BigDecimal.ZERO) == 0
                 ? EMPTY_BALANCE
                 : ethBalance.multiply(new BigDecimal(ticker.price))
-                .setScale(2, RoundingMode.HALF_UP)
+                .setScale(2, RoundingMode.HALF_DOWN)
                 .stripTrailingZeros()
                 .toPlainString();
         String formattedPercents = "";

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TotalBalanceHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TotalBalanceHolder.java
@@ -26,6 +26,6 @@ public class TotalBalanceHolder extends BinderViewHolder<BigDecimal> {
     public void bind(@Nullable BigDecimal data, @NonNull Bundle addition) {
         title.setText(data == null
             ? "--"
-            : "$" + data.setScale(2, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString());
+            : "$" + data.setScale(2, RoundingMode.HALF_DOWN).stripTrailingZeros().toPlainString());
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/util/BalanceUtils.java
+++ b/app/src/main/java/io/stormbird/wallet/util/BalanceUtils.java
@@ -15,7 +15,7 @@ public class BalanceUtils {
 
     public static String ethToUsd(String priceUsd, String ethBalance) {
         BigDecimal usd = new BigDecimal(ethBalance).multiply(new BigDecimal(priceUsd));
-        usd = usd.setScale(2, RoundingMode.HALF_UP);
+        usd = usd.setScale(2, RoundingMode.HALF_DOWN);
         return usd.toString();
     }
 


### PR DESCRIPTION
Issue #553 

Wallet rounds up to 4 decimal places, so a balance of 5.99999 is shown as 6.0000 instead of 5.9999. Change the behaviour to show a better representation of balance (use round down).