### PR TITLE
Ensure fragment system is ready before use

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/DappBrowserFragment.java
@@ -223,40 +223,71 @@ public class DappBrowserFragment extends Fragment implements
     }
 
     private void attachFragment(Fragment fragment, String tag) {
-        if (tag != null && getChildFragmentManager().findFragmentByTag(tag) == null) {
-            if (tag.equals(DAPP_HOME)) {
-                DappHomeFragment f = (DappHomeFragment) fragment;
-                showFragment(f, tag);
-            } else if (tag.equals(DISCOVER_DAPPS)) {
-                DiscoverDappsFragment f = (DiscoverDappsFragment) fragment;
-                showFragment(f, tag);
-            } else if (tag.equals(MY_DAPPS)) {
-                MyDappsFragment f = (MyDappsFragment) fragment;
-                showFragment(f, tag);
-            } else if (tag.equals(HISTORY)) {
-                BrowserHistoryFragment f = (BrowserHistoryFragment) fragment;
-                showFragment(f, tag);
-            } else {
-                showFragment(fragment, tag);
+        if (tag != null && getContext() != null && getChildFragmentManager().findFragmentByTag(tag) == null)
+        {
+            switch (tag)
+            {
+                case DAPP_HOME:
+                {
+                    DappHomeFragment f = (DappHomeFragment) fragment;
+                    showFragment(f, tag);
+                    break;
+                }
+                case DISCOVER_DAPPS:
+                {
+                    DiscoverDappsFragment f = (DiscoverDappsFragment) fragment;
+                    showFragment(f, tag);
+                    break;
+                }
+                case MY_DAPPS:
+                {
+                    MyDappsFragment f = (MyDappsFragment) fragment;
+                    showFragment(f, tag);
+                    break;
+                }
+                case HISTORY:
+                {
+                    BrowserHistoryFragment f = (BrowserHistoryFragment) fragment;
+                    showFragment(f, tag);
+                    break;
+                }
+                default:
+                    showFragment(fragment, tag);
+                    break;
             }
         }
     }
 
     private void attachFragment(String tag) {
-        if (tag != null && getChildFragmentManager().findFragmentByTag(tag) == null) {
-            if (tag.equals(DAPP_HOME)) {
-                DappHomeFragment f = new DappHomeFragment();
-                showFragment(f, tag);
-                lastHomeTag = DAPP_HOME;
-            } else if (tag.equals(DISCOVER_DAPPS)) {
-                DiscoverDappsFragment f = new DiscoverDappsFragment();
-                showFragment(f, tag);
-            } else if (tag.equals(MY_DAPPS)) {
-                MyDappsFragment f = new MyDappsFragment();
-                showFragment(f, tag);
-            } else if (tag.equals(HISTORY)) {
-                BrowserHistoryFragment f = new BrowserHistoryFragment();
-                showFragment(f, tag);
+        if (tag != null && getContext() != null && getChildFragmentManager().findFragmentByTag(tag) == null)
+        {
+            switch (tag)
+            {
+                case DAPP_HOME:
+                {
+                    DappHomeFragment f = new DappHomeFragment();
+                    showFragment(f, tag);
+                    lastHomeTag = DAPP_HOME;
+                    break;
+                }
+                case DISCOVER_DAPPS:
+                {
+                    DiscoverDappsFragment f = new DiscoverDappsFragment();
+                    showFragment(f, tag);
+                    break;
+                }
+                case MY_DAPPS:
+                {
+                    MyDappsFragment f = new MyDappsFragment();
+                    showFragment(f, tag);
+                    break;
+                }
+                case HISTORY:
+                {
+                    BrowserHistoryFragment f = new BrowserHistoryFragment();
+                    showFragment(f, tag);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Fix error reported from Crashlytics:

The view had been initialised but the Dapp browser fragment handler was not ready when the user tried to use it. Not sure how this can happen, but after checking the Android OS source code you only get this error if one of the internal view handlers is still nulled. Luckily you can check for that via the fragment's context.

```
Fatal Exception: java.lang.IllegalStateException: Fragment has not been attached yet.
       at android.support.v4.app.Fragment.instantiateChildFragmentManager + 2383(Fragment.java:2383)
       at android.support.v4.app.Fragment.getChildFragmentManager + 845(Fragment.java:845)
       at io.stormbird.wallet.ui.DappBrowserFragment.attachFragment + 226(DappBrowserFragment.java:226)
       at io.stormbird.wallet.ui.DappBrowserFragment.homePressed + 287(DappBrowserFragment.java:287)
       at io.stormbird.wallet.ui.HomeActivity.onBottomNavigationItemSelected + 302(HomeActivity.java:302)
       at io.stormbird.wallet.widget.AWalletBottomNavigationView.selectItem + 63(AWalletBottomNavigationView.java:63)
       at io.stormbird.wallet.widget.AWalletBottomNavigationView.lambda$new$1 + 48(AWalletBottomNavigationView.java:48)
       at io.stormbird.wallet.widget.-$$Lambda$AWalletBottomNavigationView$SYqwNetiU9a1f4guUJpIdiyDnWA.onClick + 2(:2)
       at android.view.View.performClick + 7339(View.java:7339)
       at android.view.View.performClickInternal + 7305(View.java:7305)
       at android.view.View.access$3200 + 846(View.java:846)
       at android.view.View$PerformClick.run + 27788(View.java:27788)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 7045(ActivityThread.java:7045)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 964(ZygoteInit.java:964)
```