### PR TITLE
Fix swipe event issue

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -28,6 +28,8 @@ import android.widget.*;
 
 import com.google.gson.Gson;
 
+import io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeInterface;
+import io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout;
 import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign;
 
@@ -87,7 +89,7 @@ import static io.stormbird.wallet.widget.AWalletAlertDialog.ERROR;
 public class DappBrowserFragment extends Fragment implements
         OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
         URLLoadInterface, ItemClickListener, SignTransactionInterface, OnDappClickListener, OnDappHomeNavClickListener,
-        OnHistoryItemRemovedListener
+        OnHistoryItemRemovedListener, DappBrowserSwipeInterface
 {
     private static final String TAG = DappBrowserFragment.class.getSimpleName();
     private static final String DAPP_BROWSER = "DAPP_BROWSER";
@@ -104,7 +106,7 @@ public class DappBrowserFragment extends Fragment implements
     DappBrowserViewModelFactory dappBrowserViewModelFactory;
     private DappBrowserViewModel viewModel;
 
-    private SwipeRefreshLayout swipeRefreshLayout;
+    private DappBrowserSwipeLayout swipeRefreshLayout;
     private Web3View web3;
     private AutoCompleteTextView urlTv;
     private ProgressBar progressBar;
@@ -331,7 +333,7 @@ public class DappBrowserFragment extends Fragment implements
         progressBar = view.findViewById(R.id.progressBar);
         urlTv = view.findViewById(R.id.url_tv);
         swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
-        swipeRefreshLayout.setOnRefreshListener(() -> web3.reload());
+        swipeRefreshLayout.setRefreshInterface(this);
         toolbar = view.findViewById(R.id.address_bar);
         toolbar.inflateMenu(R.menu.menu_bookmarks);
         toolbar.getMenu().findItem(R.id.action_reload)
@@ -936,5 +938,11 @@ public class DappBrowserFragment extends Fragment implements
                 .putString(CURRENT_FRAGMENT, currentFragment)
                 .putString(CURRENT_URL, urlTv.getText().toString())
                 .apply();
+    }
+
+    @Override
+    public void RefreshEvent()
+    {
+        web3.reload();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeInterface.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeInterface.java
@@ -1,0 +1,10 @@
+package io.stormbird.wallet.ui.widget.entity;
+
+/**
+ * Created by James on 8/07/2019.
+ * Stormbird in Sydney
+ */
+public interface DappBrowserSwipeInterface
+{
+    void RefreshEvent();
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeLayout.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeLayout.java
@@ -1,0 +1,62 @@
+package io.stormbird.wallet.ui.widget.entity;
+
+import android.content.Context;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import static android.view.MotionEvent.*;
+
+/**
+ * Created by James on 8/07/2019.
+ * Stormbird in Sydney
+ *
+ * This class overrides the SwipeRefreshLayout and makes the swipe refresh less sensitive.
+ * To create a swipe refresh event user must make a quick, medium to large downward swipe of less than 300ms;
+ * Otherwise a slower event will be treated as a browser scroll event.
+ *
+ */
+public class DappBrowserSwipeLayout extends SwipeRefreshLayout
+{
+    private float trackMove;
+    private DappBrowserSwipeInterface refreshInterface;
+
+    public DappBrowserSwipeLayout(Context context)
+    {
+        super(context);
+    }
+
+    public DappBrowserSwipeLayout(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+    }
+
+    public void setRefreshInterface(DappBrowserSwipeInterface refresh)
+    {
+        refreshInterface = refresh;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev)
+    {
+        switch (ev.getAction())
+        {
+            case ACTION_DOWN:
+                trackMove = ev.getRawY();
+                break;
+            case ACTION_UP:
+                float flingDistance = ev.getRawY() - trackMove;
+                if ((ev.getEventTime() - ev.getDownTime()) < 300 && flingDistance > 400) //User wants a swipe refresh
+                {
+                    refreshInterface.RefreshEvent();
+                }
+                break;
+            case ACTION_MOVE:
+                break;
+            default:
+                break;
+        }
+
+        return false;
+    }
+}

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -158,7 +158,7 @@
         android:focusable="true"
         android:focusableInTouchMode="true">
 
-        <android.support.v4.widget.SwipeRefreshLayout
+        <io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout
             android:id="@+id/swipe_refresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -168,6 +168,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-        </android.support.v4.widget.SwipeRefreshLayout>
+        </io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout>
     </FrameLayout>
 </RelativeLayout>


### PR DESCRIPTION
As reported by @zhangzhongnan928 on the Telegram group. 

It was impossible to scroll down on a website that was slightly longer than the screen height as this gesture was intercepted as a screen refresh event.

This PR makes the swipe refresh event detection less sensitive; specifically to trigger it you need to swipe downward more than 400 pixels within 300ms. These figures were arrived at by collecting swipe gesture pattern data; typically a swipe refresh fling gesture lasts only 100ms and will be well over 500 pixels. Using the more generous data still allows easy refresh but lets through browser scrolling.