### PR TITLE
ERC721 Tokenscript

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -1,48 +1,36 @@
 package io.stormbird.wallet.entity;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.v7.widget.AppCompatRadioButton;
 import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
-import io.stormbird.token.entity.*;
-import io.stormbird.token.tools.TokenDefinition;
-import io.stormbird.token.util.DateTime;
-import io.stormbird.token.util.DateTimeFactory;
-
-import io.stormbird.wallet.C;
-import io.stormbird.wallet.entity.opensea.Asset;
-import io.stormbird.wallet.ui.TokenFunctionActivity;
-import io.stormbird.wallet.web3.Web3TokenView;
-import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.Function;
-import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.utils.Numeric;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+import io.stormbird.token.entity.TicketRange;
+import io.stormbird.token.entity.TokenScriptResult;
+import io.stormbird.token.tools.TokenDefinition;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.repository.entity.RealmToken;
 import io.stormbird.wallet.service.AssetDefinitionService;
 import io.stormbird.wallet.ui.BaseActivity;
 import io.stormbird.wallet.ui.widget.holder.TokenHolder;
 import io.stormbird.wallet.viewmodel.BaseViewModel;
-
-import static io.stormbird.wallet.C.Key.TICKET;
-import static io.stormbird.wallet.util.Utils.isAlNum;
+import io.stormbird.wallet.web3.Web3TokenView;
 
 /**
  * Created by James on 27/01/2018.  It might seem counter intuitive

--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -489,10 +489,6 @@ public class Token implements Parcelable
         contractType = type;
     }
     public ContractType getInterfaceSpec() { return contractType; }
-    public List<BigInteger> stringHexToBigIntegerList(String integerString)
-    {
-        return null;
-    }
     public int interfaceOrdinal()
     {
         return 0;
@@ -589,6 +585,35 @@ public class Token implements Parcelable
         {
             return "0";
         }
+    }
+
+    /**
+     * Convert a CSV string of Hex values into a BigInteger List
+     * @param integerString CSV string of hex ticket id's
+     * @return
+     */
+    public List<BigInteger> stringHexToBigIntegerList(String integerString)
+    {
+        List<BigInteger> idList = new ArrayList<>();
+
+        try
+        {
+            String[] ids = integerString.split(",");
+
+            for (String id : ids)
+            {
+                //remove whitespace
+                String trim = id.trim();
+                BigInteger val = Numeric.toBigInt(trim);
+                idList.add(val);
+            }
+        }
+        catch (Exception e)
+        {
+            idList = new ArrayList<>();
+        }
+
+        return idList;
     }
 
     public String getTransactionValue(Transaction transaction, Context context)

