### PR TITLE
Add TokenScript Element error reporting

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
@@ -336,8 +336,8 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         else if (valueFromInput.equals("__searching")) //second pass through, still searching - error.
         {
             //display error, basic script error reporting
-            String details = attr.name;
-            if (attr.id != null && attr.id.length() > 0) details += " (" + attr.id + ")";
+            String attrDetails = e.ref + " (" + attr.name + ")";
+            String details = getString(R.string.tokenscript_element_not_present, attrDetails);
             tokenscriptError(details);
             resolved = false;
         }

--- a/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
+++ b/app/src/main/java/io/stormbird/wallet/ui/FunctionActivity.java
@@ -335,7 +335,10 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         }
         else if (valueFromInput.equals("__searching")) //second pass through, still searching - error.
         {
-            //display error
+            //display error, basic script error reporting
+            String details = attr.name;
+            if (attr.id != null && attr.id.length() > 0) details += " (" + attr.id + ")";
+            tokenscriptError(details);
             resolved = false;
         }
         else
@@ -489,6 +492,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
 
     private void errorInvalidAddress(String address)
     {
+        if (alertDialog != null && alertDialog.isShowing()) alertDialog.dismiss();
         alertDialog = new AWalletAlertDialog(this);
         alertDialog.setIcon(AWalletAlertDialog.ERROR);
         alertDialog.setTitle(R.string.error_invalid_address);
@@ -500,10 +504,23 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
 
     private void errorInsufficientFunds(Token currency)
     {
+        if (alertDialog != null && alertDialog.isShowing()) alertDialog.dismiss();
         alertDialog = new AWalletAlertDialog(this);
         alertDialog.setIcon(AWalletAlertDialog.ERROR);
         alertDialog.setTitle(R.string.error_insufficient_funds);
         alertDialog.setMessage(getString(R.string.current_funds, currency.getCorrectedBalance(currency.tokenInfo.decimals), currency.tokenInfo.symbol));
+        alertDialog.setButtonText(R.string.button_ok);
+        alertDialog.setButtonListener(v ->alertDialog.dismiss());
+        alertDialog.show();
+    }
+
+    private void tokenscriptError(String elementName)
+    {
+        if (alertDialog != null && alertDialog.isShowing()) alertDialog.dismiss();
+        alertDialog = new AWalletAlertDialog(this);
+        alertDialog.setIcon(AWalletAlertDialog.ERROR);
+        alertDialog.setTitle(R.string.tokenscript_error);
+        alertDialog.setMessage(getString(R.string.tokenscript_error_detail, elementName));
         alertDialog.setButtonText(R.string.button_ok);
         alertDialog.setButtonListener(v ->alertDialog.dismiss());
         alertDialog.show();
@@ -517,7 +534,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
                 html -> {
                     StringBuilder sb = new StringBuilder();
                     for (char ch : html.toCharArray()) if (ch!='\"') sb.append(ch);
-                    args.put(value, sb.toString());
+                    if (!html.equals("null")) args.put(value, sb.toString());
                     completeTokenscriptFunction(actionMethod);
                 }
         );

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -194,4 +194,5 @@
     <string name="action_receive">Receive</string>
     <string name="tokenscript_error">TokenScript Element Error</string>
     <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
+    <string name="tokenscript_element_not_present">function input \'%1$s\' not found in HTML elements.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -192,4 +192,6 @@
     <string name="no_fingerprint_enrolled">No fingerprints Enrolled. Use PIN</string>
     <string name="cannot_process_fingerprint">Unable to process fingerprint. Use PIN</string>
     <string name="action_receive">Receive</string>
+    <string name="tokenscript_error">TokenScript Element Error</string>
+    <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -458,4 +458,6 @@
     <string name="no_fingerprint_enrolled">No fingerprints Enrolled. Use PIN</string>
     <string name="cannot_process_fingerprint">Unable to process fingerprint. Use PIN</string>
     <string name="action_receive">Receive</string>
+    <string name="tokenscript_error">TokenScript Element Error</string>
+    <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -460,4 +460,5 @@
     <string name="action_receive">Receive</string>
     <string name="tokenscript_error">TokenScript Element Error</string>
     <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
+    <string name="tokenscript_element_not_present">function input \'%1$s\' not found in HTML elements.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,4 +596,5 @@
     <string name="action_receive">Receive</string>
     <string name="tokenscript_error">TokenScript Element Error</string>
     <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
+    <string name="tokenscript_element_not_present">function input \'%1$s\' not found in HTML elements.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -594,4 +594,6 @@
     <string name="no_fingerprint_enrolled">No fingerprints Enrolled. Use PIN</string>
     <string name="cannot_process_fingerprint">Unable to process fingerprint. Use PIN</string>
     <string name="action_receive">Receive</string>
+    <string name="tokenscript_error">TokenScript Element Error</string>
+    <string name="tokenscript_error_detail">Error in TokenScript element: %1$s</string>
 </resources>

--- a/lib/src/main/java/io/stormbird/token/entity/AttributeType.java
+++ b/lib/src/main/java/io/stormbird/token/entity/AttributeType.java
@@ -39,6 +39,7 @@ public class AttributeType {
     {
         definition = def;
         id = attr.getAttribute("id");
+        as = As.Unsigned; //default value
         try {
             switch (attr.getAttribute("syntax")) { // We don't validate syntax here; schema does it.
                 case "1.3.6.1.4.1.1466.115.121.1.6":
@@ -114,6 +115,7 @@ public class AttributeType {
             if (node.getNodeType() == Node.ELEMENT_NODE)
             {
                 Element resolve = (Element) node;
+                setAs(definition.parseAs(resolve));
                 switch (node.getLocalName())
                 {
                     case "ethereum":


### PR DESCRIPTION
Add some basic TokenScript error handling for developers working on their scripts.
In particular this one warns the dev that the user input element they defined in the function isn't present as an HTML element.

Also fixes Crashlytics report:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Enum.ordinal()' on a null object reference
       at io.stormbird.wallet.ui.FunctionActivity.checkTokenScriptElement + 317(FunctionActivity.java:317)
       at io.stormbird.wallet.ui.FunctionActivity.checkFunctionArgs + 297(FunctionActivity.java:297)
       at io.stormbird.wallet.ui.FunctionActivity.handleConfirmClick + 255(FunctionActivity.java:255)
       at io.stormbird.wallet.ui.FunctionActivity.handleTokenScriptFunction + 642(FunctionActivity.java:642)
       at io.stormbird.wallet.widget.FunctionButtonBar.handleUseClick + 187(FunctionButtonBar.java:187)
       at io.stormbird.wallet.widget.FunctionButtonBar.onClick + 147(FunctionButtonBar.java:147)
       at android.view.View.performClick + 6891(View.java:6891)
       at android.widget.TextView.performClick + 12651(TextView.java:12651)
       at android.view.View$PerformClick.run + 26083(View.java:26083)
       at android.os.Handler.handleCallback + 789(Handler.java:789)
       at android.os.Handler.dispatchMessage + 98(Handler.java:98)
```

In a satisfying manner - in future the handling will catch the script mistake and help direct the developer to the right place for a fix.