### PR TITLE
Fix import token using gas

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/ImportTokenActivity.java
@@ -554,7 +554,22 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         }
         else
         {
-            viewModel.performImport();
+            //needs gas, so require auth first
+            SignAuthenticationCallback cb = new SignAuthenticationCallback()
+            {
+                @Override
+                public void GotAuthorisation(boolean gotAuth)
+                {
+                    viewModel.performImport();
+                }
+
+                @Override
+                public void setupAuthenticationCallback(PinAuthenticationCallbackInterface authCallback)
+                {
+                    authInterface = authCallback;
+                }
+            };
+            viewModel.getAuthorisation(this, cb);
         }
     }
 


### PR DESCRIPTION
Ensure we have auth to use gas to import tokens from magiclink. 

The PR fixes an issue where authentication wasn't obtained before attempting to use gas, so the transaction sign errored.