### PR TITLE
Fix issue from crashlytics

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -929,7 +929,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                     if (tokenDef != null && tokenDef.isDebug()) token.hasDebugTokenscript = true;
                     token.hasTokenScript = true;
                     TokenDefinition td = getAssetDefinition(networkId, address);
-                    if (td != null)
+                    if (td != null && td.contracts != null)
                     {
                         ContractInfo cInfo = td.contracts.get(td.holdingToken);
                         if (cInfo != null) checkCorrectInterface(token, cInfo.contractInterface);


### PR DESCRIPTION
```
Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'java.util.Map io.stormbird.token.tools.TokenDefinition.contracts' on a null object reference
       at io.stormbird.wallet.service.AssetDefinitionService.checkTokenscriptEnabledTokens + 925(AssetDefinitionService.java:925)
       at io.stormbird.wallet.viewmodel.WalletViewModel.startBalanceUpdate + 211(WalletViewModel.java:211)
       at io.stormbird.wallet.viewmodel.WalletViewModel.lambda$AbWJsNwcRVsHLIMMLcXS3YWHA88()
       at io.stormbird.wallet.viewmodel.-$$Lambda$WalletViewModel$AbWJsNwcRVsHLIMMLcXS3YWHA88.run + 2(:2)
       at io.reactivex.internal.observers.LambdaObserver.onComplete + 92(LambdaObserver.java:92)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.checkTerminated + 287(ObservableObserveOn.java:287)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal + 193(ObservableObserveOn.java:193)
       at io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run + 255(ObservableObserveOn.java:255)
       at io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run + 124(HandlerScheduler.java:124)
       at android.os.Handler.handleCallback + 907(Handler.java:907)
       at android.os.Handler.dispatchMessage + 105(Handler.java:105)
       at android.os.Looper.loop + 216(Looper.java:216)
       at android.app.ActivityThread.main + 7625(ActivityThread.java:7625)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 524(RuntimeInit.java:524)
       at com.android.internal.os.ZygoteInit.main + 987(ZygoteInit.java:987)
```