### PR TITLE
Allow trusted extensions

### DIFF
--- a/app/src/main/res/values/trusted_apps.xml
+++ b/app/src/main/res/values/trusted_apps.xml
@@ -3,4 +3,8 @@
     <string-array name="TrustedApps">
         <item>org.telegram.messenger,tg:join?invite=</item>
     </string-array>
+
+    <string-array name="TrustedExtensions">
+        <item>application/pdf,pdf</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
As requested in #528 

Add a list of known extensions which are safe to handle externally outside the dapp browser.