### PR TITLE
Fix issue where sometimes the webview doesn't display

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Ticket.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v7.widget.AppCompatRadioButton;
+import android.util.Base64;
 import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -30,6 +31,7 @@ import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.*;
@@ -391,7 +393,8 @@ public class Ticket extends Token implements Parcelable
         String viewData = tokenView.injectWeb3TokenInit(ctx, view, attrs.toString());
         viewData = tokenView.injectStyleData(viewData, style); //style injected last so it comes first
 
-        tokenView.loadData(viewData, "text/html", "utf-8");
+        String base64 = android.util.Base64.encodeToString(viewData.getBytes(Charset.forName("UTF-8")), Base64.DEFAULT);
+        tokenView.loadData(base64, "text/html; charset=utf-8", "base64");
     }
 
     private void onError(Throwable throwable, Context ctx, AssetDefinitionService assetService, StringBuilder attrs, ProgressBar waitSpinner, Web3TokenView tokenView, boolean iconified)

--- a/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
+import android.util.Base64;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -41,6 +42,8 @@ import javax.inject.Inject;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.SignatureException;
 import java.util.HashMap;
 import java.util.List;
@@ -111,7 +114,8 @@ public class FunctionActivity extends BaseActivity implements View.OnClickListen
             injectedView = tokenView.injectJSAtEnd(injectedView, magicValues);
             if (action.style != null) injectedView = tokenView.injectStyleData(injectedView, action.style);
 
-            tokenView.loadData(injectedView, "text/html", "utf-8");
+            String base64 = Base64.encodeToString(injectedView.getBytes(Charset.forName("UTF-8")), Base64.DEFAULT);
+            tokenView.loadData(base64, "text/html; charset=utf-8", "base64");
         }
         catch (Exception e)
         {

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenFunctionViewHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenFunctionViewHolder.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RawRes;
+import android.util.Base64;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +28,7 @@ import org.web3j.crypto.Sign;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.security.SignatureException;
 import java.util.function.Function;
 
@@ -72,7 +74,8 @@ public class TokenFunctionViewHolder extends BinderViewHolder<String> implements
             String injectedView = tokenView.injectWeb3TokenInit(getContext(), view, "");
             String style = assetDefinitionService.getTokenView(token.tokenInfo.chainId, token.getAddress(), "style");
             injectedView = tokenView.injectStyleData(injectedView, style);
-            tokenView.loadData(injectedView, "text/html", "utf-8");
+            String base64 = Base64.encodeToString(injectedView.getBytes(Charset.forName("UTF-8")), Base64.DEFAULT);
+            tokenView.loadData(base64, "text/html; charset=utf-8", "base64");
         }
         catch (Exception ex)
         {

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenscriptViewHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenscriptViewHolder.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatRadioButton;
+import android.util.Base64;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
@@ -25,6 +26,7 @@ import io.stormbird.wallet.web3.entity.Address;
 import io.stormbird.wallet.web3.entity.PageReadyCallback;
 
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.text.ParseException;
 
 import static io.stormbird.wallet.C.Key.TICKET;
@@ -97,7 +99,8 @@ public class TokenscriptViewHolder extends BinderViewHolder<TicketRange> impleme
         String viewData = tokenView.injectWeb3TokenInit(getContext(), view, tokenAttrs);
         viewData = tokenView.injectStyleData(viewData, style); //style injected last so it comes first
 
-        tokenView.loadData(viewData, "text/html", "utf-8");
+        String base64 = Base64.encodeToString(viewData.getBytes(Charset.forName("UTF-8")), Base64.DEFAULT);
+        tokenView.loadData(base64, "text/html; charset=utf-8", "base64");
 
         if (iconified)
         {

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -256,8 +256,8 @@
             android:gravity="center"
             android:visibility="gone"
             android:orientation="vertical"
-            android:paddingStart="20dp"
-            android:paddingEnd="20dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
             android:paddingTop="10dp"
             android:paddingBottom="10dp">
 

--- a/app/src/main/res/layout/item_tokenscript.xml
+++ b/app/src/main/res/layout/item_tokenscript.xml
@@ -36,7 +36,7 @@
             android:layout_margin="5dp"
             android:gravity="center"
             android:orientation="vertical"
-            android:padding="10dp">
+            android:padding="5dp">
 
             <io.stormbird.wallet.web3.Web3TokenView
                 android:id="@+id/web3_tokenview"


### PR DESCRIPTION
This PR fixes an issue where Android had deprecated or changed the internal code to load data directly into the webview. The issue manifests by sometimes seeing 'no data' in the function webview, especially in newer phones using Android 9. It is most likely due to certain data sequences not rendering correctly and triggering an exception.