### PR TITLE
Fix standard eth transaction

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
@@ -37,6 +37,7 @@ import java.util.List;
 import static io.stormbird.token.tools.Convert.getEthString;
 import static io.stormbird.wallet.C.ETH_SYMBOL;
 import static io.stormbird.wallet.C.PRUNE_ACTIVITY;
+import static io.stormbird.wallet.entity.ConfirmationType.ETH;
 import static io.stormbird.wallet.entity.ConfirmationType.WEB3TRANSACTION;
 import static io.stormbird.wallet.widget.AWalletAlertDialog.ERROR;
 
@@ -177,19 +178,27 @@ public class ConfirmationActivity extends BaseActivity {
                 title.setVisibility(View.VISIBLE);
                 title.setText(R.string.confirm_dapp_transaction);
                 toAddress = transaction.recipient.toString();
-                if (transaction.contract != null)
+                if (transaction.payload == null) //pure ETH transaction
+                {
+                    confirmationType = ETH;
+                    symbolText.setText(symbol);
+                    transactionBytes = null;
+                }
+                else if (transaction.contract != null) //transaction function call
                 {
                     contractAddrText.setVisibility(View.VISIBLE);
                     contractAddrLabel.setVisibility(View.VISIBLE);
                     contractAddrText.setText(transaction.contract.toString());
+                    transactionBytes = Numeric.hexStringToByteArray(transaction.payload);
                 }
-                else
+                else //constructor call
                 {
                     BigInteger addr = Numeric.toBigInt(transaction.recipient.toString());
                     if (addr.equals(BigInteger.ZERO)) //constructor
                     {
                         toAddress = getString(R.string.ticket_contract_constructor);
                     }
+                    transactionBytes = Numeric.hexStringToByteArray(transaction.payload);
                 }
                 String urlRequester = getIntent().getStringExtra(C.EXTRA_CONTRACT_NAME);
                 networkName = getIntent().getStringExtra(C.EXTRA_NETWORK_NAME);
@@ -206,7 +215,6 @@ public class ConfirmationActivity extends BaseActivity {
                 BigDecimal ethAmount = Convert.fromWei(transaction.value.toString(10), Convert.Unit.ETHER);
                 amountString = getEthString(ethAmount.doubleValue());
                 symbolText.setText(ETH_SYMBOL);
-                transactionBytes = Numeric.hexStringToByteArray(transaction.payload);
                 break;
             case ERC721:
                 String contractName = getIntent().getStringExtra(C.EXTRA_CONTRACT_NAME);

--- a/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ConfirmationActivity.java
@@ -62,6 +62,7 @@ public class ConfirmationActivity extends BaseActivity {
     private TextView websiteLabel;
     private TextView websiteText;
     private Button sendButton;
+    private Button moreDetail;
     private TextView title;
     private TextView chainName;
 
@@ -101,6 +102,7 @@ public class ConfirmationActivity extends BaseActivity {
         gasLimitText = findViewById(R.id.text_gas_limit);
         networkFeeText = findViewById(R.id.text_network_fee);
         sendButton = findViewById(R.id.send_button);
+        moreDetail = findViewById(R.id.more_detail);
         contractAddrText = findViewById(R.id.text_contract);
         contractAddrLabel = findViewById(R.id.label_contract);
         websiteLabel = findViewById(R.id.label_website);
@@ -181,22 +183,19 @@ public class ConfirmationActivity extends BaseActivity {
                 if (transaction.payload == null) //pure ETH transaction
                 {
                     confirmationType = ETH;
-                    symbolText.setText(symbol);
                     transactionBytes = null;
                 }
-                else if (transaction.contract != null) //transaction function call
-                {
-                    contractAddrText.setVisibility(View.VISIBLE);
-                    contractAddrLabel.setVisibility(View.VISIBLE);
-                    contractAddrText.setText(transaction.contract.toString());
-                    transactionBytes = Numeric.hexStringToByteArray(transaction.payload);
-                }
-                else //constructor call
+                else
                 {
                     BigInteger addr = Numeric.toBigInt(transaction.recipient.toString());
                     if (addr.equals(BigInteger.ZERO)) //constructor
                     {
                         toAddress = getString(R.string.ticket_contract_constructor);
+                    }
+                    else //function call to contract
+                    {
+                        moreDetail.setVisibility(View.VISIBLE);
+                        moreDetail.setOnClickListener(v -> { viewModel.showMoreDetails(this, toAddress, chainId); }); // allow user to check out contract
                     }
                     transactionBytes = Numeric.hexStringToByteArray(transaction.payload);
                 }

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -652,7 +652,7 @@ public class DappBrowserFragment extends Fragment implements
 
         if (transaction.recipient.equals(Address.EMPTY) && (transaction.payload == null || transaction.value != null))
         {
-            resultDialog.setMessage(getString(R.string.contains_no_receipient));
+            resultDialog.setMessage(getString(R.string.contains_no_recipient));
         }
         else if (transaction.payload == null && transaction.value == null)
         {

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -630,42 +630,38 @@ public class DappBrowserFragment extends Fragment implements
     @Override
     public void onSignTransaction(Web3Transaction transaction, String url)
     {
-        //minimum for transaction to be valid: to and value or payload
-        if (transaction.recipient == null || ((transaction.payload == null || transaction.payload.length() < 1) && transaction.value == null))
+        //minimum for transaction to be valid: recipient and value or payload
+        if ((transaction.recipient.equals(Address.EMPTY) && transaction.payload != null) // Constructor
+            || (!transaction.recipient.equals(Address.EMPTY) && (transaction.payload != null || transaction.value != null))) // Raw or Function TX
+        {
+            viewModel.openConfirmation(getContext(), transaction, url, networkInfo);
+        }
+        else
         {
             //display transaction error
             onInvalidTransaction(transaction);
             web3.onSignCancel(transaction);
         }
-        else
-        {
-            viewModel.openConfirmation(getContext(), transaction, url, networkInfo);
-        }
-    }
-
-    private void onProgress() {
-        resultDialog = new AWalletAlertDialog(getActivity());
-        resultDialog.setIcon(AWalletAlertDialog.NONE);
-        resultDialog.setTitle(R.string.title_dialog_sending);
-        resultDialog.setMessage(R.string.transfer);
-        resultDialog.setProgressMode();
-        resultDialog.setCancelable(false);
-        resultDialog.show();
     }
 
     private void onInvalidTransaction(Web3Transaction transaction) {
+        if (getActivity() == null) return;
         resultDialog = new AWalletAlertDialog(getActivity());
         resultDialog.setIcon(AWalletAlertDialog.ERROR);
         resultDialog.setTitle(getString(R.string.invalid_transaction));
-        if (transaction.recipient == null)
+
+        if (transaction.recipient.equals(Address.EMPTY) && (transaction.payload == null || transaction.value != null))
         {
             resultDialog.setMessage(getString(R.string.contains_no_receipient));
+        }
+        else if (transaction.payload == null && transaction.value == null)
+        {
+            resultDialog.setMessage(getString(R.string.contains_no_value));
         }
         else
         {
             resultDialog.setMessage(getString(R.string.contains_no_data));
         }
-        resultDialog.setProgressMode();
         resultDialog.setButtonText(R.string.button_ok);
         resultDialog.setButtonListener(v -> {
             resultDialog.dismiss();
@@ -813,6 +809,7 @@ public class DappBrowserFragment extends Fragment implements
     }
 
     public void handleSelectNetwork(int resultCode, Intent data) {
+        if (getActivity() == null) return;
         if (resultCode == RESULT_OK) {
             int networkId = data.getIntExtra(C.EXTRA_CHAIN_ID, 1); //default to mainnet in case of trouble
             if (networkInfo.chainId != networkId) {
@@ -870,6 +867,7 @@ public class DappBrowserFragment extends Fragment implements
 
     private void showCameraDenied()
     {
+        if (getActivity() == null) return;
         resultDialog = new AWalletAlertDialog(getActivity());
         resultDialog.setTitle(R.string.title_dialog_error);
         resultDialog.setMessage(R.string.error_camera_permission_denied);
@@ -918,6 +916,7 @@ public class DappBrowserFragment extends Fragment implements
 
     private void DisplayAddressFound(String address, FragmentMessenger messenger)
     {
+        if (getActivity() == null) return;
         resultDialog = new AWalletAlertDialog(getActivity());
         resultDialog.setIcon(AWalletAlertDialog.ERROR);
         resultDialog.setTitle(getString(R.string.address_found));

--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -630,10 +630,11 @@ public class DappBrowserFragment extends Fragment implements
     @Override
     public void onSignTransaction(Web3Transaction transaction, String url)
     {
-        if (transaction.payload == null || transaction.payload.length() < 1)
+        //minimum for transaction to be valid: to and value or payload
+        if (transaction.recipient == null || ((transaction.payload == null || transaction.payload.length() < 1) && transaction.value == null))
         {
             //display transaction error
-            onInvalidTransaction();
+            onInvalidTransaction(transaction);
             web3.onSignCancel(transaction);
         }
         else
@@ -652,11 +653,18 @@ public class DappBrowserFragment extends Fragment implements
         resultDialog.show();
     }
 
-    private void onInvalidTransaction() {
+    private void onInvalidTransaction(Web3Transaction transaction) {
         resultDialog = new AWalletAlertDialog(getActivity());
         resultDialog.setIcon(AWalletAlertDialog.ERROR);
         resultDialog.setTitle(getString(R.string.invalid_transaction));
-        resultDialog.setMessage(getString(R.string.contains_no_data));
+        if (transaction.recipient == null)
+        {
+            resultDialog.setMessage(getString(R.string.contains_no_receipient));
+        }
+        else
+        {
+            resultDialog.setMessage(getString(R.string.contains_no_data));
+        }
         resultDialog.setProgressMode();
         resultDialog.setButtonText(R.string.button_ok);
         resultDialog.setButtonListener(v -> {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/ConfirmationViewModel.java
@@ -3,6 +3,10 @@ package io.stormbird.wallet.viewmodel;
 import android.app.Activity;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
+import android.content.Intent;
+import android.net.Uri;
+import android.text.TextUtils;
+import io.stormbird.token.entity.MagicLinkInfo;
 import io.stormbird.token.tools.Numeric;
 import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.interact.CreateTransactionInteract;
@@ -217,5 +221,17 @@ public class ConfirmationViewModel extends BaseViewModel {
     public String getNetworkName(int chainId)
     {
         return findDefaultNetworkInteract.getNetworkName(chainId);
+    }
+
+    public void showMoreDetails(Activity ctx, String toAddress, int chainId)
+    {
+        Uri etherscanLink = Uri.parse(MagicLinkInfo.getEtherscanURLbyNetwork(chainId))
+                .buildUpon()
+                .appendEncodedPath("address")
+                .appendEncodedPath(toAddress)
+                .build();
+
+        Intent launchBrowser = new Intent(Intent.ACTION_VIEW, etherscanLink);
+        ctx.startActivity(launchBrowser);
     }
 }

--- a/app/src/main/res/layout/activity_confirm.xml
+++ b/app/src/main/res/layout/activity_confirm.xml
@@ -117,15 +117,44 @@
                         android:textIsSelectable="true"
                         android:textSize="14sp" />
 
-                    <TextView
+                    <LinearLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="5dp"
                         android:layout_marginTop="20dp"
-                        android:fontFamily="@font/font_regular"
-                        android:text="@string/label_to"
-                        android:textColor="@color/text_dark_gray"
-                        android:textSize="18sp" />
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginEnd="50dp"
+                            android:fontFamily="@font/font_regular"
+                            android:text="@string/label_to"
+                            android:textColor="@color/text_dark_gray"
+                            android:textSize="18sp" />
+
+                        <Button
+                            android:id="@+id/more_detail"
+                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:layout_gravity="center_vertical"
+                            android:autoLink="web"
+                            android:background="@drawable/background_round_primary"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:fontFamily="@font/font_regular"
+                            android:linksClickable="true"
+                            android:paddingLeft="50dp"
+                            android:paddingRight="50dp"
+                            android:text="@string/action_more_details"
+                            android:textAllCaps="false"
+                            android:textColor="@color/white"
+                            android:textSize="18sp"
+                            android:visibility="gone" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/text_to"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,4 +86,5 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
+    <string name="contains_no_receipient">Transaction has no recipient</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -87,6 +87,6 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
-    <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_recipient">Transaction has no recipient</string>
     <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="wallet_label">billetera</string>
+    <string name="wallet_label">Billetera</string>
     <string name="tx_label">Actas</string>
     <string name="browser_label">Navegadora</string>
     <string name="settings_label">Ajustes</string>
@@ -19,6 +19,7 @@
     <string name="unconfirmed">Unconfirmed</string>
     <string name="no_recent_transactions">You have no transactions yet</string>
     <string name="paste">Paste</string>
+    <string name="label_contract">Contrato</string>
     <string name="no_recent_transactions_subtext">When you send or receive %1$s,\n your transactions will appear here</string>
     <string name="no_recent_transactions_subtext_ether">ether</string>
     <string name="no_recent_transactions_subtext_tokens">tokens</string>
@@ -87,4 +88,5 @@
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
     <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -350,4 +350,5 @@
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
     <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -349,6 +349,6 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
-    <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_recipient">Transaction has no recipient</string>
     <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -349,4 +349,5 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
+    <string name="contains_no_receipient">Transaction has no recipient</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,6 +490,6 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
-    <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_recipient">Transaction has no recipient</string>
     <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
     <string name="enable_xml_override_dir">Enable XML Override</string>
     <string name="explain_xml_override">Enable XML override will create a directory \'AlphaWallet\' in your phone storage. Token config files (XML) can be dropped into this directory which will override default or network Token configs.</string>
     <string name="ask_user_about_xml_override">Do you wish to enable Token config override directory?</string>
-    <string name="label_contract">contract</string>
+    <string name="label_contract">Contract</string>
     <string name="toolbar_header_browser">DApp Browser</string>
     <string name="message_to_sign">Message</string>
     <string name="signer_address">Address</string>
@@ -491,4 +491,5 @@
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
     <string name="contains_no_receipient">Transaction has no recipient</string>
+    <string name="contains_no_value">DApp transaction contains no value.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,4 +490,5 @@
     <string name="searching_for_token">Scanning for Token</string>
     <string name="token_selection">Token Selection</string>
     <string name="token_requirement">This function requires %1$s tokens</string>
+    <string name="contains_no_receipient">Transaction has no recipient</string>
 </resources>


### PR DESCRIPTION
Addressing #745, standard ETH dapp transactions have never been supported.

Logic was changed to ensure all types of Dapp transaction are handled correctly, and also added a 'check contract' button in the confirmation screen so the user can check the contract they're calling on etherscan.