### PR TITLE
Fix ERC20DetailActivity crash

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/Erc20DetailActivity.java
@@ -86,7 +86,7 @@ public class Erc20DetailActivity extends BaseActivity {
 
     private void onTokenTicker(Ticker ticker)
     {
-        if (token != null)
+        if (token != null && tokenViewAdapter != null) //might be a delayed return after user closed screen
         {
             token.ticker = new TokenTicker(String.valueOf(token.tokenInfo.chainId), token.getAddress(), ticker.price_usd, ticker.percentChange24h, null);
             Token[] tokens = {token};

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
@@ -274,7 +274,7 @@ public class WalletsViewModel extends BaseViewModel
     private void onStored(Integer count)
     {
         Log.d(TAG, "Stored " + count + " Wallets");
-    }c
+    }
 
     private Observable<List<Wallet>> fetchWalletList(Wallet[] wallets)
     {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/WalletsViewModel.java
@@ -274,7 +274,7 @@ public class WalletsViewModel extends BaseViewModel
     private void onStored(Integer count)
     {
         Log.d(TAG, "Stored " + count + " Wallets");
-    }
+    }c
 
     private Observable<List<Wallet>> fetchWalletList(Wallet[] wallets)
     {


### PR DESCRIPTION
Fix for NPE caused by a long delayed API call. API returned after the view had been destroyed so the adapter would have been null.

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.stormbird.wallet.ui.widget.adapter.TokensAdapter.setTokens(io.stormbird.wallet.entity.Token[])' on a null object reference
       at io.stormbird.wallet.ui.Erc20DetailActivity.onTokenTicker + 93(Erc20DetailActivity.java:93)
       at io.stormbird.wallet.ui.Erc20DetailActivity.lambda$W4LnSvB5-oNytSWKTKXwtrcE3I0(Erc20DetailActivity.java)
       at io.stormbird.wallet.ui.-$$Lambda$Erc20DetailActivity$W4LnSvB5-oNytSWKTKXwtrcE3I0.onChanged(lambda)
       at android.arch.lifecycle.LiveData.considerNotify + 109(LiveData.java:109)
       at android.arch.lifecycle.LiveData.dispatchingValue + 126(LiveData.java:126)
       at android.arch.lifecycle.LiveData.setValue + 282(LiveData.java:282)
       at android.arch.lifecycle.MutableLiveData.setValue + 33(MutableLiveData.java:33)
       at android.arch.lifecycle.LiveData$1.run + 87(LiveData.java:87)
       at android.os.Handler.handleCallback + 751(Handler.java:751)
       at android.os.Handler.dispatchMessage + 95(Handler.java:95)
```