### PR TITLE
Ensure name is never null

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Token.java
@@ -189,7 +189,9 @@ public class Token implements Parcelable
     {
         if (isTerminated()) return SetupTokensInteract.EXPIRED_CONTRACT;
         if (isBad()) return SetupTokensInteract.UNKNOWN_CONTRACT;
-        return tokenInfo.name + (tokenInfo.symbol != null && tokenInfo.symbol.length() > 0 ? "(" + tokenInfo.symbol.toUpperCase() + ")" : "");
+        String name = tokenInfo.name == null ? "" : tokenInfo.name;
+        String symbol = tokenInfo.symbol == null ? "" : "(" + tokenInfo.symbol.toUpperCase() + ")";
+        return name + symbol;
     }
 
     public String getFullName(AssetDefinitionService assetDefinition, int count)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
@@ -263,7 +263,7 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
         String tokenName = token.getFullName();
         if(token.isEthereum()) return token.tokenInfo.chainId;
         if(token.isBad()) return 99999999;
-        if(token.tokenInfo.name == null || token.tokenInfo.name.length() < 2)
+        if(tokenName.length() == 0)
         {
             return Integer.MAX_VALUE;
         }


### PR DESCRIPTION
fixes

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
       at com.alphawallet.app.ui.widget.adapter.TokensAdapter.calculateWeight + 266(TokensAdapter.java:266)
       at com.alphawallet.app.ui.widget.adapter.TokensAdapter.updateToken + 182(TokensAdapter.java:182)
       at com.alphawallet.app.ui.WalletFragment.onToken + 153(WalletFragment.java:153)
       at com.alphawallet.app.ui.WalletFragment.lambda$rUzMV0r24SivNNoiX6182w5xH9c(WalletFragment.java)
       at com.alphawallet.app.ui.-$$Lambda$WalletFragment$rUzMV0r24SivNNoiX6182w5xH9c.onChanged(lambda)
       at android.arch.lifecycle.LiveData.considerNotify + 109(LiveData.java:109)
       at android.arch.lifecycle.LiveData.dispatchingValue + 126(LiveData.java:126)
       at android.arch.lifecycle.LiveData.setValue + 282(LiveData.java:282)
       at android.arch.lifecycle.MutableLiveData.setValue + 33(MutableLiveData.java:33)
       at android.arch.lifecycle.LiveData$1.run + 87(LiveData.java:87)
       at android.os.Handler.handleCallback + 754(Handler.java:754)
       at android.os.Handler.dispatchMessage + 95(Handler.java:95)
       at android.os.Looper.loop + 163(Looper.java:163)
       at android.app.ActivityThread.main + 6238(ActivityThread.java:6238)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run + 933(ZygoteInit.java:933)
       at com.android.internal.os.ZygoteInit.main + 823(ZygoteInit.java:823)
```