### PR TITLE
Fix token titles

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/Token.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/Token.java
@@ -3,6 +3,7 @@ package io.stormbird.wallet.entity;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
 import android.view.View;
 import io.stormbird.token.entity.TicketRange;
 import io.stormbird.wallet.R;
@@ -251,6 +252,18 @@ public class Token implements Parcelable
             holder.contractSeparator.setVisibility(View.VISIBLE);
             holder.contractType.setText(R.string.erc20);
             holder.layoutValueDetails.setVisibility(View.GONE);
+
+            //For tokens with a long balance, wrap the name onto a new line so as not to appear cluttered
+            if (value.length() > 8)
+            {
+                holder.symbol.setText("");
+                String symbolStr = tokenInfo.symbol != null ? tokenInfo.symbol.toUpperCase() : "";
+                holder.symbolAux.setVisibility(View.VISIBLE);
+                holder.symbolAux.setText(TextUtils.isEmpty(tokenInfo.name)
+                        ? symbolStr
+                        : getFullName());
+            }
+
             //currently we don't collect the value of ERC20 tokens
             //TODO: get ticker for ERC20 tokens
         }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -873,7 +873,7 @@ public class TokenRepository implements TokenRepositoryType {
         StringBuilder sb = new StringBuilder();
         for (char ch : name.toCharArray())
         {
-            if (Character.isLetterOrDigit(ch) || Character.isSpaceChar(ch) || Character.isWhitespace(ch))
+            if (ch >= 0x20 && ch <= 0x7E) //valid ASCII character
             {
                 sb.append(ch);
             }

--- a/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
+++ b/app/src/main/java/io/stormbird/wallet/repository/TokenRepository.java
@@ -860,10 +860,26 @@ public class TokenRepository implements TokenRepositoryType {
                     data = Arrays.copyOfRange(data, 0, index + 1);
                 }
                 name = new String(data, "UTF-8");
+                //now filter out any 'bad' chars
+                name = filterAscii(name);
             }
         }
 
         return name;
+    }
+
+    private String filterAscii(String name)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (char ch : name.toCharArray())
+        {
+            if (Character.isLetterOrDigit(ch) || Character.isSpaceChar(ch) || Character.isWhitespace(ch))
+            {
+                sb.append(ch);
+            }
+        }
+
+        return sb.toString();
     }
 
     private String getName(String address, NetworkInfo network) throws Exception {

--- a/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/widget/holder/TokenHolder.java
@@ -40,6 +40,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
     public static final String EMPTY_BALANCE = "\u2014\u2014";
 
     public final TextView symbol;
+    public final TextView symbolAux;
     public final TextView balanceEth;
     public final TextView balanceCurrency;
     public final ImageView icon;
@@ -68,6 +69,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
 
         icon = findViewById(R.id.icon);
         symbol = findViewById(R.id.symbol);
+        symbolAux = findViewById(R.id.symbolAux);
         balanceEth = findViewById(R.id.balance_eth);
         balanceCurrency = findViewById(R.id.balance_currency);
         text24Hours = findViewById(R.id.text_24_hrs);
@@ -100,6 +102,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
 
         try
         {
+            symbolAux.setVisibility(View.GONE);
             tokenLayout.setBackgroundResource(R.drawable.background_marketplace_event);
             blockchain.setText(getString(R.string.blockchain, token.getNetworkName()));
             chainName.setText(token.getNetworkName());

--- a/app/src/main/res/layout/item_token.xml
+++ b/app/src/main/res/layout/item_token.xml
@@ -88,9 +88,9 @@
                 android:id="@+id/balance_eth"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="2dp"
+                android:layout_marginEnd="2dp"
                 android:fontFamily="@font/font_light"
-                android:text="8888888"
+                android:text="0"
                 android:textColor="@color/text_black"
                 android:textSize="21sp" />
 
@@ -98,7 +98,7 @@
                 android:id="@+id/balance_eth_pending"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_toRightOf="@+id/balance_eth"
+                android:layout_toEndOf="@+id/balance_eth"
                 android:layout_alignParentTop="true"
                 android:fontFamily="@font/font_light"
                 android:text=""
@@ -109,10 +109,22 @@
                 android:id="@+id/symbol"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_toRightOf="@+id/balance_eth_pending"
+                android:layout_toEndOf="@+id/balance_eth_pending"
                 android:layout_marginStart="3dp"
                 android:fontFamily="@font/font_light"
                 android:text="@string/ethereum"
+                android:textColor="@color/text_black"
+                android:textSize="21sp" />
+
+            <TextView
+                android:id="@+id/symbolAux"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/balance_eth"
+                android:layout_marginTop="1dp"
+                android:fontFamily="@font/font_light"
+                android:lines="1"
+                android:visibility="gone"
                 android:textColor="@color/text_black"
                 android:textSize="21sp" />
 
@@ -155,7 +167,7 @@
                 android:id="@+id/issuer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="2dp"
+                android:layout_marginEnd="2dp"
                 android:fontFamily="@font/font_semibold"
                 android:text="@string/ethereum"
                 android:textColor="@color/colorPrimaryDark"


### PR DESCRIPTION
- Strip garbage characters from token name if name specified in bytes type rather than string type.
- If token has a very long balance (eg 19999944475) then split the name onto the next line to avoid display appearing cluttered.

(Both points noticed when handling a token with some bad characters in the name and a very large balance, FYI: Rinkeby 0x8D8Df3Ec3ca5D0b23F465754830B866238c43B7e).