### PR TITLE
Pass wallet address directly into tokenscript function

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -1005,7 +1005,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                                 Observable.fromIterable(token.getNonZeroArrayBalance())
                                         .map(tokenId -> getFunctionResult(cAddr, attr, tokenId))
                                         .filter(txResult -> txResult.needsUpdating(token.lastTxUpdate))
-                                        .concatMap(result -> tokenscriptUtility.fetchAttrResult(attr.id, result.tokenId, cAddr, td, this, token.lastTxUpdate))
+                                        .concatMap(result -> tokenscriptUtility.fetchAttrResult(token.getWallet(), attr.id, result.tokenId, cAddr, td, this, token.lastTxUpdate))
                                         .subscribeOn(Schedulers.io())
                                         .observeOn(AndroidSchedulers.mainThread())
                                         .subscribe();
@@ -1016,7 +1016,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                             TransactionResult tr = getFunctionResult(cAddr, attr, BigInteger.ZERO);
                             if (tr.needsUpdating(token.lastTxUpdate))
                             {
-                                tokenscriptUtility.fetchAttrResult(attr.id, tr.tokenId, cAddr, td, this, token.lastTxUpdate)
+                                tokenscriptUtility.fetchAttrResult(token.getWallet(), attr.id, tr.tokenId, cAddr, td, this, token.lastTxUpdate)
                                         .subscribeOn(Schedulers.io())
                                         .observeOn(AndroidSchedulers.mainThread())
                                         .subscribe();
@@ -1240,7 +1240,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         ContractAddress cAddr = new ContractAddress(token.tokenInfo.chainId, token.tokenInfo.address);
         //return definition.resolveAttributes(tokenId, this, cAddr);
         //resolveAttributes(BigInteger tokenId, AttributeInterface attrIf, ContractAddress cAddr, TokenDefinition td)
-        return tokenscriptUtility.resolveAttributes(tokenId, this, cAddr, definition, token.lastTxUpdate);
+        return tokenscriptUtility.resolveAttributes(token.getWallet(), tokenId, this, cAddr, definition, token.lastTxUpdate);
     }
 
     public Observable<TokenScriptResult.Attribute> resolveAttrs(Token token, List<BigInteger> tokenIds)

--- a/dmz/src/main/java/com/alphawallet/token/web/AppSiteController.java
+++ b/dmz/src/main/java/com/alphawallet/token/web/AppSiteController.java
@@ -178,7 +178,7 @@ public class AppSiteController implements AttributeInterface
             e.printStackTrace();
         }
 
-        tokenscriptFunction.resolveAttributes(firstTokenId, this, cAddr, definition)
+        tokenscriptFunction.resolveAttributes(ZERO_ADDRESS, firstTokenId, this, cAddr, definition)
                 .forEach(attr -> TokenScriptResult.addPair(tokenData, attr.id, attr.text))
                 .isDisposed();
 


### PR DESCRIPTION
To fix an issue reported from crashlytics where cached wallet address is scavenged by memory.
```
Caused by java.lang.NumberFormatException: Invalid BigInteger: 
       at java.math.BigInt.invalidBigInteger + 86(BigInt.java:86)
       at java.math.BigInt.checkString + 134(BigInt.java:134)
       at java.math.BigInt.putHexString + 99(BigInt.java:99)
       at java.math.BigInteger.<init> + 244(BigInteger.java:244)
       at org.web3j.utils.Numeric.toBigIntNoPrefix + 98(Numeric.java:98)
       at org.web3j.utils.Numeric.toBigInt + 94(Numeric.java:94)
       at org.web3j.abi.datatypes.Address.<init> + 29(Address.java:29)
       at com.alphawallet.app.entity.tokenscript.TokenscriptFunction.generateTransactionFunction + 66(TokenscriptFunction.java:66)
       at com.alphawallet.app.entity.tokenscript.TokenscriptFunction.lambda$fetchResultFromEthereum$0$TokenscriptFunction + 208(TokenscriptFunction.java:208)
       at com.alphawallet.app.entity.tokenscript.-$$Lambda$TokenscriptFunction$2vrXkvUTKGDA-nen2nqOcUmdmEc.call(lambda)
       at io.reactivex.internal.operators.observable.ObservableFromCallable.subscribeActual + 43(ObservableFromCallable.java:43)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableConcatMap$SourceObserver.drain + 223(ObservableConcatMap.java:223)
       at io.reactivex.internal.operators.observable.ObservableConcatMap$SourceObserver.onSubscribe + 103(ObservableConcatMap.java:103)
       at io.reactivex.internal.observers.BasicFuseableObserver.onSubscribe + 66(BasicFuseableObserver.java:66)
       at io.reactivex.internal.observers.BasicFuseableObserver.onSubscribe + 66(BasicFuseableObserver.java:66)
       at io.reactivex.internal.operators.observable.ObservableFromIterable.subscribeActual + 55(ObservableFromIterable.java:55)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableMap.subscribeActual + 32(ObservableMap.java:32)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableFilter.subscribeActual + 30(ObservableFilter.java:30)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableConcatMap.subscribeActual + 53(ObservableConcatMap.java:53)
       at io.reactivex.Observable.subscribe + 12267(Observable.java:12267)
       at io.reactivex.internal.operators.observable.ObservableSubscribeOn$SubscribeTask.run + 96(ObservableSubscribeOn.java:96)
       at io.reactivex.Scheduler$DisposeTask.run + 578(Scheduler.java:578)
       at io.reactivex.internal.schedulers.ScheduledRunnable.run + 66(ScheduledRunnable.java:66)
       at io.reactivex.internal.schedulers.ScheduledRunnable.call + 57(ScheduledRunnable.java:57)
       at java.util.concurrent.FutureTask.run + 237(FutureTask.java:237)
       at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run + 272(ScheduledThreadPoolExecutor.java:272)
       at java.util.concurrent.ThreadPoolExecutor.runWorker + 1133(ThreadPoolExecutor.java:1133)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run + 607(ThreadPoolExecutor.java:607)
       at java.lang.Thread.run + 760(Thread.java:760)
```