### PR TITLE
Fix dapp browser refresh issue

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -943,6 +943,17 @@ public class DappBrowserFragment extends Fragment implements
     @Override
     public void RefreshEvent()
     {
-        web3.reload();
+        //determine scroll position
+        Log.i("Touch", "SCROLL: " + web3.getScrollY());
+        if (web3.getScrollY() == 0)
+        {
+            web3.reload();
+        }
+    }
+
+    @Override
+    public int getCurrentScrollPosition()
+    {
+        return web3.getScrollY();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -28,6 +28,8 @@ import android.widget.*;
 
 import com.google.gson.Gson;
 
+import io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeInterface;
+import io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout;
 import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign;
 
@@ -87,7 +89,7 @@ import static io.stormbird.wallet.widget.AWalletAlertDialog.ERROR;
 public class DappBrowserFragment extends Fragment implements
         OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
         URLLoadInterface, ItemClickListener, SignTransactionInterface, OnDappClickListener, OnDappHomeNavClickListener,
-        OnHistoryItemRemovedListener
+        OnHistoryItemRemovedListener, DappBrowserSwipeInterface
 {
     private static final String TAG = DappBrowserFragment.class.getSimpleName();
     private static final String DAPP_BROWSER = "DAPP_BROWSER";
@@ -104,7 +106,7 @@ public class DappBrowserFragment extends Fragment implements
     DappBrowserViewModelFactory dappBrowserViewModelFactory;
     private DappBrowserViewModel viewModel;
 
-    private SwipeRefreshLayout swipeRefreshLayout;
+    private DappBrowserSwipeLayout swipeRefreshLayout;
     private Web3View web3;
     private AutoCompleteTextView urlTv;
     private ProgressBar progressBar;
@@ -331,7 +333,7 @@ public class DappBrowserFragment extends Fragment implements
         progressBar = view.findViewById(R.id.progressBar);
         urlTv = view.findViewById(R.id.url_tv);
         swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
-        swipeRefreshLayout.setOnRefreshListener(() -> web3.reload());
+        swipeRefreshLayout.setRefreshInterface(this);
         toolbar = view.findViewById(R.id.address_bar);
         toolbar.inflateMenu(R.menu.menu_bookmarks);
         toolbar.getMenu().findItem(R.id.action_reload)
@@ -936,5 +938,11 @@ public class DappBrowserFragment extends Fragment implements
                 .putString(CURRENT_FRAGMENT, currentFragment)
                 .putString(CURRENT_URL, urlTv.getText().toString())
                 .apply();
+    }
+
+    @Override
+    public void RefreshEvent()
+    {
+        web3.reload();
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
@@ -35,6 +35,8 @@ import io.stormbird.wallet.BuildConfig;
 import io.stormbird.wallet.C;
 import io.stormbird.wallet.R;
 import io.stormbird.wallet.entity.*;
+import io.stormbird.wallet.ui.widget.entity.ScrollControlInterface;
+import io.stormbird.wallet.ui.widget.entity.ScrollControlViewPager;
 import io.stormbird.wallet.util.RootUtil;
 import io.stormbird.wallet.viewmodel.BaseNavigationActivity;
 import io.stormbird.wallet.viewmodel.HomeViewModel;
@@ -50,7 +52,7 @@ import java.lang.reflect.Method;
 
 import static io.stormbird.wallet.widget.AWalletBottomNavigationView.*;
 
-public class HomeActivity extends BaseNavigationActivity implements View.OnClickListener, DownloadInterface, FragmentMessenger
+public class HomeActivity extends BaseNavigationActivity implements View.OnClickListener, DownloadInterface, FragmentMessenger, ScrollControlInterface
 {
     @Inject
     HomeViewModelFactory homeViewModelFactory;
@@ -58,7 +60,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
     private SystemView systemView;
     private Dialog dialog;
-    private ViewPager viewPager;
+    private ScrollControlViewPager viewPager;
     private PagerAdapter pagerAdapter;
     private DownloadReceiver downloadReceiver;
     private AWalletConfirmationDialog cDialog;
@@ -124,6 +126,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         toolbar();
 
         viewPager = findViewById(R.id.view_pager);
+        viewPager.setInterface(this);
         pagerAdapter = new ScreenSlidePagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(pagerAdapter);
         viewPager.setOffscreenPageLimit(4);
@@ -444,6 +447,18 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public void AddToken(String address)
     {
         viewModel.showAddToken(this, address);
+    }
+
+    @Override
+    public int getCurrentPage()
+    {
+        return viewPager.getCurrentItem();
+    }
+
+    @Override
+    public boolean isViewingDappBrowser()
+    {
+        return viewPager.getCurrentItem() == DAPP_BROWSER;
     }
 
     private class ScreenSlidePagerAdapter extends FragmentStatePagerAdapter {

--- a/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/HomeActivity.java
@@ -24,6 +24,7 @@ import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.RecyclerView;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -123,10 +124,13 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
         setContentView(R.layout.activity_home);
 
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+
         toolbar();
 
         viewPager = findViewById(R.id.view_pager);
-        viewPager.setInterface(this);
+        viewPager.setInterface(this, displayMetrics.widthPixels);
         pagerAdapter = new ScreenSlidePagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(pagerAdapter);
         viewPager.setOffscreenPageLimit(4);
@@ -459,6 +463,20 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public boolean isViewingDappBrowser()
     {
         return viewPager.getCurrentItem() == DAPP_BROWSER;
+    }
+
+    @Override
+    public void moveLeft()
+    {
+        int newPage = viewPager.getCurrentItem() - 1;
+        showPage(newPage);
+    }
+
+    @Override
+    public void moveRight()
+    {
+        int newPage = viewPager.getCurrentItem() + 1;
+        showPage(newPage);
     }
 
     private class ScreenSlidePagerAdapter extends FragmentStatePagerAdapter {

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeInterface.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeInterface.java
@@ -1,0 +1,10 @@
+package io.stormbird.wallet.ui.widget.entity;
+
+/**
+ * Created by James on 8/07/2019.
+ * Stormbird in Sydney
+ */
+public interface DappBrowserSwipeInterface
+{
+    void RefreshEvent();
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeLayout.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/DappBrowserSwipeLayout.java
@@ -1,0 +1,62 @@
+package io.stormbird.wallet.ui.widget.entity;
+
+import android.content.Context;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import static android.view.MotionEvent.*;
+
+/**
+ * Created by James on 8/07/2019.
+ * Stormbird in Sydney
+ *
+ * This class overrides the SwipeRefreshLayout and makes the swipe refresh less sensitive.
+ * To create a swipe refresh event user must make a quick, medium to large downward swipe of less than 300ms;
+ * Otherwise a slower event will be treated as a browser scroll event.
+ *
+ */
+public class DappBrowserSwipeLayout extends SwipeRefreshLayout
+{
+    private float trackMove;
+    private DappBrowserSwipeInterface refreshInterface;
+
+    public DappBrowserSwipeLayout(Context context)
+    {
+        super(context);
+    }
+
+    public DappBrowserSwipeLayout(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+    }
+
+    public void setRefreshInterface(DappBrowserSwipeInterface refresh)
+    {
+        refreshInterface = refresh;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev)
+    {
+        switch (ev.getAction())
+        {
+            case ACTION_DOWN:
+                trackMove = ev.getRawY();
+                break;
+            case ACTION_UP:
+                float flingDistance = ev.getRawY() - trackMove;
+                if ((ev.getEventTime() - ev.getDownTime()) < 300 && flingDistance > 400) //User wants a swipe refresh
+                {
+                    refreshInterface.RefreshEvent();
+                }
+                break;
+            case ACTION_MOVE:
+                break;
+            default:
+                break;
+        }
+
+        return false;
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlInterface.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlInterface.java
@@ -4,8 +4,8 @@ package io.stormbird.wallet.ui.widget.entity;
  * Created by James on 8/07/2019.
  * Stormbird in Sydney
  */
-public interface DappBrowserSwipeInterface
+public interface ScrollControlInterface
 {
-    void RefreshEvent();
-    int getCurrentScrollPosition();
+    int getCurrentPage();
+    boolean isViewingDappBrowser();
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlInterface.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlInterface.java
@@ -8,4 +8,6 @@ public interface ScrollControlInterface
 {
     int getCurrentPage();
     boolean isViewingDappBrowser();
+    void moveLeft();
+    void moveRight();
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlViewPager.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlViewPager.java
@@ -1,0 +1,60 @@
+package io.stormbird.wallet.ui.widget.entity;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+/**
+ * Created by James on 8/07/2019.
+ * Stormbird in Sydney
+ */
+public class ScrollControlViewPager extends ViewPager
+{
+    private ScrollControlInterface pageInterface;
+
+    public ScrollControlViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ScrollControlViewPager(@NonNull Context context)
+    {
+        super(context);
+    }
+
+    public void setInterface(ScrollControlInterface pInterface)
+    {
+        pageInterface = pInterface;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+        if (pageInterface != null && pageInterface.isViewingDappBrowser())
+        {
+            return false;
+        }
+        else
+        {
+            return super.onInterceptTouchEvent(event);
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (pageInterface != null && pageInterface.isViewingDappBrowser())
+        {
+            return false;
+        }
+        else
+        {
+            return super.onTouchEvent(event);
+        }
+    }
+
+    @Override
+    public boolean performClick()
+    {
+        return super.performClick();
+    }
+}

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlViewPager.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/entity/ScrollControlViewPager.java
@@ -4,7 +4,10 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.MotionEvent;
+
+import static android.view.MotionEvent.*;
 
 /**
  * Created by James on 8/07/2019.
@@ -13,6 +16,11 @@ import android.view.MotionEvent;
 public class ScrollControlViewPager extends ViewPager
 {
     private ScrollControlInterface pageInterface;
+    private float trackMove;
+    private boolean alwaysLeft;
+    private boolean alwaysRight;
+    private float lastX;
+    private float flingRequired;
 
     public ScrollControlViewPager(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -23,21 +31,58 @@ public class ScrollControlViewPager extends ViewPager
         super(context);
     }
 
-    public void setInterface(ScrollControlInterface pInterface)
+    public void setInterface(ScrollControlInterface pInterface, int width)
     {
         pageInterface = pInterface;
+        flingRequired = ((float)width)*0.6f;
     }
 
     @Override
-    public boolean onInterceptTouchEvent(MotionEvent event) {
+    public boolean onInterceptTouchEvent(MotionEvent ev)
+    {
         if (pageInterface != null && pageInterface.isViewingDappBrowser())
         {
-            return false;
+            //Simple algorithm to ensure only a 'fling' to left or right will page the view.
+            //the threshold for a 'fling' seems to be velocity of 5.5 or above.
+            switch (ev.getAction())
+            {
+                case ACTION_DOWN:
+                    trackMove = ev.getX();
+                    lastX = trackMove;
+                    alwaysLeft = true;
+                    alwaysRight = true;
+                    break;
+                case ACTION_UP:
+                    float flingDistance = Math.abs(ev.getX() - trackMove);
+                    float velocity = (float)flingDistance / (float) (ev.getEventTime() - ev.getDownTime());
+                    if (flingDistance > flingRequired && velocity > 5.5f)
+                    {
+                        if (alwaysLeft) pageInterface.moveLeft();
+                        else if (alwaysRight) pageInterface.moveRight();
+                    }
+                    break;
+                case ACTION_MOVE:
+                    //moving left, value decreases
+                    if ((ev.getX() - lastX) > 0)
+                    {
+                        alwaysRight = false;
+                    }
+                    else if ((ev.getX() - lastX) < 0)
+                    {
+                        alwaysLeft = false;
+                    }
+                    lastX = ev.getX();
+                    break;
+                default:
+                    break;
+            }
         }
         else
         {
-            return super.onInterceptTouchEvent(event);
+            return super.onInterceptTouchEvent(ev);
         }
+
+        return false;
     }
 
     @Override

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -18,11 +18,16 @@
 
             <include layout="@layout/layout_simple_toolbar" />
 
-            <android.support.v4.view.ViewPager
-                android:id="@+id/view_pager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </LinearLayout>
+<!--            <android.support.v4.view.ViewPager-->
+<!--                android:id="@+id/view_pager"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="match_parent" />-->
+
+                    <io.stormbird.wallet.ui.widget.entity.ScrollControlViewPager
+                        android:id="@+id/view_pager"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent" />
+                </LinearLayout>
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -132,7 +132,7 @@
                 android:layout_marginRight="5dp"
                 android:fontFamily="@font/font_regular"
                 android:gravity="center_vertical"
-                android:text="1000.0000"
+                android:text="0.0"
                 android:textColor="@color/text_dark_gray"
                 android:textSize="15sp" />
 
@@ -143,7 +143,7 @@
                 android:layout_marginRight="10dp"
                 android:layout_toEndOf="@id/balance"
                 android:fontFamily="@font/font_semibold"
-                android:text="ETH"
+                android:text="@string/eth"
                 android:textColor="@color/colorPrimaryDark"
                 android:textSize="15sp" />
         </RelativeLayout>

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -158,7 +158,7 @@
         android:focusable="true"
         android:focusableInTouchMode="true">
 
-        <android.support.v4.widget.SwipeRefreshLayout
+        <io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout
             android:id="@+id/swipe_refresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -168,6 +168,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-        </android.support.v4.widget.SwipeRefreshLayout>
+        </io.stormbird.wallet.ui.widget.entity.DappBrowserSwipeLayout>
     </FrameLayout>
 </RelativeLayout>


### PR DESCRIPTION
Fixing a double issue with DappBrowser usability. 

@zhangzhongnan928 reported an issue on Telegram where on some aspect ratios the Uniswap Dapp page couldn't be scrolled down. This is due to the web page layout - a header locks the outer page scroll to be always at the top, while an inner view scrolls up/down. This confuses the native refresh pull down system, which doesn't pass the down gesture on to the underlying page. I overrode with a simple algorithm to make the pull down refresh less sensitive.

A related issue can be observed in the 'Cryptocare' dapp. On the page there are left/right sliders and clicking on the 'causes' link there are causes you can browse by scrolling left and right.

The left/right scroll gestures were intercepted by the viewpager layer and just go to shift the page to transactions or settings. Implementing a simple algorithm to measure the velocity and fling distance; if velocity is over a certain threshold and the fling distance is more than 60% then it's passed to view pager to change page. Anything less is passed through into the dapp browser screen.