### PR TITLE
Fix for upgrading the key to use authentication locked key.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/KeyService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeyService.java
@@ -753,13 +753,16 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
     {
         //first check if the phone is unlocked
         String dialogTitle;
+        boolean requireUnlock = false;
         switch (operation)
         {
+            case UPGRADE_HD_KEY:
+            case UPGRADE_KEYSTORE_KEY:
+                requireUnlock = true;
+                //drop through
             case IMPORT_HD_KEY:
             case CREATE_HD_KEY:
-            case UPGRADE_HD_KEY:
             case CREATE_KEYSTORE_KEY:
-            case UPGRADE_KEYSTORE_KEY:
             case CREATE_PRIVATE_KEY:
                 dialogTitle = context.getString(R.string.provide_authentication);
                 break;
@@ -772,7 +775,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         }
 
         //see if unlock is required
-        if (!requiresUnlock() && signCallback != null)
+        if (!requireUnlock && !requiresUnlock() && signCallback != null)
         {
             signCallback.GotAuthorisation(true);
             return;

--- a/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
@@ -118,6 +118,9 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
                 DisplayKeyFailureDialog("Export Private key not yet implemented");
                 //TODO: Not yet implemented
                 break;
+            case UPGRADE_KEY:
+                setupUpgradeKey(false);
+                break;
         }
     }
 
@@ -133,15 +136,18 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
         }
     }
 
-    private void setupUpgradeKey()
+    private void setupUpgradeKey(boolean showSuccess)
     {
         setContentView(R.layout.activity_backup);
         initViews();
 
         successOverlay = findViewById(R.id.layout_success_overlay);
-        if (successOverlay != null) successOverlay.setVisibility(View.VISIBLE);
-        handler = new Handler();
-        handler.postDelayed(this, 1000);
+        if (successOverlay != null && showSuccess)
+        {
+            successOverlay.setVisibility(View.VISIBLE);
+            handler = new Handler();
+            handler.postDelayed(this, 1000);
+        }
 
         setTitle(getString(R.string.empty));
         state = BackupState.UPGRADE_KEY_SECURITY;
@@ -509,7 +515,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
             case STRONGBOX_NO_AUTHENTICATION:
             case TEE_NO_AUTHENTICATION:
                 //improve key security
-                setupUpgradeKey();
+                setupUpgradeKey(true);
                 break;
             default:
                 finishBackupSuccess(true);
@@ -931,7 +937,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
 
     public enum BackupOperationType
     {
-        UNDEFINED, BACKUP_HD_KEY, BACKUP_KEYSTORE_KEY, SHOW_SEED_PHRASE, EXPORT_PRIVATE_KEY
+        UNDEFINED, BACKUP_HD_KEY, BACKUP_KEYSTORE_KEY, SHOW_SEED_PHRASE, EXPORT_PRIVATE_KEY, UPGRADE_KEY
     }
 
 //                switch (operation)

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -59,6 +59,7 @@ public class NewSettingsFragment extends Fragment
     private View backupPopupAnchor;
     private LinearLayout layoutBackupKey;
     private LinearLayout layoutBackupDivider;
+    private TextView backupText;
 
     @Nullable
     @Override
@@ -76,6 +77,7 @@ public class NewSettingsFragment extends Fragment
         notificationState = view.findViewById(R.id.switch_notifications);
         backupStatusText = view.findViewById(R.id.text_backup_status);
         backupStatusImage = view.findViewById(R.id.image_backup_status);
+        backupText = view.findViewById(R.id.backup_text);
 
         TextView helpText = view.findViewById(R.id.text_version);
         try
@@ -243,6 +245,21 @@ public class NewSettingsFragment extends Fragment
                 break;
         }
 
+        //override if this is an upgrade
+        switch (wallet.authLevel)
+        {
+            case NOT_SET:
+            case STRONGBOX_NO_AUTHENTICATION:
+            case TEE_NO_AUTHENTICATION:
+                if (wallet.lastBackupTime > 0)
+                {
+                    intent.putExtra("TYPE", BackupKeyActivity.BackupOperationType.UPGRADE_KEY);
+                }
+                break;
+            default:
+                break;
+        }
+
         intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         getActivity().startActivityForResult(intent, C.REQUEST_BACKUP_WALLET);
     }
@@ -271,17 +288,20 @@ public class NewSettingsFragment extends Fragment
             case TEE_NO_AUTHENTICATION:
                 if (wallet.lastBackupTime > 0)
                 {
+                    backupText.setText(R.string.action_upgrade_key);
                     backupStatusText.setText(R.string.not_locked);
                     backupStatusImage.setImageResource(R.drawable.ic_orange_bar);
                 }
                 else
                 {
+                    backupText.setText(R.string.back_up_this_wallet);
                     backupStatusText.setText(R.string.back_up_now);
                     backupStatusImage.setImageResource(R.drawable.ic_red_bar);
                 }
                 break;
             case TEE_AUTHENTICATION:
             case STRONGBOX_AUTHENTICATION:
+                backupText.setText(R.string.back_up_this_wallet);
                 backupStatusText.setText(R.string.key_secure);
                 backupStatusImage.setImageResource(R.drawable.ic_green_bar);
                 break;

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -135,6 +135,7 @@
                 </RelativeLayout>
 
                 <TextView
+                    android:id="@+id/backup_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"


### PR DESCRIPTION
Fix for upgrade path for upgrading key security. Previously there were two issues:
1. The require user fingerprint/PIN didn't always work under every condition.
2. Once the key was backed up, you were required to confirm back up once again before upgrading to the next level of key security.