### PR TITLE
Remove redundant code

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/QRScanning/BarcodeScannerView.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/QRScanning/BarcodeScannerView.java
@@ -12,7 +12,6 @@ import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
-
 import io.stormbird.wallet.R;
 
 public abstract class BarcodeScannerView extends FrameLayout implements Camera.PreviewCallback  {
@@ -22,7 +21,6 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private IViewFinder mViewFinderView;
     private Rect mFramingRectInPreview;
     private CameraHandlerThread mCameraHandlerThread;
-    private Boolean mFlashState;
     private boolean mAutofocusState = true;
     private boolean mShouldScaleToFill = true;
 
@@ -191,9 +189,6 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         if(mCameraWrapper != null) {
             setupLayout(mCameraWrapper);
             mViewFinderView.setupViewFinder();
-            /*if(mFlashState != null) {
-                setFlash(mFlashState);
-            }*/
             setAutoFocus(mAutofocusState);
         }
     }
@@ -251,46 +246,6 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
             mFramingRectInPreview = rect;
         }
         return mFramingRectInPreview;
-    }
-
-    public void setFlash(boolean flag) {
-        mFlashState = flag;
-        if(mCameraWrapper != null && CameraUtils.isFlashSupported(mCameraWrapper.mCamera)) {
-
-            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
-            if(flag) {
-                if(parameters.getFlashMode().equals(Camera.Parameters.FLASH_MODE_TORCH)) {
-                    return;
-                }
-                parameters.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
-            } else {
-                if(parameters.getFlashMode().equals(Camera.Parameters.FLASH_MODE_OFF)) {
-                    return;
-                }
-                parameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-            }
-            mCameraWrapper.mCamera.setParameters(parameters);
-        }
-    }
-
-    public boolean getFlash() {
-        if(mCameraWrapper != null && CameraUtils.isFlashSupported(mCameraWrapper.mCamera)) {
-            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
-            return parameters.getFlashMode().equals(Camera.Parameters.FLASH_MODE_TORCH);
-        }
-        return false;
-    }
-
-    public void toggleFlash() {
-        if(mCameraWrapper != null && CameraUtils.isFlashSupported(mCameraWrapper.mCamera)) {
-            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
-            if(parameters.getFlashMode().equals(Camera.Parameters.FLASH_MODE_TORCH)) {
-                parameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-            } else {
-                parameters.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
-            }
-            mCameraWrapper.mCamera.setParameters(parameters);
-        }
     }
 
     public void setAutoFocus(boolean state) {

--- a/app/src/main/java/io/stormbird/wallet/ui/QRScanning/CameraUtils.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/QRScanning/CameraUtils.java
@@ -2,8 +2,6 @@ package io.stormbird.wallet.ui.QRScanning;
 
 import android.hardware.Camera;
 
-import java.util.List;
-
 public class CameraUtils
 {
     /** A safe way to get an instance of the Camera object. */
@@ -40,22 +38,5 @@ public class CameraUtils
             // Camera is not available (in use or does not exist)
         }
         return c; // returns null if camera is unavailable
-    }
-
-    public static boolean isFlashSupported(Camera camera) {
-        /* Credits: Top answer at http://stackoverflow.com/a/19599365/868173 */
-        if (camera != null) {
-            Camera.Parameters parameters = camera.getParameters();
-
-            if (parameters.getFlashMode() == null) {
-                return false;
-            }
-
-            List<String> supportedFlashModes = parameters.getSupportedFlashModes();
-            return supportedFlashModes != null && !supportedFlashModes.isEmpty() && (supportedFlashModes.size() != 1 || !supportedFlashModes.get(0).equals(Camera.Parameters.FLASH_MODE_OFF));
-        } else {
-            return false;
-        }
-
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/zxing/FullScannerFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/zxing/FullScannerFragment.java
@@ -11,7 +11,6 @@ import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.Result;
 
@@ -23,12 +22,10 @@ public class FullScannerFragment extends Fragment implements ZXingScannerView.Re
     public static final String BarcodeObject = "Barcode";
     public static final int SUCCESS = 0; /* currenly, this is the only possible result, so does it really make sense to use it? - Weiwu */
 
-    private static final String FLASH_STATE = "FLASH_STATE";
     private static final String AUTO_FOCUS_STATE = "AUTO_FOCUS_STATE";
     private static final String SELECTED_FORMATS = "SELECTED_FORMATS";
     private static final String CAMERA_ID = "CAMERA_ID";
     private ZXingScannerView mScannerView;
-    private boolean mFlash;
     private boolean mAutoFocus;
     private ArrayList<Integer> mSelectedIndices;
     private int mCameraId = -1;
@@ -41,14 +38,12 @@ public class FullScannerFragment extends Fragment implements ZXingScannerView.Re
 
         if (state != null)
         {
-            mFlash = state.getBoolean(FLASH_STATE, false);
             mAutoFocus = state.getBoolean(AUTO_FOCUS_STATE, true);
             mSelectedIndices = state.getIntegerArrayList(SELECTED_FORMATS);
             mCameraId = state.getInt(CAMERA_ID, -1);
         }
         else
         {
-            mFlash = false;
             mAutoFocus = true;
             mSelectedIndices = null;
             mCameraId = -1;
@@ -69,7 +64,6 @@ public class FullScannerFragment extends Fragment implements ZXingScannerView.Re
         super.onResume();
         mScannerView.setResultHandler(this);
         mScannerView.startCamera(mCameraId);
-        mScannerView.setFlash(mFlash);
         mScannerView.setAutoFocus(mAutoFocus);
     }
 
@@ -77,7 +71,6 @@ public class FullScannerFragment extends Fragment implements ZXingScannerView.Re
     public void onSaveInstanceState(Bundle outState)
     {
         super.onSaveInstanceState(outState);
-        outState.putBoolean(FLASH_STATE, mFlash);
         outState.putBoolean(AUTO_FOCUS_STATE, mAutoFocus);
         outState.putIntegerArrayList(SELECTED_FORMATS, mSelectedIndices);
         outState.putInt(CAMERA_ID, mCameraId);

--- a/app/src/main/java/io/stormbird/wallet/ui/zxing/ZXingScannerView.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/zxing/ZXingScannerView.java
@@ -8,30 +8,17 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.AttributeSet;
 import android.util.Log;
-
-import com.google.zxing.BarcodeFormat;
-import com.google.zxing.BinaryBitmap;
-import com.google.zxing.DecodeHintType;
-import com.google.zxing.LuminanceSource;
-import com.google.zxing.MultiFormatReader;
-import com.google.zxing.NotFoundException;
-import com.google.zxing.PlanarYUVLuminanceSource;
-import com.google.zxing.ReaderException;
-import com.google.zxing.Result;
+import com.google.zxing.*;
 import com.google.zxing.common.HybridBinarizer;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-
 import io.stormbird.wallet.ui.QRScanning.BarcodeScannerView;
 import io.stormbird.wallet.ui.QRScanning.DisplayUtils;
+
+import java.util.*;
 
 public class ZXingScannerView extends BarcodeScannerView
 {
     private static final String TAG = "ZXingScannerView";
+    private final Context context;
 
     public interface ResultHandler {
         void handleResult(Result rawResult);
@@ -46,17 +33,19 @@ public class ZXingScannerView extends BarcodeScannerView
     {
         ALL_FORMATS.add(BarcodeFormat.QR_CODE);
         ALL_FORMATS.add(BarcodeFormat.AZTEC);
-        ALL_FORMATS.add(BarcodeFormat.MAXICODE);
+        //ALL_FORMATS.add(BarcodeFormat.MAXICODE);
     }
 
     public ZXingScannerView(Context context) {
         super(context);
         initMultiFormatReader();
+        this.context = context;
     }
 
     public ZXingScannerView(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
         initMultiFormatReader();
+        this.context = context;
     }
 
     public void setFormats(List<BarcodeFormat> formats) {


### PR DESCRIPTION
Fix another issue reported from crashlytics caused by deprecated camera code operating on Android 9. The PR removes the (unused) deprecated code causing the crash.

This is pending an overhaul to use the updated Google camera2 API, which is more complex but gives greater control.