### PR TITLE
Implement EIP155 signing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
+import static com.alphawallet.app.service.KeyService.FAILED_SIGNATURE;
 
 public class TransactionRepository implements TransactionRepositoryType {
 
@@ -208,7 +209,7 @@ public class TransactionRepository implements TransactionRepositoryType {
 	{
 		return Single.fromCallable(() -> {
 			Sign.SignatureData sigData = sigFromByteArray(signatureBytes);
-			if (sigData == null) return "0000".getBytes();
+			if (sigData == null) return FAILED_SIGNATURE.getBytes();
 			return encode(rtx, sigData);
 		});
 	}

--- a/app/src/main/java/com/alphawallet/app/service/KeyService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeyService.java
@@ -54,7 +54,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
     private static final String PADDING = KeyProperties.ENCRYPTION_PADDING_NONE;
     private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
     private static final int AUTHENTICATION_DURATION_SECONDS = 30;
-    private static final String FAILED_SIGNATURE = "00000000000000000000000000000000000000000000000000000000000000000";
+    public  static final String FAILED_SIGNATURE = "00000000000000000000000000000000000000000000000000000000000000000";
 
     //This value determines the time interval between the user swiping away the backup warning notice and it re-appearing
     public static final int TIME_BETWEEN_BACKUP_WARNING_MILLIS = 1000 * 60 * 60 * 24 * 30; //30 days //1000 * 60 * 3; //3 minutes for testing

--- a/app/src/main/java/com/alphawallet/app/service/KeystoreAccountService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeystoreAccountService.java
@@ -218,14 +218,29 @@ public class KeystoreAccountService implements AccountKeystoreService
                     dataStr
                     );
 
-            byte chainIdByte = (byte)(chainId & 0xFF);
+            //TODO: Remove this branch once web3j 4.5.0 is released which upgrades chainId from 1 byte to 8 bytes to handle chainId > 255
+            if (chainId > 255)
+            {
+                //old code to be removed
+                byte[] signData = TransactionEncoder.encode(rtx);
+                byte[] signatureBytes = keyService.signData(signer, signData);
+                Sign.SignatureData sigData = sigFromByteArray(signatureBytes);
+                if (sigData == null) return FAILED_SIGNATURE.getBytes();
+                else return encode(rtx, sigData);
+            }
+            else
+            {
+                //This is the code to use once web3j 4.5.0 is released and the project is upgraded to use it.
+                //TODO: remove this line
+                byte chainIdByte = (byte) (chainId & 0xFF);
 
-            byte[] signData = TransactionEncoder.encode(rtx, chainIdByte);
-            byte[] signatureBytes = keyService.signData(signer, signData);
-            Sign.SignatureData sigData = sigFromByteArray(signatureBytes);
-            if (sigData == null) return FAILED_SIGNATURE.getBytes();
-            Sign.SignatureData eip155SignatureData = TransactionEncoder.createEip155SignatureData(sigData, chainIdByte);
-            return encode(rtx, eip155SignatureData);
+                byte[] signData = TransactionEncoder.encode(rtx, chainIdByte); //TODO: pass in chainId directly
+                byte[] signatureBytes = keyService.signData(signer, signData);
+                Sign.SignatureData sigData = sigFromByteArray(signatureBytes);
+                if (sigData == null) return FAILED_SIGNATURE.getBytes();
+                Sign.SignatureData eip155SignatureData = TransactionEncoder.createEip155SignatureData(sigData, chainIdByte); //TODO: pass in chainId directly
+                return encode(rtx, eip155SignatureData);
+            }
         })
         .subscribeOn(Schedulers.io());
     }


### PR DESCRIPTION
Implement EIP155 signing to ensure sigs from one chain can't be used in another.
TODO: Fully implement EIP155 when web3j 4.5.0 for Android is published (chainId is upgraded from 1 byte to 8 bytes in order to implement chainId's greater than 255).

@hboon Recall our conversation about EIP155 usage in Android - in summary previously chainId wasn't used in the signature. The current implementation in web3j 4.2.0 treats the 'V' in the signature as a single byte as per the original Ethereum implementation. When it upgrades to 4.5.0 we can use the full 8 byte 'long' implementation but until then this implementation uses the intermediate single byte which at least protects all the original chains and testnets.