### PR TITLE
Validate objects on Destroy

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SendActivity.java
@@ -393,10 +393,6 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
                     sendText.setVisibility(View.VISIBLE);
                     sendText.setText(R.string.token_transfer_request);
                 }
-                else
-                {
-                    //TODO: handle ERC875 & ERC721 transfer
-                }
                 break;
 
             case FUNCTION_CALL:
@@ -439,8 +435,8 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
             dialog.dismiss();
         }
         super.onDestroy();
-        handler.removeCallbacksAndMessages(null);
-        amountInput.onClear();
+        if (handler != null) handler.removeCallbacksAndMessages(null);
+        if (amountInput != null) amountInput.onClear();
     }
 
     private boolean isBalanceEnough(String eth) {


### PR DESCRIPTION
Fixing NPE error reported from Crashlytics:

```
Fatal Exception: java.lang.RuntimeException: Unable to destroy activity {io.stormbird.wallet/io.stormbird.wallet.ui.SendActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.stormbird.wallet.ui.widget.entity.AmountEntryItem.onClear()' on a null object reference
       at android.app.ActivityThread.performDestroyActivity + 5100(ActivityThread.java:5100)
       at android.app.ActivityThread.handleDestroyActivity + 5119(ActivityThread.java:5119)
       at android.app.servertransaction.DestroyActivityItem.execute + 39(DestroyActivityItem.java:39)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState + 145(TransactionExecutor.java:145)
       at android.app.servertransaction.TransactionExecutor.execute + 70(TransactionExecutor.java:70)
       at android.app.ActivityThread$H.handleMessage + 2155(ActivityThread.java:2155)
       at android.os.Handler.dispatchMessage + 109(Handler.java:109)
       at android.os.Looper.loop + 207(Looper.java:207)
       at android.app.ActivityThread.main + 7539(ActivityThread.java:7539)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 524(RuntimeInit.java:524)
       at com.android.internal.os.ZygoteInit.main + 958(ZygoteInit.java:958)
```