### PR TITLE
Fix to initial wallet creation

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -694,7 +694,7 @@ public class TokenRepository implements TokenRepositoryType {
     @Override
     public Single<Token> getEthBalance(NetworkInfo network, Wallet wallet) {
         Token currency = createCurrencyToken(network, wallet);
-        currency.pendingBalance = BigDecimal.ONE;
+        currency.pendingBalance = BigDecimal.ZERO;
         return attachEth(network, wallet, currency);
     }
 

--- a/app/src/main/java/io/stormbird/wallet/ui/SplashActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/SplashActivity.java
@@ -18,7 +18,10 @@ import javax.inject.Inject;
 import com.crashlytics.android.core.CrashlyticsCore;
 import dagger.android.AndroidInjection;
 import io.fabric.sdk.android.Fabric;
+import io.stormbird.token.entity.SalesOrderMalformed;
+import io.stormbird.token.tools.ParseMagicLink;
 import io.stormbird.wallet.BuildConfig;
+import io.stormbird.wallet.entity.CryptoFunctions;
 import io.stormbird.wallet.entity.Wallet;
 import io.stormbird.wallet.router.HomeRouter;
 import io.stormbird.wallet.router.ImportTokenRouter;
@@ -136,16 +139,24 @@ public class SplashActivity extends BaseActivity {
         else
         {
             //there is at least one account here
-            if (importData != null)
+
+            //See if this is a valid import magiclink
+            if (importData != null && importData.length() > 60 && importData.contains("aw.app") )
             {
-                new ImportTokenRouter().open(this, importData);
-                finish();
+                try
+                {
+                    ParseMagicLink parser = new ParseMagicLink(new CryptoFunctions());
+                    if (parser.parseUniversalLink(importData).chainId > 0)
+                    {
+                        new ImportTokenRouter().open(this, importData);
+                        finish();
+                        return;
+                    }                }
+                catch (SalesOrderMalformed ignored) { }
             }
-            else
-            {
-                new HomeRouter().open(this, true);
-                finish();
-            }
+
+            new HomeRouter().open(this, true);
+            finish();
         }
     }
 }

--- a/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/WalletsActivity.java
@@ -52,8 +52,7 @@ public class WalletsActivity extends BaseActivity implements
     private WalletsAdapter adapter;
 
     private boolean walletChange = false;
-    private boolean isSetDefault;
-    private boolean isNewWalletCreated;
+    private boolean requiresHomeRefresh;
     private NetworkInfo networkInfo;
 
     @Override
@@ -64,6 +63,7 @@ public class WalletsActivity extends BaseActivity implements
         toolbar();
         setTitle(R.string.empty);
         initViews();
+        requiresHomeRefresh = false;
     }
 
     @Override
@@ -180,8 +180,7 @@ public class WalletsActivity extends BaseActivity implements
                 //set as isSetDefault
                 Wallet importedWallet = data.getParcelableExtra(C.Key.WALLET);
                 if (importedWallet != null) {
-                    isSetDefault = true;
-                    walletChange = true;
+                    requiresHomeRefresh = true;
                     viewModel.setDefaultWallet(importedWallet);
                 }
             }
@@ -238,9 +237,9 @@ public class WalletsActivity extends BaseActivity implements
         }
 
         adapter.setDefaultWallet(wallet);
-
-        if (isSetDefault && !isNewWalletCreated)
+        if (requiresHomeRefresh)
         {
+            requiresHomeRefresh = false;
             viewModel.showHome(this);
         }
     }
@@ -287,10 +286,9 @@ public class WalletsActivity extends BaseActivity implements
     }
 
     private void onSetWalletDefault(Wallet wallet) {
+        requiresHomeRefresh = true;
         viewModel.setDefaultWallet(wallet);
-        isSetDefault = true;
         walletChange = true;
-        isNewWalletCreated = false;
     }
 
     private void hideDialog() {

--- a/app/src/main/java/io/stormbird/wallet/viewmodel/SplashViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/SplashViewModel.java
@@ -76,7 +76,6 @@ public class SplashViewModel extends ViewModel {
                 .create()
                 .subscribe(account -> {
                     fetchWallets();
-                    createWallet.postValue(account);
                 }, this::onError);
     }
 


### PR DESCRIPTION
Fixes a reported issue where sometimes no Ethereum main net balance card appears when first creating a wallet, until another refresh is done.

Was caused by a race condition as the main page would be started twice - a background thread fetching the balance would be interrupted by the second instance of the main page, leading to the tokens service getting refreshed part way through clashing with the return from the second instance of the balance update.