### PR TITLE
Fix for URL crash when certain URLs are added

### DIFF
--- a/lib/src/main/java/io/stormbird/token/tools/ParseMagicLink.java
+++ b/lib/src/main/java/io/stormbird/token/tools/ParseMagicLink.java
@@ -145,9 +145,10 @@ public class ParseMagicLink
     {
         MagicLinkData data = new MagicLinkData();
         data.chainId = chainId;
-        byte[] fullOrder = cryptoInterface.Base64Decode(linkData);
+
         try
         {
+            byte[] fullOrder = cryptoInterface.Base64Decode(linkData);
             ByteArrayInputStream bas = new ByteArrayInputStream(fullOrder);
             EthereumReadBuffer ds = new EthereumReadBuffer(bas);
             data.contractType = ds.readByte();


### PR DESCRIPTION
When copy/pasting a URL containing base64 param such as:

`https://jamboard.google.com/d/3x33DeFGe0cAch3G0TMugg13D1o93gIpgcll3s/viewer?f=4`

into the dapp browser, the app would crash in the base64 decoder while trying to decode what it thought was a base64.

Move the decode into the exception handled zone, then if it's not a magic link it'll throw, the function will return a null and the app will proceed normally.