### PR TITLE
Trigger reset of dappbrowserfragment if required

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -180,6 +180,10 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         super.onResume();
         if (currentFragment == null) currentFragment = DAPP_HOME;
         attachFragment(currentFragment);
+        if (web3 == null && getActivity() != null) //trigger reload
+        {
+            ((HomeActivity)getActivity()).ResetDappBrowser();
+        }
     }
 
     @Nullable

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -591,6 +591,15 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         //viewModel.upgradeWallet(keyAddress);
     }
 
+    public void ResetDappBrowser()
+    {
+        getSupportFragmentManager()
+                .beginTransaction()
+                .detach(dappBrowserFragment)
+                .attach(dappBrowserFragment)
+                .commit();
+    }
+
     private class ScreenSlidePagerAdapter extends FragmentStatePagerAdapter {
         public ScreenSlidePagerAdapter(FragmentManager fm) {
             super(fm);


### PR DESCRIPTION
Sometimes pointer to webview has been scavenged by memory. On resume of the view, check if we lost the pointers, if we did then force a refresh of the view. Fixes this:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.alphawallet.app.web3.Web3View.onSignTransactionSuccessful(com.alphawallet.app.web3.entity.Web3Transaction, java.lang.String)' on a null object reference
       at com.alphawallet.app.ui.DappBrowserFragment.handleTransactionCallback + 736(DappBrowserFragment.java:736)
       at com.alphawallet.app.ui.HomeActivity.onActivityResult + 838(HomeActivity.java:838)
       at android.app.Activity.dispatchActivityResult + 7761(Activity.java:7761)
       at android.app.ActivityThread.deliverResults + 4581(ActivityThread.java:4581)
       at android.app.ActivityThread.handleSendResult + 4630(ActivityThread.java:4630)
       at android.app.servertransaction.ActivityResultItem.execute + 49(ActivityResultItem.java:49)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 1926(ActivityThread.java:1926)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 6990(ActivityThread.java:6990)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 1445(ZygoteInit.java:1445)
```