### PR TITLE
Fix from crashlytics

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -991,6 +991,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                 if (attr.function == null) continue;
                 FunctionDefinition fd = attr.function;
                 ContractInfo cInfo = fd.contract;
+                if (cInfo == null || cInfo.addresses == null) continue;
                 List<String> addresses = cInfo.addresses.get(token.tokenInfo.chainId);
 
                 if (addresses != null)


### PR DESCRIPTION
fixes:

```
Fatal Exception: io.reactivex.exceptions.OnErrorNotImplementedException: The exception was not handled due to missing onError handler in the subscribe() method call. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | java.lang.NullPointerException: Attempt to read from field 'java.util.Map io.stormbird.token.entity.ContractInfo.addresses' on a null object reference
       at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept + 704(Functions.java:704)
       at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept + 701(Functions.java:701)
       at io.reactivex.internal.observers.ConsumerSingleObserver.onError + 46(ConsumerSingleObserver.java:46)
       at io.reactivex.internal.operators.single.SingleObserveOn$ObserveOnSingleObserver.run + 79(SingleObserveOn.java:79)
       at io.reactivex.Scheduler$DisposeTask.run + 578(Scheduler.java:578)
       at io.reactivex.internal.schedulers.ScheduledRunnable.run + 66(ScheduledRunnable.java:66)
       at io.reactivex.internal.schedulers.ScheduledRunnable.call + 57(ScheduledRunnable.java:57)
       at java.util.concurrent.FutureTask.run + 266(FutureTask.java:266)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run + 301(ScheduledThreadPoolExecutor.java:301)
       at java.util.concurrent.ThreadPoolExecutor.runWorker + 1162(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run + 636(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run + 764(Thread.java:764)
```