### PR TITLE
Smooth Token refresh

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Token.java
@@ -235,19 +235,13 @@ public class Token implements Parcelable
             ethBalance = balance.divide(new BigDecimal(Math.pow(10, tokenInfo.decimals)));
             //fractional value. How to represent?
             value = getMinimalString(ethBalance.toPlainString());
-            if (value.length() > 6)
+            if (ethBalance.compareTo(BigDecimal.valueOf(0.000001)) < 0)
             {
-                holder.balanceEth.setText(R.string.dust_value);
-            }
-            else
-            {
-                holder.balanceEth.setText(value);
+                value = holder.getString(R.string.dust_value);
             }
         }
-        else
-        {
-            holder.balanceEth.setText(value);
-        }
+
+        holder.balanceEth.setText(value);
 
         if (isEthereum())
         {

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -1088,6 +1088,8 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         newToken.setTokenWallet(token.getWallet());
         newToken.walletUIUpdateRequired = true;
         newToken.updateBlancaTime = 0;
+        newToken.transferPreviousData(token);
+
 
         tokenLocalSource.saveToken(new Wallet(token.getWallet()), newToken)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
@@ -193,7 +193,7 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
                 {
                     TokenSortedItem tsi = (TokenSortedItem) si;
                     Token thisToken = tsi.value;
-                    if (thisToken.getAddress().equals(token.getAddress()) && thisToken.tokenInfo.chainId == token.tokenInfo.chainId)
+                    if (canDisplayToken(thisToken) && thisToken.getAddress().equals(token.getAddress()) && thisToken.tokenInfo.chainId == token.tokenInfo.chainId)
                     {
                         Log.d(TAG, "REMOVE: " + token.getFullName());
                         items.removeItemAt(i);
@@ -211,7 +211,7 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     {
         if (token == null) return false;
         //Add token to display list if it's the base currency, or if it has balance
-        boolean allowThroughFilter = true;
+        boolean allowThroughFilter = VisibilityFilter.filterToken(token, true);
 
         switch (filterType)
         {
@@ -237,7 +237,7 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
                 break;
         }
 
-        return VisibilityFilter.filterToken(token, allowThroughFilter);
+        return allowThroughFilter;
     }
 
     private void populateTokens(Token[] tokens)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.ui.widget.holder;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
@@ -59,6 +60,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
     private final TextView pendingText;
     private final RelativeLayout tokenLayout;
     private final LinearLayout extendedInfo;
+    private Handler handler;
 
     public Token token;
     private OnTokenClickListener onTokenClickListener;
@@ -229,12 +231,24 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
         balanceCurrency.setText(EMPTY_BALANCE);
     }
 
+    private Runnable clearElevation = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            tokenLayout.setElevation(3);
+            handler = null;
+        }
+    };
+
     @Override
     public void onClick(View v) {
         if (onTokenClickListener != null) {
             tokenLayout.setElevation(0.0f);
             tokenLayout.setBackgroundResource(R.drawable.background_light_grey);
             onTokenClickListener.onTokenClick(v, token, null, true);
+            handler = new Handler();
+            handler.postDelayed(clearElevation, 2000);
         }
     }
 


### PR DESCRIPTION
- stop cards from 'jumping' on refresh.
- stop native cards appearing in the 'collectables' filtered tokens.