### PR TITLE
Fix from crashlytics nsf

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -148,7 +148,7 @@ public class NewSettingsFragment extends Fragment
             }
             try
             {
-                startActivity(intent);
+                getActivity().startActivity(intent);
             }
             catch (Exception e)
             {
@@ -169,7 +169,7 @@ public class NewSettingsFragment extends Fragment
             }
             try
             {
-                startActivity(intent);
+                getActivity().startActivity(intent);
             }
             catch (Exception e)
             {
@@ -206,7 +206,7 @@ public class NewSettingsFragment extends Fragment
             }
             try
             {
-                startActivity(intent);
+                getActivity().startActivity(intent);
             }
             catch (Exception e)
             {

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -32,6 +32,7 @@ import com.alphawallet.app.viewmodel.NewSettingsViewModel;
 import com.alphawallet.app.viewmodel.NewSettingsViewModelFactory;
 import com.alphawallet.app.widget.AWalletConfirmationDialog;
 import com.alphawallet.app.widget.SelectLocaleDialog;
+import com.crashlytics.android.Crashlytics;
 
 import static com.alphawallet.app.C.*;
 import static com.alphawallet.app.C.Key.WALLET;
@@ -145,7 +146,15 @@ public class NewSettingsFragment extends Fragment
             if (isAppAvailable(C.TELEGRAM_PACKAGE_NAME)) {
                 intent.setPackage(C.TELEGRAM_PACKAGE_NAME);
             }
-            startActivity(intent);
+            try
+            {
+                startActivity(intent);
+            }
+            catch (Exception e)
+            {
+                Crashlytics.logException(e);
+                e.printStackTrace();
+            }
         });
 
         final LinearLayout layoutTwitter = view.findViewById(R.id.layout_twitter);
@@ -158,7 +167,15 @@ public class NewSettingsFragment extends Fragment
             } catch (Exception e) {
                 intent = new Intent(Intent.ACTION_VIEW, Uri.parse(C.AWALLET_TWITTER_URL));
             }
-            startActivity(intent);
+            try
+            {
+                startActivity(intent);
+            }
+            catch (Exception e)
+            {
+                Crashlytics.logException(e);
+                e.printStackTrace();
+            }
         });
 
         final LinearLayout layoutNotifications = view.findViewById(R.id.layout_notification_settings);
@@ -187,7 +204,15 @@ public class NewSettingsFragment extends Fragment
             } catch (Exception e) {
                 intent = new Intent(Intent.ACTION_VIEW, Uri.parse(C.AWALLET_FACEBOOK_URL));
             }
-            startActivity(intent);
+            try
+            {
+                startActivity(intent);
+            }
+            catch (Exception e)
+            {
+                Crashlytics.logException(e);
+                e.printStackTrace();
+            }
         });
 
         layoutEnableXML = view.findViewById(R.id.layout_xml_override);


### PR DESCRIPTION
Fixes strange crash starting up a web-view. Possibly a permissioned phone:

```
Fatal Exception: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=fb://page/1958651857482632 }
       at android.app.Instrumentation.checkStartActivityResult + 1879(Instrumentation.java:1879)
       at android.app.Instrumentation.execStartActivity + 1546(Instrumentation.java:1546)
       at android.app.Activity.startActivityForResult + 4298(Activity.java:4298)
       at android.support.v4.app.FragmentActivity.startActivityForResult + 767(FragmentActivity.java:767)
       at android.support.v4.app.ActivityCompat.startActivityForResult + 234(ActivityCompat.java:234)
       at android.support.v4.app.FragmentActivity.startActivityFromFragment + 881(FragmentActivity.java:881)
       at android.support.v4.app.FragmentActivity$HostCallbacks.onStartActivityFromFragment + 995(FragmentActivity.java:995)
       at android.support.v4.app.Fragment.startActivity + 1084(Fragment.java:1084)
       at android.support.v4.app.Fragment.startActivity + 1073(Fragment.java:1073)
       at io.stormbird.wallet.ui.NewSettingsFragment.lambda$onCreateView$10$NewSettingsFragment + 190(NewSettingsFragment.java:190)
       at io.stormbird.wallet.ui.-$$Lambda$NewSettingsFragment$Mee0ITP84N9MeL-KfLDEf6e9E08.onClick(lambda)
       at android.view.View.performClick + 5721(View.java:5721)
       at android.view.View$PerformClick.run + 22620(View.java:22620)
       at android.os.Handler.handleCallback + 739(Handler.java:739)
       at android.os.Handler.dispatchMessage + 95(Handler.java:95)
       at android.os.Looper.loop + 148(Looper.java:148)
       at android.app.ActivityThread.main + 7406(ActivityThread.java:7406)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run + 1230(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main + 1120(ZygoteInit.java:1120)
```