### PR TITLE
Fix link intercept in manifest file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
                     android:pathPrefix="/"
                     android:scheme="https" />
                 <data
-                    android:host="goerli.aw.io"
+                    android:host="goerli.aw.app"
                     android:pathPrefix="/"
                     android:scheme="https" />
             </intent-filter>


### PR DESCRIPTION
Fix typo in link URL, so the goerli link will add alphawallet as open intent.

#668 