### PR TITLE
Fixes from crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         applicationId "io.stormbird.wallet"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 58
+        versionCode 59
         versionName "2.00.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true

--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -283,7 +283,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                     }
                     else
                     {
-                        //try asset directory - NB if 
+                        //try asset directory - NB if no file here then expection thrown
                         is = context.getResources().getAssets().open(tokenScriptFile.getName());
                     }
 

--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -283,7 +283,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                     }
                     else
                     {
-                        //try asset directory
+                        //try asset directory - NB if 
                         is = context.getResources().getAssets().open(tokenScriptFile.getName());
                     }
 
@@ -320,6 +320,8 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     public TokenDefinition getAssetDefinition(int chainId, String address)
     {
         TokenDefinition assetDef = null;
+        if (address == null) return null;
+
         if (address.equalsIgnoreCase(tokensService.getCurrentAddress()))
         {
             address = "ethereum";

--- a/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
@@ -375,9 +375,12 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
     private void setupNetwork(int chainId)
     {
         networkInfo = viewModel.getNetworkInfo(chainId);
-        currentNetwork.setText(networkInfo.name);
-        Utils.setChainColour(networkIcon, networkInfo.chainId);
-        viewModel.setPrimaryChain(chainId);
+        if (networkInfo != null)
+        {
+            currentNetwork.setText(networkInfo.name);
+            Utils.setChainColour(networkIcon, networkInfo.chainId);
+            viewModel.setPrimaryChain(chainId);
+        }
     }
 
     private void selectNetwork() {

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -810,9 +810,9 @@ public class DappBrowserFragment extends Fragment implements
             qrCode = null;
         }
 
-        if (qrCode == null)
+        if (qrCode == null && getActivity() != null)
         {
-            Toast.makeText(getContext(), R.string.toast_invalid_code, Toast.LENGTH_SHORT).show();
+            Toast.makeText(getActivity(), R.string.toast_invalid_code, Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
The following Null Pointer crashes fixed from Crashlytics reporting:

AssetDefinitionService: being passed a null contract address from wallet token list, reported from a fork of Alphawallet. Not sure what's going on in the modified code but the issue can be patched to ensure it doesn't cause a problem for us.

AddTokenActivity: Switching to an unavailable network - possibly a user build since only available networks are added to the network selector.

DappBrowserFragment QR handling warning: Crash when context switched out. This could occur when a user task switches while the camera is open, causing the QR scanner to return null, and the app tries to display the 'invalid QR' message but there's no context available.