### PR TITLE
Fix token detection when reading constructor bytes that have a proxy contract inside it

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -57,7 +57,6 @@ public class FetchTransactionsInteract {
     {
         switch (type)
         {
-            default:
             case ERC20:
             case ERC721:
                 return Single.fromCallable(() -> type);
@@ -66,6 +65,10 @@ public class FetchTransactionsInteract {
                 transactionRepository.queryInterfaceSpec(tokenInfo.address, tokenInfo)
                         .subscribe(actualType -> TokensService.setInterfaceSpec(tokenInfo.chainId, tokenInfo.address, actualType)).isDisposed();
                 return Single.fromCallable(() -> type);
+            default:
+                //Token wasn't any of the easily determinable ones, use constructor to analyse
+                return tokenRepository.resolveProxyAddress(tokenInfo) //resolve proxy address to find base constructor and analyse
+                        .flatMap(address -> transactionRepository.queryInterfaceSpec(address, tokenInfo));
         }
     }
 

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -63,6 +63,7 @@ public class FetchTransactionsInteract {
             case ERC875:
                 //requires additional handling to determine if it's Legacy type, but safe to return ERC875 for now:
                 transactionRepository.queryInterfaceSpec(tokenInfo.address, tokenInfo)
+                        .subscribeOn(Schedulers.io())
                         .subscribe(actualType -> TokensService.setInterfaceSpec(tokenInfo.chainId, tokenInfo.address, actualType)).isDisposed();
                 return Single.fromCallable(() -> type);
             default:

--- a/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/io/stormbird/wallet/interact/FetchTransactionsInteract.java
@@ -1,5 +1,6 @@
 package io.stormbird.wallet.interact;
 
+import io.reactivex.SingleSource;
 import io.stormbird.wallet.entity.*;
 import io.stormbird.wallet.repository.TokenRepositoryType;
 import io.stormbird.wallet.repository.TransactionRepositoryType;
@@ -47,8 +48,25 @@ public class FetchTransactionsInteract {
 
     public Single<ContractType> queryInterfaceSpec(TokenInfo tokenInfo)
     {
-        return  tokenRepository.resolveProxyAddress(tokenInfo)
-                .flatMap(address -> transactionRepository.queryInterfaceSpec(address, tokenInfo));
+        //can resolve erc20, erc721 and erc875 from a getbalance check and look at decimals. Otherwise try more esoteric
+        return tokenRepository.determineCommonType(tokenInfo)
+                .flatMap(type -> additionalHandling(type, tokenInfo));
+    }
+
+    private Single<ContractType> additionalHandling(ContractType type, TokenInfo tokenInfo)
+    {
+        switch (type)
+        {
+            default:
+            case ERC20:
+            case ERC721:
+                return Single.fromCallable(() -> type);
+            case ERC875:
+                //requires additional handling to determine if it's Legacy type, but safe to return ERC875 for now:
+                transactionRepository.queryInterfaceSpec(tokenInfo.address, tokenInfo)
+                        .subscribe(actualType -> TokensService.setInterfaceSpec(tokenInfo.chainId, tokenInfo.address, actualType)).isDisposed();
+                return Single.fromCallable(() -> type);
+        }
     }
 
     public Transaction fetchCached(String walletAddress, String hash)

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -1225,11 +1225,17 @@ public class TokenRepository implements TokenRepositoryType {
                 if (responseValue != null)
                 {
                     List<Type> response = FunctionReturnDecoder.decode(responseValue, function.getOutputParameters());
-                    if (response.size() == 1) returnType = ContractType.ERC20;
-                    else if (response.size() > 1)
+                    if (response.size() > 0)
                     {
                         BigDecimal balance = new BigDecimal(((Uint256) response.get(0)).getValue());
-                        if (balance.equals(BigDecimal.valueOf(32)) && responseValue.length() > 66) returnType = ContractType.ERC875;
+                        if (balance.equals(BigDecimal.valueOf(0x20)) && responseValue.length() > 66)
+                        {
+                            returnType = ContractType.ERC875;
+                        }
+                        else
+                        {
+                            returnType = ContractType.ERC20;
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepositoryType.java
@@ -37,5 +37,6 @@ public interface TokenRepositoryType {
 
     Disposable updateBlockRead(Token token, Wallet wallet);
     Single<String> resolveProxyAddress(TokenInfo tokenInfo);
+    Single<ContractType> determineCommonType(TokenInfo tokenInfo);
     Single<Token[]> addERC20(Wallet wallet, Token[] tokens);
 }


### PR DESCRIPTION
Was failing previously due to Token contract with unassigned proxy.

Now uses the following heuristic:

Call getBalance.
- result is a single integer: Assume ERC20 (If ERC721 then OpenSea call will override this).
- result is an array declaration with 1 or more entries: Assume ERC875, and set off thread to determine if ERC875 contract is legacy.
- result is neither of these: Contract doesn't contain any balance query; unknown contract attempt to query constructor.
