### PR TITLE
Fix Network Select when Adding duplicate token on different networks

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/AddTokenActivity.java
@@ -280,7 +280,7 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
             lastCheck = address;
             chainName.setVisibility(View.GONE);
             showProgress(true);
-            viewModel.testNetworks(address);
+            viewModel.testNetworks(address, networkInfo);
         }
     }
 
@@ -357,7 +357,11 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == InputAddressView.BARCODE_READER_REQUEST_CODE) {
+        if (requestCode == C.REQUEST_SELECT_NETWORK && resultCode == RESULT_OK) {
+            int networkId = data.getIntExtra(C.EXTRA_CHAIN_ID, 1);
+            setupNetwork(networkId);
+        }
+        else if (requestCode == InputAddressView.BARCODE_READER_REQUEST_CODE) {
             switch (resultCode)
             {
                 case FullScannerFragment.SUCCESS:


### PR DESCRIPTION
Ensure selected network is checked first when adding token.

Previously the app just ignores the user's hint. Normally it doesn't matter because the scanner will find your token but if you have token contracts on different networks from the same account they can be at the same address. This made it impossible to add the token on the different network - it would always discover the token on eg mainnet, before the one on xDAI etc.