### PR TITLE
sets the ethereum window object

### DIFF
--- a/app/src/main/res/raw/init.js
+++ b/app/src/main/res/raw/init.js
@@ -56,3 +56,5 @@ window.web3.eth.getCoinbase = function(cb) {
     return cb(null, addressHex)
 }
 window.web3.eth.defaultAccount = addressHex
+
+window.ethereum = web3.currentProvider


### PR DESCRIPTION
For #698 

This allows any dapp website to access the window.ethereum object and should solve some of the issues with dapp websites not working properly. 