### PR TITLE
Protect against null view

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/util/KeyboardUtils.java
+++ b/app/src/main/java/io/stormbird/wallet/util/KeyboardUtils.java
@@ -7,6 +7,7 @@ import android.view.inputmethod.InputMethodManager;
 public class KeyboardUtils {
 
     public static void showKeyboard(View view) {
+        if (view == null || view.getContext() == null) return;
         InputMethodManager inputMethodManager
                 = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         if (inputMethodManager != null) {
@@ -15,6 +16,7 @@ public class KeyboardUtils {
     }
 
     public static void hideKeyboard(View view) {
+        if (view == null || view.getContext() == null) return;
         InputMethodManager inputMethodManager
                 = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         if (inputMethodManager != null) {


### PR DESCRIPTION
Fix reported error from Crashlytics:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.Context android.view.View.getContext()' on a null object reference
       at io.stormbird.wallet.util.KeyboardUtils.hideKeyboard + 19(KeyboardUtils.java:19)
       at io.stormbird.wallet.ui.SendActivity.onNext + 199(SendActivity.java:199)
       at io.stormbird.wallet.ui.SendActivity.lambda$initViews$1 + 160(SendActivity.java:160)
       at io.stormbird.wallet.ui.-$$Lambda$SendActivity$YaYqNvCjg6Xjbp0LiQ-d0T3xEGM.onClick + 2(:2)
       at android.view.View.performClick + 7339(View.java:7339)
       at android.widget.TextView.performClick + 14225(TextView.java:14225)
       at android.view.View.performClickInternal + 7305(View.java:7305)
       at android.view.View.access$3200 + 846(View.java:846)
       at android.view.View$PerformClick.run + 27788(View.java:27788)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 7058(ActivityThread.java:7058)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 964(ZygoteInit.java:964)
```