--- a/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokensRealmSource.java
@@ -743,6 +743,7 @@ public class TokensRealmSource implements TokenLocalSource {
         {
             TokenFactory tf = new TokenFactory();
             RealmERC721Token realmItem = realmItems.get(i);
+            if (realmItem.isTokenId()) continue;
             if (realmItem != null)
             {
                 //get all the assets for this ERC first

--- a/app/src/main/java/io/stormbird/wallet/repository/entity/RealmERC721Asset.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/entity/RealmERC721Asset.java
@@ -27,7 +27,7 @@ public class RealmERC721Asset extends RealmObject
         String[] str = tokenIdAddr.split("-");
         if (str.length > 1)
         {
-            return str[1];
+            return str[str.length-1];
         }
         else
         {

--- a/app/src/main/java/io/stormbird/wallet/repository/entity/RealmERC721Token.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/entity/RealmERC721Token.java
@@ -128,4 +128,16 @@ public class RealmERC721Token extends RealmObject
     {
         this.contractType = contractType;
     }
+
+    public boolean isTokenId()
+    {
+        if (address.contains("-"))
+        {
+            String[] split = address.split("-");
+            //address:0x16baf0de678e52367adc69fd067e5edd1d33e3bf-4-6488
+            return split.length > 2 && Character.isDigit(split[2].charAt(0));
+        }
+
+        return false;
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -10,6 +10,7 @@ import android.os.Environment;
 import android.os.FileObserver;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 import android.util.SparseArray;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -19,6 +20,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableCompletableObserver;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
+import io.realm.RealmResults;
 import io.realm.exceptions.RealmPrimaryKeyConstraintException;
 import io.stormbird.token.entity.*;
 import io.stormbird.token.tools.TokenDefinition;
@@ -29,9 +31,12 @@ import io.stormbird.wallet.repository.EthereumNetworkRepositoryType;
 import io.stormbird.wallet.repository.TokenLocalSource;
 import io.stormbird.wallet.repository.TransactionsRealmCache;
 import io.stormbird.wallet.repository.entity.RealmAuxData;
+import io.stormbird.wallet.repository.entity.RealmERC721Token;
+import io.stormbird.wallet.repository.entity.RealmToken;
 import io.stormbird.wallet.ui.HomeActivity;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.ethereum.geth.BigInt;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.datatypes.Function;
 import org.xml.sax.SAXException;
@@ -675,7 +680,6 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     {
         //check all definitions in the download zone
         Disposable d = Observable.fromIterable(getScriptsInSecureZone())
-                //.concatMap(this::checkFileTime)
                 .concatMap(this::fetchXMLFromServer)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -819,6 +823,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                                 if (addContractAddresses(newTSFile))
                                 {
                                     notificationService.DisplayNotification("Definition Updated", s, NotificationCompat.PRIORITY_MAX);
+                                    cachedDefinition = null;
                                 }
                             }
                         }
@@ -1103,7 +1108,6 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         TokenScriptResult.addPair(attrs, "chainId", String.valueOf(token.tokenInfo.chainId));
         TokenScriptResult.addPair(attrs, "tokenId", tokenId);
 
-
         if (token.isEthereum())
         {
             TokenScriptResult.addPair(attrs, "balance", token.balance.toString());
@@ -1140,9 +1144,26 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     {
         TokenDefinition definition = getAssetDefinition(token.tokenInfo.chainId, token.tokenInfo.address);
         ContractAddress cAddr = new ContractAddress(token.tokenInfo.chainId, token.tokenInfo.address);
+        updateTokenTime(token, tokenId);
         //return definition.resolveAttributes(tokenId, this, cAddr);
         //resolveAttributes(BigInteger tokenId, AttributeInterface attrIf, ContractAddress cAddr, TokenDefinition td)
         return tokenscriptUtility.resolveAttributes(tokenId, this, cAddr, definition, token.lastTxUpdate);
+    }
+
+    private void updateTokenTime(Token token, BigInteger tokenId)
+    {
+        if (token.getInterfaceSpec() == ContractType.ERC721 || token.getInterfaceSpec() == ContractType.ERC721_LEGACY)
+        {
+            token.lastTxUpdate = fetchTxUpdate(token, tokenId);
+            //needs updating?
+            long currentTime = System.currentTimeMillis();
+            if (token.lastTxUpdate == 0 || (currentTime - token.lastTxUpdate) > 1*60*1000)
+            {
+                token.lastTxUpdate = currentTime + 1*60*1000;
+                //update the time
+                storeTxUpdate(token, tokenId);
+            }
+        }
     }
 
     private List<String> getCanonicalizedAssets()
@@ -1176,5 +1197,101 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         Function function = tokenscriptUtility.generateTransactionFunction(token.getWallet(), tokenId, td, def, this);
         String encodedFunction = FunctionEncoder.encode(function);
         return encodedFunction;
+    }
+
+    private long fetchTxUpdate(Token token, BigInteger tokenId)
+    {
+        long updatedTime = 0;
+        try (Realm realm = realmManager.getERC721RealmInstance(new Wallet(token.getWallet())))
+        {
+            RealmERC721Token realmToken = realm.where(RealmERC721Token.class)
+                    .equalTo("address", erc721key(token, tokenId))
+                    .equalTo("chainId", token.tokenInfo.chainId)
+                    .findFirst();
+
+            if (realmToken != null)
+            {
+                updatedTime = realmToken.getUpdatedTime();
+            }
+        }
+        catch (Exception ex)
+        {
+            ex.printStackTrace();
+        }
+
+        return updatedTime;
+    }
+
+    private Disposable storeTxUpdate(Token token, BigInteger tokenId)
+    {
+        return Completable.complete()
+                .subscribeWith(new DisposableCompletableObserver()
+                {
+                    Realm realm;
+                    @Override
+                    public void onStart()
+                    {
+                        realm = realmManager.getERC721RealmInstance(new Wallet(token.getWallet()));
+                        RealmERC721Token realmToken = realm.where(RealmERC721Token.class)
+                                .equalTo("address", erc721key(token, tokenId))
+                                .equalTo("chainId", token.tokenInfo.chainId)
+                                .findFirst();
+
+                        if (realmToken != null)
+                        {
+                            TransactionsRealmCache.addRealm();
+                            realm.beginTransaction();
+                            realmToken.setUpdatedTime(token.lastTxUpdate);
+                        }
+                        else
+                        {
+                            createTokenStore(realm, token, tokenId);
+                        }
+                    }
+
+                    @Override
+                    public void onComplete()
+                    {
+                        if (realm.isInTransaction()) realm.commitTransaction();
+                        TransactionsRealmCache.subRealm();
+                        realm.close();
+                    }
+
+                    @Override
+                    public void onError(Throwable e)
+                    {
+                        if (realm != null && !realm.isClosed())
+                        {
+                            realm.close();
+                        }
+                    }
+                });
+    }
+
+    private String erc721key(Token token, BigInteger tokenId)
+    {
+        return token.getAddress() + "-" + token.tokenInfo.chainId + "-" + tokenId.toString();
+    }
+
+    private void createTokenStore(Realm realm, Token token, BigInteger tokenId)
+    {
+        String databaseKey = erc721key(token, tokenId);
+
+        realm.beginTransaction();
+
+        RealmERC721Token realmToken = realm.where(RealmERC721Token.class)
+                .equalTo("address", databaseKey)
+                .equalTo("chainId", token.tokenInfo.chainId)
+                .findFirst();
+
+        if (realmToken == null)
+        {
+            realmToken = realm.createObject(RealmERC721Token.class, databaseKey);
+            realmToken.setName(token.tokenInfo.name);
+            realmToken.setSymbol(token.tokenInfo.symbol);
+            realmToken.setAddedTime(token.updateBlancaTime);
+            realmToken.setUpdatedTime(token.lastTxUpdate);
+            realmToken.setChainId(token.tokenInfo.chainId);
+        }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -238,7 +238,7 @@ public class TokensService
         List<Token> changedTokens = new ArrayList<>();
         for (Token t : tokens)
         {
-            if (t.isBad() || t.getInterfaceSpec() == ContractType.OTHER) continue;
+            if (t == null || t.isBad() || t.getInterfaceSpec() == ContractType.OTHER) continue;
             Token check = getToken(t.tokenInfo.chainId, t.tokenInfo.address);
             if (check == null || t.checkBalanceChange(check))
             {

--- a/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
@@ -339,7 +339,7 @@ public class ConfirmationActivity extends BaseActivity {
                 break;
 
             case TOKENSCRIPT:
-                viewModel.signTokenScriptTransaction(transactionHex, contractAddress, gasSettings.gasPrice, gasSettings.gasLimit, chainId);
+                viewModel.signTokenScriptTransaction(transactionHex, contractAddress, gasSettings.gasPrice, gasSettings.gasLimit, amount.toBigInteger(), chainId);
                 break;
 
             case MARKET:

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -6,6 +6,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -88,6 +89,7 @@ public class DappBrowserFragment extends Fragment implements
     public static final String SEARCH = "SEARCH";
     public static final String PERSONAL_MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
     public static final String CURRENT_FRAGMENT = "currentFragment";
+    private static final String CURRENT_URL = "urlInBar";
 
     @Inject
     DappBrowserViewModelFactory dappBrowserViewModelFactory;
@@ -156,13 +158,28 @@ public class DappBrowserFragment extends Fragment implements
             String url = getArguments().getString("url");
             loadUrl(url);
         } else {
-            if (savedInstanceState != null) {
+            String prevFragment = PreferenceManager.getDefaultSharedPreferences(getContext()).getString(CURRENT_FRAGMENT, null);
+            String prevUrl = PreferenceManager.getDefaultSharedPreferences(getContext()).getString(CURRENT_URL, null);
+            if (savedInstanceState != null)
+            {
                 currentFragment = savedInstanceState.getString(CURRENT_FRAGMENT, "");
-                if (currentFragment.isEmpty()) {
+                String lastUrl = savedInstanceState.getString(CURRENT_URL, "");
+                if (currentFragment.isEmpty())
+                {
                     attachFragment(DAPP_HOME);
-                } else {
+                }
+                else
+                {
                     attachFragment(currentFragment);
                 }
+
+                if (lastUrl.length() > 0)
+                    loadUrl(lastUrl);
+            }
+            else if (prevFragment != null)
+            {
+                attachFragment(prevFragment);
+                if (prevUrl != null && prevFragment.equals(DAPP_BROWSER) && prevUrl.length() > 0) loadUrl(prevUrl);
             } else {
                 attachFragment(DAPP_HOME);
             }
@@ -649,6 +666,12 @@ public class DappBrowserFragment extends Fragment implements
             attachFragment(lastHomeTag);
             lastHomeTag = DAPP_HOME;
         }
+        else if (lastHomeTag == null)
+        {
+            detachFragments(true);
+            attachFragment(DAPP_HOME);
+            lastHomeTag = DAPP_HOME;
+        }
     }
 
     private void goToNextPage() {
@@ -707,7 +730,8 @@ public class DappBrowserFragment extends Fragment implements
 
     private boolean loadUrl(String urlText)
     {
-        if (!lastHomeTag.equals(DAPP_BROWSER)) lastHomeTag = currentFragment;
+        if (lastHomeTag == null) lastHomeTag = DAPP_BROWSER;
+        else if (!lastHomeTag.equals(DAPP_BROWSER)) lastHomeTag = currentFragment;
         detachFragments(true);
         this.currentFragment = DAPP_BROWSER;
         cancelSearchSession();
@@ -868,5 +892,10 @@ public class DappBrowserFragment extends Fragment implements
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(CURRENT_FRAGMENT, currentFragment);
+        outState.putString(CURRENT_URL, urlTv.getText().toString());
+        PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
+                .putString(CURRENT_FRAGMENT, currentFragment)
+                .putString(CURRENT_URL, urlTv.getText().toString())
+                .apply();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/Erc20DetailActivity.java
@@ -152,7 +152,7 @@ public class Erc20DetailActivity extends BaseActivity {
                     Intent intent = new Intent(this, FunctionActivity.class);
                     intent.putExtra(TICKET, token);
                     intent.putExtra(C.EXTRA_STATE, action);
-                    intent.putExtra(C.EXTRA_TOKEN_ID, BigInteger.ZERO.toString(Character.MAX_RADIX));
+                    intent.putExtra(C.EXTRA_TOKEN_ID, BigInteger.ZERO.toString(16));
                     intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
                     startActivity(intent);
                 });

--- a/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
@@ -40,8 +40,10 @@ import javax.inject.Inject;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.security.SignatureException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.stormbird.wallet.C.Key.TICKET;
@@ -60,6 +62,7 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
     private TokenFunctionViewModel viewModel;
 
     private Token token;
+    private List<BigInteger> tokenIds;
     private BigInteger tokenId;
     private String actionMethod;
     private SystemView systemView;
@@ -77,7 +80,8 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
         actionMethod = getIntent().getStringExtra(C.EXTRA_STATE);
         String tokenIdStr = getIntent().getStringExtra(C.EXTRA_TOKEN_ID);
         if (tokenIdStr == null || tokenIdStr.length() == 0) tokenIdStr = "0";
-        tokenId = new BigInteger(tokenIdStr, Character.MAX_RADIX);
+        tokenIds = token.stringHexToBigIntegerList(tokenIdStr);
+        tokenId = tokenIds.get(0);
 
         tokenView = findViewById(R.id.web3_tokenview);
         waitSpinner = findViewById(R.id.progress_element);
@@ -119,6 +123,8 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
         try
         {
             attrs = viewModel.getAssetDefinitionService().getTokenAttrs(token, tokenId, 1);
+            //add extra tokenIds if required
+            addMultipleTokenIds(attrs);
         }
         catch (Exception e)
         {
@@ -130,6 +136,38 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onAttr, this::onError, () -> displayFunction(attrs.toString()))
                 .isDisposed();
+    }
+
+    private void addMultipleTokenIds(StringBuilder sb)
+    {
+        Map<String, TSAction> functions = viewModel.getAssetDefinitionService().getTokenFunctionMap(token.tokenInfo.chainId, token.getAddress());
+        TSAction action = functions.get(actionMethod);
+        boolean hasTokenIds = false;
+
+        for (MethodArg arg : action.function.parameters)
+        {
+            int index = arg.getTokenIndex();
+            if (arg.isTokenId() && index >= 0 && index < tokenIds.size())
+            {
+                if (!hasTokenIds)
+                {
+                    sb.append("tokenIds: [");//\"Saab\", \"Volvo\", \"BMW\"];")
+                }
+                else
+                {
+                    sb.append(", ");
+                }
+                sb.append("\"");
+                sb.append(tokenIds.get(index));
+                sb.append("\"");
+                hasTokenIds = true;
+            }
+        }
+
+        if (hasTokenIds)
+        {
+            sb.append("],\n");
+        }
     }
 
     private void onError(Throwable throwable)
@@ -232,6 +270,7 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
             //if there's input params, resolve them
             boolean resolved = checkNativeTransaction(action, true);
             resolved = checkFunctionArgs(action, resolved);
+            resolveTokenIds(action);
 
             if (resolved)
             {
@@ -241,6 +280,18 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
         else
         {
             tokenView.callToJS("onConfirm" + "('sig')");
+        }
+    }
+
+    private void resolveTokenIds(TSAction action)
+    {
+        for (MethodArg arg : action.function.parameters)
+        {
+            int index = arg.getTokenIndex();
+            if (arg.isTokenId() && index >= 0 && index < tokenIds.size())
+            {
+                arg.element.value = tokenIds.get(index).toString();
+            }
         }
     }
 
@@ -268,7 +319,7 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
 
     private boolean checkTokenScriptElement(TSAction action, TokenscriptElement e, boolean resolved)
     {
-        if (e.ref != null && e.ref.length() > 0)
+        if (e.ref != null && e.ref.length() > 0 && action.attributeTypes != null)
         {
             AttributeType attr = action.attributeTypes.get(e.ref);
             if (attr == null) return true;
@@ -314,9 +365,9 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
 
     private void handleFunction(TSAction action)
     {
-        if (action.function.tx != null)
+        if (action.function.tx != null && (action.function.parameters == null || action.function.parameters.size() == 0))
         {
-            //this is a native style transaction
+            //no params, this is a native style transaction
             NativeSend(action);
         }
         else
@@ -326,9 +377,27 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
             //confirm the transaction
             ContractAddress cAddr = new ContractAddress(action.function, token.tokenInfo.chainId, token.tokenInfo.address); //viewModel.getAssetDefinitionService().getContractAddress(action.function, token);
 
-            functionEffect = functionEffect + " to " + actionMethod;
+            if (functionEffect == null)
+            {
+                functionEffect = actionMethod;
+            }
+            else
+            {
+                functionEffect = functionEffect + " to " + actionMethod;
+            }
 
-            viewModel.confirmTransaction(this, cAddr.chainId, functionData, null, cAddr.address, actionMethod, functionEffect);
+            //function call may include some value
+            String value = "0";
+            if (action.function.tx != null && action.function.tx.args.containsKey("value"))
+            {
+                //this is very specific but 'value' is a specifically handled param
+                value = action.function.tx.args.get("value").value;
+                BigDecimal valCorrected = getCorrectedBalance(value, 18);
+                functionEffect = valCorrected.toString() + " to " + actionMethod;
+            }
+
+            viewModel.confirmTransaction(this, cAddr.chainId, functionData, null,
+                                         cAddr.address, actionMethod, functionEffect, value);
         }
     }
 
@@ -339,7 +408,7 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
         FunctionDefinition function = action.function;
 
         //check we have a 'to' and a 'value'
-        if (!(function.tx.args.containsKey("to") && function.tx.args.containsKey("value")))
+        if (!(function.tx.args.containsKey("value")))
         {
             isValid = false;
             //TODO: Display error
@@ -487,5 +556,22 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
         {
             e.printStackTrace();
         }
+    }
+
+    public BigDecimal getCorrectedBalance(String value, int scale)
+    {
+        BigDecimal val = BigDecimal.ZERO;
+        try
+        {
+            val = new BigDecimal(value);
+            BigDecimal decimalDivisor = new BigDecimal(Math.pow(10, scale));
+            val = val.divide(decimalDivisor);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return val.setScale(scale, RoundingMode.HALF_DOWN).stripTrailingZeros();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetDialog;
 import android.support.multidex.MultiDex;

--- a/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatRadioButton;
 import android.util.Log;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -210,6 +211,19 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
     {
         super.onPause();
         hideDialog();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //16908332
+        switch (item.getItemId()) {
+            case android.R.id.home: {
+                new HomeRouter().open(this, true);
+                finish();
+                return true;
+            }
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void setTicket(boolean ticket, boolean progress, boolean invalid)
@@ -610,5 +624,11 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         }
 
         return magicLink;
+    }
+
+    @Override
+    public void onBackPressed() {
+        setResult(RESULT_CANCELED);
+        super.onBackPressed();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/RedeemAssetSelectActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/RedeemAssetSelectActivity.java
@@ -165,7 +165,7 @@ public class RedeemAssetSelectActivity extends BaseActivity implements OnTokenCl
         TicketRange range = adapter.getCheckedItem();
         if (range != null)
         {
-            onTokenClick(null, token, range.tokenIds);
+            onTokenClick(null, token, range.tokenIds, true);
 
             adapter.setRedeemTicketQuantity(range, token);
             RecyclerView list = findViewById(R.id.listTickets);
@@ -192,7 +192,7 @@ public class RedeemAssetSelectActivity extends BaseActivity implements OnTokenCl
     }
 
     @Override
-    public void onTokenClick(View v, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View v, Token token, List<BigInteger> ids, boolean selected) {
         currentMenu = R.menu.redeem_menu;
         invalidateOptionsMenu();
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/SellDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SellDetailActivity.java
@@ -550,7 +550,7 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
     }
 
     @Override
-    public void onTokenClick(View view, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View view, Token token, List<BigInteger> ids, boolean selected) {
         Context context = view.getContext();
         //TODO: what action should be performed when clicking on a range?
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/SellTicketActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SellTicketActivity.java
@@ -181,7 +181,7 @@ public class SellTicketActivity extends BaseActivity implements OnTokenClickList
     }
 
     @Override
-    public void onTokenClick(View view, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View view, Token token, List<BigInteger> ids, boolean selected) {
         Context context = view.getContext();
         //TODO: what action should be performed when clicking on a range?
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketActivity.java
@@ -173,7 +173,7 @@ public class TransferTicketActivity extends BaseActivity implements OnTokenClick
     }
 
     @Override
-    public void onTokenClick(View view, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View view, Token token, List<BigInteger> ids, boolean selected) {
         Context context = view.getContext();
         //TODO: what action should be performed when clicking on a range?
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/TransferTicketDetailActivity.java
@@ -529,7 +529,7 @@ public class TransferTicketDetailActivity extends BaseActivity implements Runnab
     }
 
     @Override
-    public void onTokenClick(View view, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View view, Token token, List<BigInteger> ids, boolean selection) {
         Context context = view.getContext();
         //TODO: what action should be performed when clicking on a range?
     }

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletFragment.java
@@ -220,7 +220,7 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
     }
 
     @Override
-    public void onTokenClick(View view, Token token, List<BigInteger> ids) {
+    public void onTokenClick(View view, Token token, List<BigInteger> ids, boolean selected) {
         if (selectedToken == null)
         {
             selectedToken = view;

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/OnTokenClickListener.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/OnTokenClickListener.java
@@ -7,6 +7,6 @@ import java.math.BigInteger;
 import java.util.List;
 
 public interface OnTokenClickListener {
-    void onTokenClick(View view, Token token, List<BigInteger> tokenIds);
+    void onTokenClick(View view, Token token, List<BigInteger> tokenIds, boolean selected);
     void onLongTokenClick(View view, Token token, List<BigInteger> tokenIds);
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/NonFungibleTokenAdapter.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/adapter/NonFungibleTokenAdapter.java
@@ -30,6 +30,7 @@ import io.stormbird.wallet.ui.widget.entity.*;
 import io.stormbird.wallet.ui.widget.holder.*;
 import io.stormbird.wallet.web3.entity.FunctionCallback;
 import io.stormbird.wallet.web3.entity.ScriptFunction;
+import org.ethereum.geth.BigInt;
 
 /**
  * Created by James on 9/02/2018.
@@ -303,35 +304,35 @@ public class NonFungibleTokenAdapter extends TokensAdapter {
         for (int i = 0; i < items.size(); i++)
         {
             SortedItem si = items.get(i);
-            if (si.viewType == AssetInstanceSortedItem.VIEW_TYPE)
+            if (si.isRadioExposed() != expose) requiresFullRedraw = true;
+            if (si.view != null)
             {
-                AssetInstanceSortedItem ais = (AssetInstanceSortedItem) si;
-                if (ais.value.exposeRadio != expose) requiresFullRedraw = true;
-                if (ais.view != null)
-                {
-                    AppCompatRadioButton button = ais.view.itemView.findViewById(R.id.radioBox);
-                    if (button != null && (button.isChecked() || ais.value.isChecked)) button.setChecked(false);
-                }
-                ais.value.isChecked = false;
-                ais.value.exposeRadio = expose;
+                AppCompatRadioButton button = si.view.itemView.findViewById(R.id.radioBox);
+                if (button != null && (button.isChecked() || si.isItemChecked())) button.setChecked(false);
             }
-            else if (si.viewType == OpenseaHolder.VIEW_TYPE)
-            {
-                AssetSortedItem asi = (AssetSortedItem) si;
-                if (asi.value.exposeRadio != expose) requiresFullRedraw = true;
-                if (asi.view != null)
-                {
-                    AppCompatRadioButton button = asi.view.itemView.findViewById(R.id.radioBox);
-                    if (button != null && (button.isChecked() || asi.value.isChecked)) button.setChecked(false);
-                }
-                asi.value.isChecked = false;
-                asi.value.exposeRadio = expose;
-            }
+            si.setIsChecked(false);
+            si.setExposeRadio(expose);
         }
 
         if (requiresFullRedraw)
         {
             notifyDataSetChanged();
         }
+    }
+
+    public List<BigInteger> getSelectedTokenIds(List<BigInteger> selection)
+    {
+        List<BigInteger> tokenIds = new ArrayList<>(selection);
+        for (int i = 0; i < items.size(); i++)
+        {
+            SortedItem si = items.get(i);
+            if (si.isItemChecked())
+            {
+                List<BigInteger> rangeIds = si.getTokenIds();
+                for (BigInteger tokenId : rangeIds) if (!tokenIds.contains(tokenId)) tokenIds.add(tokenId);
+            }
+        }
+
+        return tokenIds;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/AssetInstanceSortedItem.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/AssetInstanceSortedItem.java
@@ -3,6 +3,10 @@ package io.stormbird.wallet.ui.widget.entity;
 import io.stormbird.token.entity.TicketRange;
 import io.stormbird.wallet.ui.widget.holder.AssetInstanceScriptHolder;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by James on 26/03/2019.
  * Stormbird in Singapore
@@ -32,5 +36,29 @@ public class AssetInstanceSortedItem extends SortedItem<TicketRange>
     {
         return other.viewType == AssetInstanceScriptHolder.VIEW_TYPE && this.viewType == AssetInstanceScriptHolder.VIEW_TYPE
                 && ( value.equals(other.value));
+    }
+
+    @Override
+    public boolean isRadioExposed()
+    {
+        return value.exposeRadio;
+    }
+
+    @Override
+    public boolean isItemChecked()
+    {
+        return value.isChecked;
+    }
+
+    @Override
+    public void setIsChecked(boolean b) { value.isChecked = b; };
+
+    @Override
+    public void setExposeRadio(boolean expose) { value.exposeRadio = expose; };
+
+    @Override
+    public List<BigInteger> getTokenIds()
+    {
+        return value.tokenIds;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/AssetSortedItem.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/AssetSortedItem.java
@@ -3,6 +3,10 @@ package io.stormbird.wallet.ui.widget.entity;
 import io.stormbird.wallet.entity.opensea.Asset;
 import io.stormbird.wallet.ui.widget.holder.OpenseaHolder;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by James on 3/10/2018.
  * Stormbird in Singapore
@@ -28,5 +32,31 @@ public class AssetSortedItem extends SortedItem<Asset>
     public boolean areItemsTheSame(SortedItem other) {
         return (other.viewType == viewType
                 && ((AssetSortedItem) other).value.getTokenId().equals(value.getTokenId()));
+    }
+
+    @Override
+    public boolean isRadioExposed()
+    {
+        return value.exposeRadio;
+    }
+
+    @Override
+    public boolean isItemChecked()
+    {
+        return value.isChecked;
+    }
+
+    @Override
+    public void setIsChecked(boolean b) { value.isChecked = b; };
+
+    @Override
+    public void setExposeRadio(boolean expose) { value.exposeRadio = expose; };
+
+    @Override
+    public List<BigInteger> getTokenIds()
+    {
+        List<BigInteger> test = new ArrayList<>();
+        test.add(new BigInteger(value.getTokenId()));
+        return test;
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/SortedItem.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/SortedItem.java
@@ -1,5 +1,6 @@
 package io.stormbird.wallet.ui.widget.entity;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,4 +25,23 @@ public abstract class SortedItem<T> {
     public abstract boolean areContentsTheSame(SortedItem newItem);
 
     public abstract boolean areItemsTheSame(SortedItem other);
+
+    public boolean isRadioExposed()
+    {
+        return false;
+    }
+
+    public boolean isItemChecked()
+    {
+        return false;
+    }
+
+    public void setIsChecked(boolean b) { };
+
+    public void setExposeRadio(boolean expose) { };
+
+    public List<BigInteger> getTokenIds()
+    {
+        return new ArrayList<>();
+    }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/AssetInstanceScriptHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/AssetInstanceScriptHolder.java
@@ -129,7 +129,7 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
         {
             if (!data.isChecked)
             {
-                tokenClickListener.onTokenClick(v,token,data.tokenIds);
+                tokenClickListener.onTokenClick(v,token,data.tokenIds, true);
                 data.isChecked = true;
                 itemSelect.setChecked(true);
             }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/BaseTicketHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/BaseTicketHolder.java
@@ -60,7 +60,7 @@ public class BaseTicketHolder extends BinderViewHolder<TicketRange> implements V
     @Override
     public void onClick(View v) {
         if (onTokenClickListener != null) {
-            onTokenClickListener.onTokenClick(v, token, thisData.tokenIds);
+            onTokenClickListener.onTokenClick(v, token, thisData.tokenIds, true);
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/ChangeTokenHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/ChangeTokenHolder.java
@@ -50,7 +50,7 @@ public class ChangeTokenHolder extends BinderViewHolder<Token> implements View.O
     public void onClick(View v) {
         if (onTokenClickListener != null) {
             enableControl.setChecked(!token.tokenInfo.isEnabled);
-            onTokenClickListener.onTokenClick(v, token, null);
+            onTokenClickListener.onTokenClick(v, token, null, true);
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/OpenseaHolder.java
@@ -127,9 +127,15 @@ public class OpenseaHolder extends BinderViewHolder<Asset> implements Runnable {
         {
             if (!asset.isChecked)
             {
-                tokenClickListener.onTokenClick(v, token, new ArrayList<>(Arrays.asList(new BigInteger(asset.getTokenId()))));
+                tokenClickListener.onTokenClick(v, token, new ArrayList<>(Arrays.asList(new BigInteger(asset.getTokenId()))), true);
                 asset.isChecked = true;
                 itemSelect.setChecked(true);
+            }
+            else
+            {
+                tokenClickListener.onTokenClick(v, token, new ArrayList<>(Arrays.asList(new BigInteger(asset.getTokenId()))), false);
+                asset.isChecked = false;
+                itemSelect.setChecked(false);
             }
         }
         else

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
@@ -106,8 +106,9 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
             Utils.setChainColour(chainName, token.tokenInfo.chainId);
             String displayTxt = assetDefinition.getIssuerName(token);
             issuer.setText(displayTxt);
+            String symbolStr = token.tokenInfo.symbol != null ? token.tokenInfo.symbol.toUpperCase() : "";
             symbol.setText(TextUtils.isEmpty(token.tokenInfo.name)
-                        ? token.tokenInfo.symbol.toUpperCase()
+                        ? symbolStr
                         : token.getFullName());
 
             animateTextWhileWaiting();
@@ -226,7 +227,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
     public void onClick(View v) {
         if (onTokenClickListener != null) {
             tokenLayout.setBackgroundResource(R.drawable.background_token_selected);
-            onTokenClickListener.onTokenClick(v, token, null);
+            onTokenClickListener.onTokenClick(v, token, null, true);
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
@@ -232,12 +232,12 @@ public class ConfirmationViewModel extends BaseViewModel {
         }
     }
 
-    public void signTokenScriptTransaction(String transactionData, String contractAddress, BigInteger gasPrice, BigInteger gasLimit, int chainId)
+    public void signTokenScriptTransaction(String transactionData, String contractAddress, BigInteger gasPrice, BigInteger gasLimit, BigInteger value, int chainId)
     {
         progress.postValue(true);
         byte[] data = Numeric.hexStringToByteArray(transactionData);
             disposable = createTransactionInteract
-                    .create(defaultWallet.getValue(), contractAddress, BigInteger.ZERO, gasPrice, gasLimit, data, chainId)
+                    .create(defaultWallet.getValue(), contractAddress, value, gasPrice, gasLimit, data, chainId)
                     .subscribe(this::onCreateTransaction,
                                this::onError);
     }

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/Erc20DetailViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/Erc20DetailViewModel.java
@@ -113,15 +113,6 @@ public class Erc20DetailViewModel extends BaseViewModel {
         return assetDefinitionService.hasAction(token.tokenInfo.chainId, token.getAddress());
     }
 
-    public String getActionText(Token token)
-    {
-        Map<String, TSAction> actions = assetDefinitionService.getTokenFunctionMap(token.tokenInfo.chainId, token.getAddress());
-        for (String key : actions.keySet())
-            return key;
-
-        return null;
-    }
-
     public void fetchTransactions(Token token, int historyCount) {
         fetchTransactionDisposable =
                 fetchTransactionsInteract.fetchTransactionsFromStorage(wallet.getValue(), token, historyCount)

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/TokenFunctionViewModel.java
@@ -97,7 +97,7 @@ public class TokenFunctionViewModel extends BaseViewModel
         intent.putExtra(TICKET, token);
         intent.putExtra(C.EXTRA_STATE, method);
         BigInteger firstId = tokenIds != null ? tokenIds.get(0) : BigInteger.ZERO;
-        intent.putExtra(C.EXTRA_TOKEN_ID, firstId.toString(Character.MAX_RADIX));
+        intent.putExtra(C.EXTRA_TOKEN_ID, firstId.toString(16));
         intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         ctx.startActivity(intent);
     }
@@ -132,13 +132,14 @@ public class TokenFunctionViewModel extends BaseViewModel
         return assetDefinitionService.getTokenScriptResult(token, tokenId);
     }
 
-    public void confirmTransaction(Context ctx, int networkId, String functionData, String toAddress, String contractAddress, String additionalDetails, String functionName)
+    public void confirmTransaction(Context ctx, int networkId, String functionData, String toAddress,
+                                   String contractAddress, String additionalDetails, String functionName, String value)
     {
         Intent intent = new Intent(ctx, ConfirmationActivity.class);
         intent.putExtra(C.EXTRA_TRANSACTION_DATA, functionData);
         intent.putExtra(C.EXTRA_NETWORKID, networkId);
         intent.putExtra(C.EXTRA_NETWORK_NAME, ethereumNetworkRepository.getNetworkByChain(networkId).getShortName());
-        intent.putExtra(C.EXTRA_AMOUNT, "0"); //TODO: amount
+        intent.putExtra(C.EXTRA_AMOUNT, value);
         if (toAddress != null) intent.putExtra(C.EXTRA_TO_ADDRESS, toAddress);
         if (contractAddress != null) intent.putExtra(C.EXTRA_CONTRACT_ADDRESS, contractAddress);
         intent.putExtra(C.EXTRA_CONTRACT_NAME, additionalDetails);

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletViewModel.java
@@ -35,7 +35,7 @@ public class WalletViewModel extends BaseViewModel
     private static final int BALANCE_CHECK_INTERVAL_MILLIS = 500; //Balance check interval in milliseconds - should be integer divisible with 1000 (1 second)
     private static final int CHECK_OPENSEA_INTERVAL_TIME = 40; //Opensea refresh interval in seconds
     private static final int CHECK_BLOCKSCOUT_INTERVAL_TIME = 30;
-    private static final int OPENSEA_RINKEBY_CHECK = 6; //check Rinkeby opensea once per XX opensea checks (ie if interval time is 25 and rinkeby check is 1 in 6, rinkeby refresh time is once per 300 seconds).
+    private static final int OPENSEA_RINKEBY_CHECK = 3; //check Rinkeby opensea once per XX opensea checks (ie if interval time is 25 and rinkeby check is 1 in 6, rinkeby refresh time is once per 300 seconds).
 
     private final MutableLiveData<Token[]> tokens = new MutableLiveData<>();
     private final MutableLiveData<BigDecimal> total = new MutableLiveData<>();
@@ -244,7 +244,7 @@ public class WalletViewModel extends BaseViewModel
         updateTokens = tokensService.getTokensAtAddress()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::receiveNetworkTokens, this::onError);
+                .subscribe(this::receiveNetworkTokens, this::onBlockscoutError);
     }
 
     private void receiveNetworkTokens(Token[] receivedTokens)
@@ -261,6 +261,11 @@ public class WalletViewModel extends BaseViewModel
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(this::storedTokens, this::onError).isDisposed();
         }
+    }
+
+    private void onBlockscoutError(Throwable throwable)
+    {
+        //unable to resolve blockscout - phone may be offline
     }
 
     private void onFetchTokensCompletable()

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,4 +78,6 @@
     <string name="tokenscript_send_native">Send %1$s %2$s to %3$s (%4$s)</string>
     <string name="current_funds">Current funds: %1$s %2$s</string>
     <string name="invalid_address_explain">%1$s is not a valid ethereum address</string>
+    <string name="token_selection">Token Selection</string>
+    <string name="token_requirement">This function requires %1$s tokens</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -341,4 +341,6 @@
     <string name="tokenscript_send_native">Send %1$s %2$s to %3$s (%4$s)</string>
     <string name="current_funds">Current funds: %1$s %2$s</string>
     <string name="invalid_address_explain">%1$s is not a valid ethereum address</string>
+    <string name="token_selection">Token Selection</string>
+    <string name="token_requirement">This function requires %1$s tokens</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -482,4 +482,6 @@
     <string name="tokenscript_send_native">Send %1$s %2$s to %3$s (%4$s)</string>
     <string name="current_funds">Current funds: %1$s %2$s</string>
     <string name="invalid_address_explain">%1$s is not a valid ethereum address</string>
+    <string name="token_selection">Token Selection</string>
+    <string name="token_requirement">This function requires %1$s tokens</string>
 </resources>

--- a/dmz/src/main/java/io/stormbird/token/web/Ethereum/TokenscriptFunction.java
+++ b/dmz/src/main/java/io/stormbird/token/web/Ethereum/TokenscriptFunction.java
@@ -50,6 +50,8 @@ public abstract class TokenscriptFunction
                             params.add(new Uint256(tokenId));
                             break;
                         case "value":
+                            params.add(new Uint256(new BigInteger(arg.element.value)));
+                            break;
                         default:
                             params.add(new Uint256(new BigInteger(arg.element.value)));
                             break;

--- a/lib/src/main/java/io/stormbird/token/entity/FunctionDefinition.java
+++ b/lib/src/main/java/io/stormbird/token/entity/FunctionDefinition.java
@@ -27,4 +27,15 @@ public class FunctionDefinition
     public long resultTime = 0;
     public BigInteger tokenId;
     public EthereumTransaction tx;
+
+    public int getTokenRequirement()
+    {
+        int count = 0;
+        for (MethodArg arg : parameters)
+        {
+            if (arg.isTokenId()) count++;
+        }
+
+        return count;
+    }
 }

--- a/lib/src/main/java/io/stormbird/token/entity/MethodArg.java
+++ b/lib/src/main/java/io/stormbird/token/entity/MethodArg.java
@@ -10,4 +10,14 @@ public class MethodArg
 {
     public String parameterType; //type of param eg uint256, address etc
     public TokenscriptElement element; // contains either the value or reference to the value
+
+    public boolean isTokenId()
+    {
+        return element.isToken();
+    }
+
+    public int getTokenIndex()
+    {
+        return element.getTokenIndex();
+    }
 }

--- a/lib/src/main/java/io/stormbird/token/entity/TokenScriptResult.java
+++ b/lib/src/main/java/io/stormbird/token/entity/TokenScriptResult.java
@@ -84,9 +84,9 @@ public class TokenScriptResult
         else
         {
             String attrValueStr = (String) attrValue;
-            if (attrValueStr.charAt(0) != '{') attrs.append("\"");
+            if (attrValueStr.length() == 0 || (attrValueStr.charAt(0) != '{')) attrs.append("\"");
             attrs.append(attrValueStr);
-            if (attrValueStr.charAt(0) != '{') attrs.append("\"");
+            if (attrValueStr.length() == 0 || (attrValueStr.charAt(0) != '{')) attrs.append("\"");
         }
 
         attrs.append(",\n");

--- a/lib/src/main/java/io/stormbird/token/entity/TokenscriptElement.java
+++ b/lib/src/main/java/io/stormbird/token/entity/TokenscriptElement.java
@@ -8,4 +8,32 @@ public class TokenscriptElement
 {
     public String ref;
     public String value;
+
+    public boolean isToken()
+    {
+        return ref != null && ref.contains("tokenId");
+    }
+
+    public int getTokenIndex()
+    {
+        int index = -1;
+        if (isToken())
+        {
+            try
+            {
+                String[] split = ref.split("[\\[\\]]");
+                if (split.length == 2)
+                {
+                    String indexStr = split[1];
+                    index = Integer.parseInt(indexStr);
+                }
+            }
+            catch (NumberFormatException e)
+            {
+                e.printStackTrace();
+            }
+        }
+
+        return index;
+    }
 }

--- a/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
+++ b/lib/src/main/java/io/stormbird/token/tools/TokenDefinition.java
@@ -106,7 +106,7 @@ public class TokenDefinition {
     }
 
     public enum As {  // always assume big endian
-        UTF8, Unsigned, Signed, Mapping, Boolean, UnsignedInput
+        UTF8, Unsigned, Signed, Mapping, Boolean, UnsignedInput, TokenId
     }
 
     /* for many occurance of the same tag, return the text content of the one in user's current language */
@@ -510,6 +510,9 @@ public class TokenDefinition {
                                 int chainId = Integer.parseInt(chainIdStr);
                                 ci.addresses.put(chainId, new ArrayList<>(Arrays.asList(ci.contractInterface)));
                                 contracts.put(name, ci);
+                                break;
+                            case "contract":
+                                handleAddresses(getFirstChildElement(element));
                                 break;
                             default:
                                 break;


### PR DESCRIPTION
Upgrade tokenscript handling to be ERC721 compatible.

This was done to make tokenscript handling for all tokens more generic - previously ERC721 wasn't supported. The upgrade allowed the Cryptokitties Tokenscript to be demoed at the Ethereum conference; 

Once we have the kitties Tokenscript working on iOS then we can release it to the server. The script may require a little formatting to make it look a bit better.