### PR TITLE
Ask for camera permission each time; even if previously denied.

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -71,6 +71,8 @@ import io.stormbird.wallet.widget.SignMessageDialog;
 import static io.stormbird.wallet.C.RESET_TOOLBAR;
 import static io.stormbird.wallet.C.RESET_WALLET;
 import static io.stormbird.wallet.entity.CryptoFunctions.sigFromByteArray;
+import static io.stormbird.wallet.ui.zxing.QRScanningActivity.DENY_PERMISSION;
+import static io.stormbird.wallet.widget.AWalletAlertDialog.ERROR;
 
 public class DappBrowserFragment extends Fragment implements
         OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
@@ -772,22 +774,31 @@ public class DappBrowserFragment extends Fragment implements
         String qrCode = null;
         try
         {
-            if (resultCode == FullScannerFragment.SUCCESS && data != null)
+            switch (resultCode)
             {
-                qrCode = data.getStringExtra(FullScannerFragment.BarcodeObject);
-            }
-
-            if (qrCode != null && !checkForMagicLink(qrCode))
-            {
-                if (Utils.isAddressValid(qrCode))
-                {
-                    DisplayAddressFound(qrCode, messenger);
-                }
-                else
-                {
-                    //attempt to go to site
-                    loadUrl(qrCode);
-                }
+                case FullScannerFragment.SUCCESS:
+                    if (data != null)
+                    {
+                        qrCode = data.getStringExtra(FullScannerFragment.BarcodeObject);
+                        if (qrCode != null && !checkForMagicLink(qrCode))
+                        {
+                            if (Utils.isAddressValid(qrCode))
+                            {
+                                DisplayAddressFound(qrCode, messenger);
+                            }
+                            else
+                            {
+                                //attempt to go to site
+                                loadUrl(qrCode);
+                            }
+                        }
+                    }
+                    break;
+                case DENY_PERMISSION:
+                    showCameraDenied();
+                    break;
+                default:
+                    break;
             }
         }
         catch (Exception e)
@@ -801,6 +812,18 @@ public class DappBrowserFragment extends Fragment implements
         }
     }
 
+    private void showCameraDenied()
+    {
+        resultDialog = new AWalletAlertDialog(getActivity());
+        resultDialog.setTitle(R.string.title_dialog_error);
+        resultDialog.setMessage(R.string.error_camera_permission_denied);
+        resultDialog.setIcon(ERROR);
+        resultDialog.setButtonText(R.string.button_ok);
+        resultDialog.setButtonListener(v -> {
+            resultDialog.dismiss();
+        });
+        resultDialog.show();
+    }
 
     private boolean checkForMagicLink(String data)
     {

--- a/app/src/main/java/io/stormbird/wallet/ui/zxing/QRScanningActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/zxing/QRScanningActivity.java
@@ -2,6 +2,7 @@ package io.stormbird.wallet.ui.zxing;
 
 
 import android.Manifest;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
@@ -13,6 +14,7 @@ import io.stormbird.wallet.ui.BaseActivity;
 public class QRScanningActivity extends BaseActivity
 {
     private static final int RC_HANDLE_CAMERA_PERM = 2;
+    public static final int DENY_PERMISSION = 1;
 
     @Override
     public void onCreate(Bundle state)
@@ -34,11 +36,7 @@ public class QRScanningActivity extends BaseActivity
         Log.w("QR SCanner", "Camera permission is not granted. Requesting permission");
 
         final String[] permissions = new String[]{Manifest.permission.CAMERA};
-
-        if (!ActivityCompat.shouldShowRequestPermissionRationale(this,
-                                                                 Manifest.permission.CAMERA)) {
-            ActivityCompat.requestPermissions(this, permissions, RC_HANDLE_CAMERA_PERM);
-        }
+        ActivityCompat.requestPermissions(this, permissions, RC_HANDLE_CAMERA_PERM); //always ask for permission to scan
     }
 
     @Override
@@ -64,8 +62,11 @@ public class QRScanningActivity extends BaseActivity
             }
         }
 
+        // Handle deny permission
         if (!handled)
         {
+            Intent intent = new Intent();
+            setResult(DENY_PERMISSION, intent);
             finish();
         }
     }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -70,4 +70,5 @@
     <string name="search_or_type_web_address">Search or type web address</string>
     <string name="network">Network</string>
     <string name="collectibles">Collectibles</string>
+    <string name="error_camera_permission_denied">Permission to use the camera was denied.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -333,4 +333,5 @@
     <string name="search_or_type_web_address">Search or type web address</string>
     <string name="network">Network</string>
     <string name="collectibles">Collectibles</string>
+    <string name="error_camera_permission_denied">Permission to use the camera was denied.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,4 +475,5 @@
     <string name="network">Network Filters</string>
     <string name="select_network_filters">Select Active Networks:</string>
     <string name="collectibles">Collectibles</string>
+    <string name="error_camera_permission_denied">Permission to use the camera was denied.</string>
 </resources>


### PR DESCRIPTION
From Alphawallet Telegram group:

> **Herve BTU Protocol**
> Small issue on Android. If you do not allow Alpha to take picture (by mistake). then you can never use qr code anymore (i assume it should ask you again each time you are trying to use the feature)

This PR fixes the issue by _always_ asking the user for permission, even if they previously denied permission. The reason being (assumption); if a user is asking to scan something, but previously denied the scan, they have reconsidered giving permission. 
The PR also handles the case of 'deny' correctly by warning the user the scan couldn't happen.

The worst case: they deny again or page back.
However this has been reported before by people who also accidentally clicked deny.