### PR TITLE
Fix NPE

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -439,8 +439,8 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
     @Override
     public void remindMeLater(Wallet wallet)
     {
-        viewModel.setKeyWarningDismissTime(wallet.address).isDisposed();
-        adapter.removeBackupWarning();
+        if (viewModel != null) viewModel.setKeyWarningDismissTime(wallet.address).isDisposed();
+        if (adapter != null) adapter.removeBackupWarning();
     }
 
     public void storeWalletBackupTime(String backedUpKey)


### PR DESCRIPTION
fixes issue from crashlytics:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'io.reactivex.disposables.Disposable com.alphawallet.app.viewmodel.WalletViewModel.setKeyWarningDismissTime(java.lang.String)' on a null object reference
       at com.alphawallet.app.ui.WalletFragment.remindMeLater + 442(WalletFragment.java:442)
       at com.alphawallet.app.ui.HomeActivity.backupWalletFail + 542(HomeActivity.java:542)
       at com.alphawallet.app.ui.HomeActivity.onActivityResult + 835(HomeActivity.java:835)
       at android.app.Activity.dispatchActivityResult + 7528(Activity.java:7528)
       at android.app.ActivityThread.deliverResults + 4412(ActivityThread.java:4412)
       at android.app.ActivityThread.handleSendResult + 4461(ActivityThread.java:4461)
       at android.app.servertransaction.ActivityResultItem.execute + 49(ActivityResultItem.java:49)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 1831(ActivityThread.java:1831)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 193(Looper.java:193)
       at android.app.ActivityThread.main + 6806(ActivityThread.java:6806)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 547(RuntimeInit.java:547)
       at com.android.internal.os.ZygoteInit.main + 873(ZygoteInit.java:873)
```