### PR TITLE
Fix issue reported from crashlytics

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/ImportKeystoreFragment.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportKeystoreFragment.java
@@ -111,7 +111,7 @@ public class ImportKeystoreFragment extends Fragment implements View.OnClickList
 
     public boolean backPressed()
     {
-        if (password.getVisibility() == View.VISIBLE)
+        if (password != null && password.getVisibility() == View.VISIBLE)
         {
             keystore.setVisibility(View.VISIBLE);
             password.setVisibility(View.GONE);
@@ -188,12 +188,18 @@ public class ImportKeystoreFragment extends Fragment implements View.OnClickList
 
     public void reset()
     {
-        password.setText("");
-        password.setVisibility(View.GONE);
+        if (password != null)
+        {
+            password.setText("");
+            password.setVisibility(View.GONE);
+            passwordText.setVisibility(View.GONE);
+        }
+        if (keystore != null)
+        {
+            keystore.setVisibility(View.VISIBLE);
+            keystore.setError(null);
+            keystore.setText("");
+        }
         updateButtonState(false);
-        keystore.setVisibility(View.VISIBLE);
-        keystore.setError(null);
-        keystore.setText("");
-        passwordText.setVisibility(View.GONE);
     }
 }


### PR DESCRIPTION
Fix issue which triggered Crashlytics. User probably pressed back after screen was restored from sleep before it could re-init.

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.View.getVisibility()' on a null object reference
       at io.stormbird.wallet.ui.ImportKeystoreFragment.backPressed + 114(ImportKeystoreFragment.java:114)
       at io.stormbird.wallet.ui.ImportWalletActivity.onOptionsItemSelected + 244(ImportWalletActivity.java:244)
       at android.app.Activity.onMenuItemSelected + 3584(Activity.java:3584)
       at android.support.v4.app.FragmentActivity.onMenuItemSelected + 436(FragmentActivity.java:436)
       at android.support.v7.app.AppCompatActivity.onMenuItemSelected + 196(AppCompatActivity.java:196)
       at android.support.v7.view.WindowCallbackWrapper.onMenuItemSelected + 109(WindowCallbackWrapper.java:109)
       at android.support.v7.view.WindowCallbackWrapper.onMenuItemSelected + 109(WindowCallbackWrapper.java:109)
       at android.support.v7.widget.ToolbarWidgetWrapper$1.onClick + 188(ToolbarWidgetWrapper.java:188)
       at android.view.View.performClick + 6935(View.java:6935)
       at android.view.View$PerformClick.run + 26211(View.java:26211)
       at android.os.Handler.handleCallback + 790(Handler.java:790)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 164(Looper.java:164)
       at android.app.ActivityThread.main + 7000(ActivityThread.java:7000)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 441(RuntimeInit.java:441)
       at com.android.internal.os.ZygoteInit.main + 1408(ZygoteInit.java:1408)
```
