### PR TITLE
Truncate huge TokenId

### DIFF
--- a/app/src/main/java/io/stormbird/wallet/entity/tokenscript/TokenscriptFunction.java
+++ b/app/src/main/java/io/stormbird/wallet/entity/tokenscript/TokenscriptFunction.java
@@ -36,6 +36,9 @@ public abstract class TokenscriptFunction
 {
     public Function generateTransactionFunction(String walletAddr, BigInteger tokenId, TokenDefinition definition, FunctionDefinition function, AttributeInterface attrIf)
     {
+        //pre-parse tokenId.
+        if (tokenId.bitCount() > 256) tokenId = tokenId.or(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE)); //truncate tokenId too large
+
         List<Type> params = new ArrayList<Type>();
         List<TypeReference<?>> returnTypes = new ArrayList<TypeReference<?>>();
         for (MethodArg arg : function.parameters)

--- a/dmz/src/main/java/io/stormbird/token/web/Ethereum/TokenscriptFunction.java
+++ b/dmz/src/main/java/io/stormbird/token/web/Ethereum/TokenscriptFunction.java
@@ -36,6 +36,9 @@ public abstract class TokenscriptFunction
 {
     public Function generateTransactionFunction(String walletAddr, BigInteger tokenId, TokenDefinition definition, FunctionDefinition function, AttributeInterface attrIf)
     {
+        //pre-parse tokenId.
+        if (tokenId.bitCount() > 256) tokenId = tokenId.or(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE)); //truncate tokenId too large
+
         List<Type> params = new ArrayList<Type>();
         List<TypeReference<?>> returnTypes = new ArrayList<TypeReference<?>>();
         for (MethodArg arg : function.parameters)


### PR DESCRIPTION
Ensure tokenId > 256 bits doesn't trigger an exception. This would come from a bad tokenscript, since any tokenId pulled from a token would fit into 256 bits.

TODO: Add a user warning once #892 has been merged.

Fixes Crashlytics:

```
Caused by java.lang.UnsupportedOperationException: Bitsize must be 8 bit aligned, and in range 0 < bitSize <= 256
       at org.web3j.abi.datatypes.IntType.<init> + 13(IntType.java:13)
       at org.web3j.abi.datatypes.Uint.<init> + 17(Uint.java:17)
       at org.web3j.abi.datatypes.Uint.<init> + 21(Uint.java:21)
       at org.web3j.abi.datatypes.generated.Uint256.<init> + 16(Uint256.java:16)
       at io.stormbird.wallet.entity.tokenscript.TokenscriptFunction.generateTransactionFunction + 50(TokenscriptFunction.java:50)
       at io.stormbird.wallet.entity.tokenscript.TokenscriptFunction.lambda$fetchResultFromEthereum$0$TokenscriptFunction + 204(TokenscriptFunction.java:204)
       at io.stormbird.wallet.entity.tokenscript.-$$Lambda$TokenscriptFunction$GbRUJiaY0nMEg-C7zK_lPvvheME.call + 12(:12)
       at io.reactivex.internal.operators.observable.ObservableFromCallable.subscribeActual + 43(ObservableFromCallable.java:43)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableConcatMap$SourceObserver.drain + 223(ObservableConcatMap.java:223)
       at io.reactivex.internal.operators.observable.ObservableConcatMap$SourceObserver.onSubscribe + 103(ObservableConcatMap.java:103)
       at io.reactivex.internal.observers.BasicFuseableObserver.onSubscribe + 66(BasicFuseableObserver.java:66)
       at io.reactivex.internal.observers.BasicFuseableObserver.onSubscribe + 66(BasicFuseableObserver.java:66)
       at io.reactivex.internal.operators.observable.ObservableFromIterable.subscribeActual + 55(ObservableFromIterable.java:55)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableFilter.subscribeActual + 30(ObservableFilter.java:30)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableConcatMap.subscribeActual + 53(ObservableConcatMap.java:53)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
```