### PR TITLE
Add exception handling for dapp browser issues

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/AddEditDappActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/AddEditDappActivity.java
@@ -96,18 +96,28 @@ public class AddEditDappActivity extends BaseActivity {
     }
 
     private void save(DApp dapp) {
-        if (dapp == null || dapp.getName() == null || dapp.getUrl() == null) { finish(); return; }
-
-        List<DApp> myDapps = DappBrowserUtils.getMyDapps(this);
-        for (DApp d : myDapps) {
-            if (d.getName().equals(dapp.getName()) &&
-                    d.getUrl().equals(dapp.getUrl())) {
-                d.setName(name.getText().toString());
-                d.setUrl(url.getText().toString());
+        try
+        {
+            List<DApp> myDapps = DappBrowserUtils.getMyDapps(this);
+            for (DApp d : myDapps)
+            {
+                if (d.getName().equals(dapp.getName()) &&
+                        d.getUrl().equals(dapp.getUrl()))
+                {
+                    d.setName(name.getText().toString());
+                    d.setUrl(url.getText().toString());
+                }
             }
+            DappBrowserUtils.saveToPrefs(this, myDapps);
         }
-        DappBrowserUtils.saveToPrefs(this, myDapps);
-        finish();
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            finish();
+        }
     }
 
     private void add(DApp dapp) {

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -190,7 +190,7 @@ public class DappBrowserFragment extends Fragment implements
     }
 
     private void attachFragment(Fragment fragment, String tag) {
-        if (getChildFragmentManager().findFragmentByTag(tag) == null) {
+        if (tag != null && getChildFragmentManager().findFragmentByTag(tag) == null) {
             if (tag.equals(DAPP_HOME)) {
                 DappHomeFragment f = (DappHomeFragment) fragment;
                 showFragment(f, tag);

--- a/app/src/main/java/io/stormbird/wallet/ui/DiscoverDappsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DiscoverDappsFragment.java
@@ -57,28 +57,48 @@ public class DiscoverDappsFragment extends Fragment {
     }
 
     private void onDappRemoved(DApp dapp) {
-        List<DApp> myDapps = DappBrowserUtils.getMyDapps(getContext());
-        for (DApp d : myDapps) {
-            if (d.getName().equals(dapp.getName())
-                    && d.getUrl().equals(dapp.getUrl())) {
-                myDapps.remove(d);
-                break;
+        try
+        {
+            List<DApp> myDapps = DappBrowserUtils.getMyDapps(getContext());
+            for (DApp d : myDapps)
+            {
+                if (d.getName().equals(dapp.getName())
+                        && d.getUrl().equals(dapp.getUrl()))
+                {
+                    myDapps.remove(d);
+                    break;
+                }
             }
+            DappBrowserUtils.saveToPrefs(getContext(), myDapps);
         }
-        DappBrowserUtils.saveToPrefs(getContext(), myDapps);
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
     }
 
     private List<DApp> getData() {
         List<DApp> dapps;
         dapps = DappBrowserUtils.getDappsList(getContext());
 
-        for (DApp d : dapps) {
-            for (DApp myDapp : DappBrowserUtils.getMyDapps(getContext())) {
-                if (d.getName().equals(myDapp.getName()) && myDapp.isAdded()) {
-                    d.setAdded(true);
+        try
+        {
+            for (DApp d : dapps)
+            {
+                for (DApp myDapp : DappBrowserUtils.getMyDapps(getContext()))
+                {
+                    if (d.getName().equals(myDapp.getName()) && myDapp.isAdded())
+                    {
+                        d.setAdded(true);
+                    }
                 }
             }
         }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
         return dapps;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/MyDappsFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/MyDappsFragment.java
@@ -77,16 +77,28 @@ public class MyDappsFragment extends Fragment {
     }
 
     private void removeDapp(DApp dapp) {
-        List<DApp> myDapps = DappBrowserUtils.getMyDapps(getContext());
-        for (DApp d : myDapps) {
-            if (d.getName().equals(dapp.getName())
-                    && d.getUrl().equals(dapp.getUrl())) {
-                myDapps.remove(d);
-                break;
+        try
+        {
+            List<DApp> myDapps = DappBrowserUtils.getMyDapps(getContext());
+            for (DApp d : myDapps)
+            {
+                if (d.getName().equals(dapp.getName())
+                        && d.getUrl().equals(dapp.getUrl()))
+                {
+                    myDapps.remove(d);
+                    break;
+                }
             }
+            DappBrowserUtils.saveToPrefs(getContext(), myDapps);
         }
-        DappBrowserUtils.saveToPrefs(getContext(), myDapps);
-        updateData();
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            updateData();
+        }
     }
 
     private void updateData() {


### PR DESCRIPTION
Fixing another set of related issues reported from crashlytics. While user was doing some fragment navigation there was a null pointer which caused an exception to be thrown.

Recommend we just wrap all fragments in exception handler for now, but revisit this area and use a fragment stack of some kind. It's probably due to one of the Android OS's scavenging space while dapp browser is out of process then the dapp browser coming back into process with fragments missing.

`DiscoverDappsFragment.java line 62 
io.stormbird.wallet.ui.DiscoverDappsFragment.onDappRemoved `

`AddEditDappActivity.java line 103 
io.stormbird.wallet.ui.AddEditDappActivity.save`

`DappBrowserFragment.java line 193 
io.stormbird.wallet.ui.DappBrowserFragment.attachFragment`
