### PR TITLE
Fix ENS resolution

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -33,7 +33,7 @@ public interface TokenRepositoryType {
     Disposable terminateToken(Token token, Wallet wallet, NetworkInfo network);
 
     Single<Token[]> addERC721(Wallet wallet, Token[] tokens);
-    Single<String> callAddressMethod(String method, byte[] resultHash, String address);
+    Single<String> resolveENS(int chainId, String address);
 
     Disposable updateBlockRead(Token token, Wallet wallet);
     Single<String> resolveProxyAddress(TokenInfo tokenInfo);

--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -156,7 +156,7 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
 
             @Override
             public void ENSCheck(String name) {
-                viewModel.checkENSAddress(name);
+                viewModel.checkENSAddress(token.tokenInfo.chainId, name);
             }
         };
         ensHandler = new ENSHandler(this, handler, adapterUrl, this, ensCallback);

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
@@ -242,7 +242,7 @@ public class TransferTicketDetailActivity extends BaseActivity implements Runnab
             @Override
             public void ENSCheck(String name)
             {
-                viewModel.checkENSAddress(name);
+                viewModel.checkENSAddress(token.tokenInfo.chainId, name);
             }
         };
         ensHandler = new ENSHandler(this, handler, adapterUrl, this, ensCallback);

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ENSHandler.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ENSHandler.java
@@ -13,6 +13,7 @@ import io.stormbird.wallet.entity.ENSCallback;
 import io.stormbird.wallet.ui.widget.adapter.AutoCompleteUrlAdapter;
 import io.stormbird.wallet.util.KeyboardUtils;
 import io.stormbird.wallet.widget.AWalletAlertDialog;
+import org.web3j.crypto.WalletUtils;
 import org.web3j.ens.EnsResolver;
 
 import static org.web3j.crypto.WalletUtils.isValidAddress;
@@ -214,6 +215,6 @@ public class ENSHandler
 
     public static boolean canBeENSName(String address)
     {
-        return EnsResolver.isValidEnsName(address);
+        return address.length() > 5 && !address.startsWith("0x") && address.contains(".");
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ENSHandler.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ENSHandler.java
@@ -13,6 +13,7 @@ import io.stormbird.wallet.entity.ENSCallback;
 import io.stormbird.wallet.ui.widget.adapter.AutoCompleteUrlAdapter;
 import io.stormbird.wallet.util.KeyboardUtils;
 import io.stormbird.wallet.widget.AWalletAlertDialog;
+import org.web3j.ens.EnsResolver;
 
 import static org.web3j.crypto.WalletUtils.isValidAddress;
 
@@ -196,7 +197,6 @@ public class ENSHandler
         {
             transferAfterENS = false;
             ensCallback.ENSComplete();
-            //onStartTransfer();
         }
     }
 
@@ -214,7 +214,6 @@ public class ENSHandler
 
     public static boolean canBeENSName(String address)
     {
-        //candidate ENS address needs to be greater than at least 5 characters, and contain a period
-        return address.length() > 5 && !address.startsWith("0x") && address.contains(".");
+        return EnsResolver.isValidEnsName(address);
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/SendViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/SendViewModel.java
@@ -67,9 +67,9 @@ public class SendViewModel extends BaseViewModel {
 
     public Token getToken(int chainId, String tokenAddress) { return tokensService.getToken(chainId, tokenAddress); };
 
-    public void checkENSAddress(String name)
+    public void checkENSAddress(int chainId, String name)
     {
-        disposable = ensInteract.checkENSAddress (name)
+        disposable = ensInteract.checkENSAddress(chainId, name)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(ensResolve::postValue, throwable -> ensFail.postValue(""));

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TransferTicketDetailViewModel.java
@@ -260,9 +260,9 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
         }
     }
 
-    public void checkENSAddress(String name)
+    public void checkENSAddress(int chainId, String name)
     {
-        disposable = ensInteract.checkENSAddress (name)
+        disposable = ensInteract.checkENSAddress (chainId, name)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(ensResolve::postValue, throwable -> ensFail.postValue(""));


### PR DESCRIPTION
Fix for ENS resolution. Previously used method was incorrect. Switch to using standard Web3j methods for validating ENS names and resolving address.