### PR TITLE
Ensure at least one network is selected

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SelectNetworkActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SelectNetworkActivity.java
@@ -104,12 +104,7 @@ public class SelectNetworkActivity extends BaseActivity {
                 list.add(new NetworkItem(info.name, info.chainId, intList.contains(info.chainId)));
             }
         }
-
-        if (list.size() < 1)
-        {
-            list.add(new NetworkItem(info.name, info.chainId, intList.contains(info.chainId)));
-        }
-
+        
         adapter = new NetworkListAdapter(this, list, selectedChainId, singleItem);
         listView.setAdapter(adapter);
         listView.setDividerHeight(0);

--- a/app/src/main/java/com/alphawallet/app/ui/SelectNetworkActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SelectNetworkActivity.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import android.widget.TextView;
 
+import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.ui.widget.adapter.NetworkListAdapter;
 import com.alphawallet.app.ui.widget.entity.NetworkItem;
 import com.alphawallet.app.util.Utils;
@@ -90,11 +91,23 @@ public class SelectNetworkActivity extends BaseActivity {
             intList.add(MAINNET_ID);
         }
 
+        //if active networks is empty ensure mainnet is displayed
+        if (activeNetworks.size() == 0)
+        {
+            activeNetworks.add(MAINNET_ID);
+            intList.add(MAINNET_ID);
+        }
+
         for (NetworkInfo info : viewModel.getNetworkList()) {
             if (!singleItem || activeNetworks.contains(info.chainId))
             {
                 list.add(new NetworkItem(info.name, info.chainId, intList.contains(info.chainId)));
             }
+        }
+
+        if (list.size() < 1)
+        {
+            list.add(new NetworkItem(info.name, info.chainId, intList.contains(info.chainId)));
         }
 
         adapter = new NetworkListAdapter(this, list, selectedChainId, singleItem);
@@ -115,16 +128,18 @@ public class SelectNetworkActivity extends BaseActivity {
 
     private void handleSetNetworks()
     {
+        Integer[] filterList = adapter.getSelectedItems();
+        if (filterList.length == 0) filterList = EthereumNetworkRepository.addDefaultNetworks().toArray(new Integer[0]);
         if (singleItem)
         {
             Intent intent = new Intent();
-            intent.putExtra(C.EXTRA_CHAIN_ID, adapter.getSelectedItems()[0]);
+            intent.putExtra(C.EXTRA_CHAIN_ID, filterList[0]);
             setResult(RESULT_OK, intent);
             finish();
         }
         else
         {
-            viewModel.setFilterNetworks(adapter.getSelectedItems());
+            viewModel.setFilterNetworks(filterList);
             sendBroadcast(new Intent(C.RESET_WALLET));
             finish();
         }


### PR DESCRIPTION
Ensure network select always has items. This crash occurred because there were no items due to a different issue (fixed in this release).

```
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
       at com.alphawallet.app.ui.SelectNetworkActivity.handleSetNetworks + 121(SelectNetworkActivity.java:121)
       at com.alphawallet.app.ui.SelectNetworkActivity.onOptionsItemSelected + 109(SelectNetworkActivity.java:109)
       at android.app.Activity.onMenuItemSelected + 3552(Activity.java:3552)
       at android.support.v4.app.FragmentActivity.onMenuItemSelected + 436(FragmentActivity.java:436)
       at android.support.v7.app.AppCompatActivity.onMenuItemSelected + 196(AppCompatActivity.java:196)
       at android.support.v7.view.WindowCallbackWrapper.onMenuItemSelected + 109(WindowCallbackWrapper.java:109)
       at android.support.v7.view.WindowCallbackWrapper.onMenuItemSelected + 109(WindowCallbackWrapper.java:109)
       at android.support.v7.widget.ToolbarWidgetWrapper$1.onClick + 188(ToolbarWidgetWrapper.java:188)
       at android.view.View.performClick + 6612(View.java:6612)
       at android.view.View.performClickInternal + 6589(View.java:6589)
       at android.view.View.access$3100 + 781(View.java:781)
       at android.view.View$PerformClick.run + 26068(View.java:26068)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 220(Looper.java:220)
       at android.app.ActivityThread.main + 7424(ActivityThread.java:7424)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 500(RuntimeInit.java:500)
       at com.android.internal.os.ZygoteInit.main + 865(ZygoteInit.java:865)
```