### PR TITLE
Handle excessively large transaction payloads which exceed the limit

### DIFF
--- a/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
+++ b/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
@@ -4,6 +4,7 @@ package com.alphawallet.app.router;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.TransactionTooLargeException;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.ui.ConfirmationActivity;
@@ -35,7 +36,7 @@ public class ConfirmationRouter {
     }
 
     //Sign transaction for dapp browser
-    public void open(Activity context, Web3Transaction transaction, String networkName, boolean isMainNet, String requesterURL, int chainId)
+    public void open(Activity context, Web3Transaction transaction, String networkName, boolean isMainNet, String requesterURL, int chainId) throws TransactionTooLargeException
     {
         Intent intent = new Intent(context, ConfirmationActivity.class);
         intent.putExtra(C.EXTRA_WEB3TRANSACTION, transaction);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.content.Context;
 import android.content.Intent;
+import android.os.TransactionTooLargeException;
 import android.preference.PreferenceManager;
 
 import com.alphawallet.app.entity.ContractResult;
@@ -222,7 +223,7 @@ public class DappBrowserViewModel extends BaseViewModel  {
         dAppFunction.DAppReturn(s.getBytes(), msg);
     }
 
-    public void openConfirmation(Activity context, Web3Transaction transaction, String requesterURL, NetworkInfo networkInfo)
+    public void openConfirmation(Activity context, Web3Transaction transaction, String requesterURL, NetworkInfo networkInfo) throws TransactionTooLargeException
     {
         String networkName = networkInfo.name;
         boolean mainNet = networkInfo.isMainNetwork;

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -199,4 +199,6 @@
     <string name="linkedin">LinkedIn</string>
     <string name="please_enable_security">Unable to create key. Try enabling security on your phone.</string>
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
+    <string name="transaction_too_large">Transaction Too Large</string>
+    <string name="unable_to_handle_tx">Transaction payload is too large</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -465,4 +465,6 @@
     <string name="linkedin">LinkedIn</string>
     <string name="please_enable_security">Unable to create key. Try enabling security on your phone.</string>
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
+    <string name="transaction_too_large">Transaction Too Large</string>
+    <string name="unable_to_handle_tx">Transaction payload is too large</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -601,4 +601,6 @@
     <string name="linkedin">LinkedIn</string>
     <string name="please_enable_security">Unable to create key. Try enabling security on your phone.</string>
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
+    <string name="transaction_too_large">Transaction Too Large</string>
+    <string name="unable_to_handle_tx">Transaction payload is too large</string>
 </resources>


### PR DESCRIPTION
Crash from crashlytics reported where transaction payload exceeded the limits. Instead of crashing report the issue to the (most likely) developer.