### PR TITLE
Fix crash issue when Script doesn't contain holding name

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
+++ b/app/src/main/java/io/stormbird/wallet/service/AssetDefinitionService.java
@@ -922,8 +922,11 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                     if (tokenDef != null && tokenDef.isDebug()) token.hasDebugTokenscript = true;
                     token.hasTokenScript = true;
                     TokenDefinition td = getAssetDefinition(networkId, address);
-                    ContractInfo cInfo = td.contracts.get(td.holdingToken);
-                    if (cInfo != null) checkCorrectInterface(token, cInfo.contractInterface);
+                    if (td != null)
+                    {
+                        ContractInfo cInfo = td.contracts.get(td.holdingToken);
+                        if (cInfo != null) checkCorrectInterface(token, cInfo.contractInterface);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reported from crashlytics:

```
Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'java.util.Map io.stormbird.token.tools.TokenDefinition.contracts' on a null object reference
       at io.stormbird.wallet.service.AssetDefinitionService.checkTokenscriptEnabledTokens + 925(AssetDefinitionService.java:925)
       at io.stormbird.wallet.viewmodel.WalletViewModel.startBalanceUpdate + 211(WalletViewModel.java:211)
       at io.stormbird.wallet.viewmodel.WalletViewModel.lambda$AbWJsNwcRVsHLIMMLcXS3YWHA88()
       at io.stormbird.wallet.viewmodel.-$$Lambda$WalletViewModel$AbWJsNwcRVsHLIMMLcXS3YWHA88.run + 2(:2)
       at io.reactivex.internal.observers.LambdaObserver.onComplete + 92(LambdaObserver.java:92)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.checkTerminated + 287(ObservableObserveOn.java:287)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal + 193(ObservableObserveOn.java:193)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run + 255(ObservableObserveOn.java:255)
       at io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run + 124(HandlerScheduler.java:124)
```