### PR TITLE
Handle different read errors.

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -547,10 +547,6 @@ public class TokenRepository implements TokenRepositoryType {
                 BigDecimal balance = null;
                 TokenInfo tInfo = token.tokenInfo;
                 ContractType interfaceSpec = token.getInterfaceSpec();
-                if (token.getAddress().equalsIgnoreCase("0xe8b3bee5997a32ec995678bee6e948b809f2cb13"))
-                {
-                    System.out.println("yoless");
-                }
                 switch (interfaceSpec)
                 {
                     case ERC875:


### PR DESCRIPTION
Distinguish between a node call error and a balance null return.

This means - when user or node is offline there is a comms error which is handled by using the last good value. If there is a balance return error (ie call getBalance and result is '0x') then most likely explanation is balance is null.

We may want to intercept that result later, so flag it.