### PR TITLE
Protect currency check

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/service/TokensService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/TokensService.java
@@ -411,8 +411,9 @@ public class TokensService
 
     private Token checkCurrencies()
     {
-        if (currencyCheckCount == networkFilter.size()) return null;
-        int chainId = networkFilter.get(currencyCheckCount++);
+        if (currencyCheckCount >= networkFilter.size()) return null;
+        int chainId = networkFilter.get(currencyCheckCount);
+        currencyCheckCount++;
         return getToken(chainId, currentAddress);
     }
 

--- a/lib/src/main/java/io/stormbird/token/tools/XMLDSigVerifier.java
+++ b/lib/src/main/java/io/stormbird/token/tools/XMLDSigVerifier.java
@@ -227,7 +227,7 @@ public class XMLDSigVerifier {
             {
                 if(found) throw new KeyStoreException("Duplicate X509Data element");
                 found = true;
-                certs = ((X509Data) xmlStructure).getContent();
+                certs = (List<X509Certificate>) ((X509Data) xmlStructure).getContent();
             }
         }
         return certs;


### PR DESCRIPTION
Issue reported from a new live fork of our wallet, I haven't tracked down the name in the Play Store yet so I think it's still closed alpha or beta. Still worth patching.

```
Caused by java.lang.IndexOutOfBoundsException: Index: 2, Size: 2
       at java.util.ArrayList.get + 437(ArrayList.java:437)
       at io.stormbird.wallet.service.TokensService.checkCurrencies + 415(TokensService.java:415)
       at io.stormbird.wallet.service.TokensService.getNextInBalanceUpdateQueue + 383(TokensService.java:383)
       at io.stormbird.wallet.viewmodel.WalletViewModel.checkTokenUpdates + 313(WalletViewModel.java:313)
       at io.stormbird.wallet.viewmodel.WalletViewModel.checkBalances + 304(WalletViewModel.java:304)
       at io.stormbird.wallet.viewmodel.WalletViewModel.lambda$updateTokenBalances$1$WalletViewModel + 291(WalletViewModel.java:291)
       at io.stormbird.wallet.viewmodel.-$$Lambda$WalletViewModel$P1wF6Xkwb-7JnjG3VlSHeeGnl0Y.accept + 4(:4)
       at io.reactivex.internal.operators.observable.ObservableDoOnEach$DoOnEachObserver.onNext + 93(ObservableDoOnEach.java:93)
       at io.reactivex.internal.operators.observable.ObservableInterval$IntervalObserver.run + 82(ObservableInterval.java:82)
       at io.reactivex.internal.schedulers.ScheduledDirectPeriodicTask.run + 38(ScheduledDirectPeriodicTask.java:38)
       at java.util.concurrent.Executors$RunnableAdapter.call + 458(Executors.java:458)
       at java.util.concurrent.FutureTask.runAndReset + 307(FutureTask.java:307)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run + 302(ScheduledThreadPoolExecutor.java:302)
       at java.util.concurrent.ThreadPoolExecutor.runWorker + 1167(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run + 641(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run + 764(Thread.java:764)
```