### PR TITLE
Reduce Data (Network) usage

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -40,6 +40,7 @@ public class Token implements Parcelable
     private short tokenNetwork;
     private boolean requiresAuxRefresh = true;
     protected ContractType contractType;
+    public long lastBlockCheck = 0;
 
     public TokenTicker ticker;
     protected Map<String, String> auxData;
@@ -54,6 +55,11 @@ public class Token implements Parcelable
         tokenInfo = in.readParcelable(TokenInfo.class.getClassLoader());
         balance = new BigDecimal(in.readString());
         updateBlancaTime = in.readLong();
+        int readType = in.readInt();
+        if (readType <= ContractType.CREATION.ordinal())
+        {
+            contractType = ContractType.values()[readType];
+        }
         int size = in.readInt();
         if (size > 0)
         {
@@ -113,6 +119,7 @@ public class Token implements Parcelable
         dest.writeParcelable(tokenInfo, flags);
         dest.writeString(balance == null ? "0" : balance.toString());
         dest.writeLong(updateBlancaTime);
+        dest.writeInt(contractType.ordinal());
         int size = (auxData == null ? 0 : auxData.size());
         dest.writeInt(size);
         if (size > 0)
@@ -504,6 +511,11 @@ public class Token implements Parcelable
                 fromRealm = ContractType.NOT_SET;
             this.contractType = fromRealm;
         }
+    }
+
+    public void setRealmLastBlock(RealmToken realmToken)
+    {
+        realmToken.setLastBlock(lastBlockCheck);
     }
 
     /**

--- a/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/TokenFactory.java
@@ -83,6 +83,7 @@ public class TokenFactory
         }
 
         thisToken.restoreAuxDataFromRealm(realmItem);
+        thisToken.lastBlockCheck = realmItem.getLastBlock();
 
         return thisToken;
     }

--- a/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/AddTokenInteract.java
@@ -2,10 +2,8 @@ package io.stormbird.wallet.interact;
 
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import io.stormbird.wallet.entity.ContractType;
-import io.stormbird.wallet.entity.Token;
-import io.stormbird.wallet.entity.TokenInfo;
-import io.stormbird.wallet.entity.Wallet;
+import io.reactivex.disposables.Disposable;
+import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.repository.TokenRepositoryType;
 import io.stormbird.wallet.repository.WalletRepositoryType;
 import io.stormbird.wallet.service.AssetDefinitionService;
@@ -34,5 +32,10 @@ public class AddTokenInteract {
     {
         if (token.hasPositiveBalance()) return tokenRepository.callTokenFunctions(token, service).toObservable();
         else return Observable.fromCallable(() -> token);
+    }
+
+    public Disposable updateBlockRead(Token token, NetworkInfo network, Wallet wallet)
+    {
+        return tokenRepository.updateBlockRead(token, network, wallet);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenLocalSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenLocalSource.java
@@ -1,5 +1,6 @@
 package io.stormbird.wallet.repository;
 
+import io.reactivex.disposables.Disposable;
 import io.stormbird.wallet.entity.NetworkInfo;
 import io.stormbird.wallet.entity.Token;
 import io.stormbird.wallet.entity.TokenTicker;
@@ -34,4 +35,6 @@ public interface TokenLocalSource {
     void setTokenTerminated(NetworkInfo network, Wallet wallet, Token token);
 
     Single<Token[]> saveERC721Tokens(NetworkInfo defaultNetwork, Wallet wallet, Token[] tokens);
+
+    Disposable storeBlockRead(Token token, NetworkInfo network, Wallet wallet);
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -573,6 +573,7 @@ public class TokenRepository implements TokenRepositoryType {
                 localSource.updateTokenBalance(network, wallet, updated);
                 updated.setTokenWallet(wallet.address);
                 updated.setTokenNetwork(network.chainId);
+                updated.lastBlockCheck = token.lastBlockCheck;
                 return updated;
             }
             catch (BadContract e)
@@ -1241,5 +1242,11 @@ public class TokenRepository implements TokenRepositoryType {
             indexedValues.add(value);
         }
         return new EventValues(indexedValues, nonIndexedValues);
+    }
+
+    @Override
+    public Disposable updateBlockRead(Token token, NetworkInfo network, Wallet wallet)
+    {
+        return localSource.storeBlockRead(token, network, wallet);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -37,4 +37,6 @@ public interface TokenRepositoryType {
 
     Single<Token[]> addERC721(Wallet wallet, Token[] tokens);
     Single<String> callAddressMethod(String method, byte[] resultHash, String address);
+
+    Disposable updateBlockRead(Token token, NetworkInfo network, Wallet wallet);
 }

--- a/app/src/main/java/io/stormbird/wallet/repository/entity/RealmToken.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/entity/RealmToken.java
@@ -19,6 +19,7 @@ public class RealmToken extends RealmObject {
     private int nullCheckCount = 0;
     private int interfaceSpec;
     private String auxData;
+    private long lastBlockRead;
 
     public int getDecimals() {
         return decimals;
@@ -142,4 +143,10 @@ public class RealmToken extends RealmObject {
     {
         this.auxData = auxData;
     }
+
+    public void setLastBlock(long lastBlockCheck)
+    {
+        this.lastBlockRead = lastBlockCheck;
+    }
+    public long getLastBlock() { return lastBlockRead; }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -17,7 +17,6 @@ public class TokensService
     private Map<String, Token> tokenMap = new ConcurrentHashMap<>();
     private List<String> terminationList = new ArrayList<>();
     private static Map<String, ContractType> interfaceSpecMap = new ConcurrentHashMap<>();
-    private Map<String, Long> updateMap = new ConcurrentHashMap<>();
     private String currentAddress = null;
     private int currentNetwork = 0;
 
@@ -212,17 +211,6 @@ public class TokensService
         }
 
         return result;
-    }
-
-    public void setLatestBlock(String address, long block)
-    {
-        updateMap.put(address, block);
-    }
-
-    public long getLatestBlock(String address)
-    {
-        if (updateMap.containsKey(address)) return updateMap.get(address);
-        else return 0;
     }
 
     public List<Token> getAllClass(Class<?> tokenClass)

--- a/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransactionsFragment.java
@@ -5,7 +5,6 @@ import android.app.Dialog;
 import android.arch.lifecycle.ViewModelProviders;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetDialog;
@@ -51,8 +50,6 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     private Dialog dialog;
 
     private boolean isVisible = false;
-    private int networkId = 0;
-    private Handler handler;
 
     RecyclerView list;
 
@@ -93,7 +90,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
 
         tokenReceiver = new TokensReceiver(getActivity(), this);
 
-        handler = new Handler();
+        viewModel.prepare();
 
         return view;
     }
@@ -120,8 +117,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     public void onResume() {
         super.onResume();
         viewModel.setVisibility(isVisible);
-        viewModel.abortAndRestart(true);
-        viewModel.prepare();
+        viewModel.restartIfRequired();
     }
 
     @Override
@@ -165,7 +161,6 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     private void onDefaultNetwork(NetworkInfo networkInfo)
     {
         adapter.setDefaultNetwork(networkInfo);
-        networkId = networkInfo.chainId;
     }
 
     private void onError(ErrorEnvelope errorEnvelope) {


### PR DESCRIPTION
Implement data saving by only querying information we haven't previously read.

During testing I noticed accounts with a lot of tokens that have a lot of transactions chew up data. This is a refinement that only reads what we haven't already read (blockchain doesn't change --- <cough>hard fork</cough>).

**TODO: allow total transaction refresh which is done in the unlikely event of hard fork.