### PR TITLE
Fix for lost inputview

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
@@ -742,6 +742,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
                 break;
             case ENTER_JSON_BACKUP:
             case SET_JSON_PASSWORD:
+                inputView = findViewById(R.id.input_password);
                 viewModel.exportWallet(wallet, mnemonic, inputView.getText().toString());
                 break;
             case SHOW_SEED_PHRASE:


### PR DESCRIPTION
Fix inputview getting lost between screen refreshes:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.CharSequence com.alphawallet.app.widget.PasswordInputView.getText()' on a null object reference
       at com.alphawallet.app.ui.BackupKeyActivity.FetchMnemonic + 745(BackupKeyActivity.java:745)
       at com.alphawallet.app.service.KeyService.authenticatePass + 810(KeyService.java:810)
       at com.alphawallet.app.service.KeyService.CompleteAuthentication + 787(KeyService.java:787)
       at com.alphawallet.app.ui.BackupKeyActivity.onActivityResult + 838(BackupKeyActivity.java:838)
       at android.app.Activity.dispatchActivityResult + 7761(Activity.java:7761)
       at android.app.ActivityThread.deliverResults + 4581(ActivityThread.java:4581)
       at android.app.ActivityThread.handleSendResult + 4630(ActivityThread.java:4630)
       at android.app.servertransaction.ActivityResultItem.execute + 49(ActivityResultItem.java:49)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 1926(ActivityThread.java:1926)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 6990(ActivityThread.java:6990)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 1445(ZygoteInit.java:1445)
```