### PR TITLE
adds an enable function which simply passes

### DIFF
--- a/app/src/main/res/raw/init.js
+++ b/app/src/main/res/raw/init.js
@@ -39,6 +39,12 @@ window.AlphaWallet.init(rpcURL, {
     const { id = 8888 } = msgParams
     AlphaWallet.addCallback(id, cb)
     alpha.signTypedMessage(id, JSON.stringify(data))
+  },
+  enable: function() {
+      return new Promise(function(resolve, reject) {
+          //send back the coinbase account as an array of one
+          resolve([addressHex])
+      })
   }
 }, {
     address: addressHex,


### PR DESCRIPTION
This PR solves for the case whereby the dapp browser asks to enable the web3 injection. Some sites do not catch for this and it can result in an unhandled exception. Since we have not created a privacy mode feature for our dapp browser yet, we should define it and allow it to pass. Carbon copy of https://github.com/AlphaWallet/alpha-wallet-ios/pull/1226