### PR TITLE
Ensure complete wallet object is passed

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/viewmodel/AssetDisplayViewModel.java
+++ b/app/src/main/java/io/stormbird/wallet/viewmodel/AssetDisplayViewModel.java
@@ -178,7 +178,7 @@ public class AssetDisplayViewModel extends BaseViewModel
 
     public void sellTicketRouter(Context context, Token token, String tokenIds) {
         Intent intent = new Intent(context, SellDetailActivity.class);
-        intent.putExtra(WALLET, new Wallet(token.getWallet()));
+        intent.putExtra(WALLET, defaultWallet.getValue());
         intent.putExtra(TICKET, token);
         intent.putExtra(EXTRA_TOKENID_LIST, tokenIds);
         intent.putExtra(EXTRA_STATE, SellDetailActivity.SET_A_PRICE);
@@ -207,7 +207,7 @@ public class AssetDisplayViewModel extends BaseViewModel
     public void showTransferToken(Context ctx, Token token, List<BigInteger> selection)
     {
         Intent intent = new Intent(ctx, TransferTicketDetailActivity.class);
-        intent.putExtra(WALLET, new Wallet(token.getWallet()));
+        intent.putExtra(WALLET, defaultWallet.getValue());
         intent.putExtra(TICKET, token);
 
         if (token instanceof ERC721Token)


### PR DESCRIPTION
Issue discovered during testing. Using the 'long press' method on the token view, send/transfer on the bottom bar appear. When you click on these we need to pass the whole wallet object to the next activity so that any signing works.

Note: depending on which wallet type you have, signing works differently - HD Key, Keystore, Keystore legacy, Watch. This is why the whole wallet object was passed. This bug was in since the HD Key overhaul, but only affects ERC875, and only when you use the long press to pop up the send/transfer buttons.