### PR TITLE
Fix Transaction Update

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/TransactionMeta.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionMeta.java
@@ -15,10 +15,12 @@ public class TransactionMeta
 {
     public final String hash;
     public final long timeStamp;
+    public final boolean isPending;
 
-    public TransactionMeta(String hash, long timeStamp)
+    public TransactionMeta(String hash, long timeStamp, boolean pending)
     {
         this.hash = hash;
         this.timeStamp = timeStamp;
+        this.isPending = pending;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
@@ -205,7 +205,7 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
 
         if (transactions.length > 0)
         {
-            int txCount = recentTransactionsAdapter.updateRecentTransactions(transactions);
+            recentTransactionsAdapter.addTransactions(transactions);
             noTransactionsLayout.setVisibility(View.GONE);
             recentTransactionsAdapter.notifyDataSetChanged();
         }
@@ -228,18 +228,6 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
         }
 
         progressBar = findViewById(R.id.progress_bar);
-    }
-
-    private void addTokenPage() {
-        LinearLayout viewWrapper = findViewById(R.id.layout_iframe);
-        try {
-            WebView iFrame = findViewById(R.id.iframe);
-            String tokenData = viewModel.getTokenData(token);
-            iFrame.loadData(tokenData, "text/html", "UTF-8");
-            viewWrapper.setVisibility(View.VISIBLE);
-        } catch (Exception e) {
-            viewWrapper.setVisibility(View.GONE);
-        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TransactionsAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TransactionsAdapter.java
@@ -142,12 +142,12 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
     public int updateTransactions(Transaction[] transactions)
     {
         if (transactions.length == 0) return 0;
-        int oldSize = items.size();
 
         items.beginBatchedUpdates();
         for (Transaction transaction : transactions)
         {
-            TransactionMeta data = new TransactionMeta(transaction.hash, transaction.timeStamp);
+            boolean isPending = transaction.blockNumber.equals("0");
+            TransactionMeta data = new TransactionMeta(transaction.hash, transaction.timeStamp, isPending);
             TransactionSortedItem sortedItem = new TransactionSortedItem(
                     TransactionHolder.VIEW_TYPE, data, TimestampSortedItem.DESC);
             items.add(sortedItem);
@@ -155,22 +155,19 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
         }
 
         items.endBatchedUpdates();
-        return items.size() - oldSize;
+        return transactions.length;
     }
 
     public void addNewTransactions(Transaction[] transactions)
     {
         if (transactions.length == 0) return;
-        DateSortedItem lastDate = items.size() > 0 ? (DateSortedItem)items.get(0) : null;
+        //DateSortedItem lastDate = items.size() > 0 ? (DateSortedItem)items.get(0) : null;
         int itemsChanged = updateTransactions(transactions);
+        //update top 10 transactions or less
         if (itemsChanged > 0)
         {
-            int startItem = 0;
-            if (lastDate != null && lastDate.areItemsTheSame(items.get(0)))
-            {
-                startItem = 1;
-            }
-            notifyItemRangeChanged(startItem, items.size() - startItem);
+            itemsChanged = items.size() < 10 ? items.size() : 10;
+            notifyItemRangeChanged(0, itemsChanged);
         }
     }
 
@@ -179,10 +176,12 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
         items.beginBatchedUpdates();
         for (Transaction transaction : transactions)
         {
-            TransactionMeta data = new TransactionMeta(transaction.hash, transaction.timeStamp);
+            boolean isPending = transaction.blockNumber.equals("0");
+            TransactionMeta data = new TransactionMeta(transaction.hash, transaction.timeStamp, isPending);
             TransactionSortedItem sortedItem = new TransactionSortedItem(
                     TransactionHolder.VIEW_TYPE, data, TimestampSortedItem.DESC);
                 items.add(sortedItem);
+            items.add(DateSortedItem.round(transaction.timeStamp));
         }
         items.endBatchedUpdates();
         notifyDataSetChanged();

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransactionSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransactionSortedItem.java
@@ -20,16 +20,28 @@ public class TransactionSortedItem extends TimestampSortedItem<TransactionMeta> 
     {
         if (other.tags.contains(IS_TIMESTAMP_TAG))
         {
+            TransactionMeta oldTx;
+            TransactionMeta newTx;
             TimestampSortedItem otherTimestamp = (TimestampSortedItem) other;
-            //we were getting an instance where two transactions went through on the same
-            //block - so the timestamp was the same. The display flickered between the two transactions.
-            if (this.getTimestamp().equals(otherTimestamp.getTimestamp()))
+            //first see if this is a replacement TX
+            if (viewType == TransactionHolder.VIEW_TYPE && viewType == other.viewType)
             {
-                TransactionMeta oldTx = value;
-                TransactionMeta newTx = (TransactionMeta) other.value;
+                oldTx = value;
+                newTx = (TransactionMeta) other.value;
 
-                //just compare the transaction hash instead
-                return oldTx.hash.compareTo(newTx.hash);
+                // Check if this is a written block replacing a pending block
+                if (oldTx.hash.equals(newTx.hash)) return 0; // match
+
+                //we were getting an instance where two transactions went through on the same
+                //block - so the timestamp was the same. The display flickered between the two transactions.
+                if (this.getTimestamp().equals(otherTimestamp.getTimestamp()))
+                {
+                    return oldTx.hash.compareTo(newTx.hash);
+                }
+                else
+                {
+                    return super.compare(other);
+                }
             }
             else
             {
@@ -51,7 +63,10 @@ public class TransactionSortedItem extends TimestampSortedItem<TransactionMeta> 
                 TransactionMeta oldTx = value;
                 TransactionMeta newTx = (TransactionMeta) newItem.value;
 
-                return oldTx.hash.equals(newTx.hash);
+                boolean hashMatch = oldTx.hash.equals(newTx.hash);
+                boolean pendingMatch = oldTx.isPending == newTx.isPending;
+
+                return hashMatch && pendingMatch;
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -118,7 +118,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
                         ? symbolStr
                         : token.getFullName());
 
-            animateTextWhileWaiting();
+            if (token.ticker != null) animateTextWhileWaiting();
             token.setupContent(this, assetDefinition);
             if (EthereumNetworkRepository.isPriorityToken(token)) extendedInfo.setVisibility(View.GONE);
             setPending();
@@ -157,7 +157,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
 
     public void fillCurrency(BigDecimal ethBalance, TokenTicker ticker) {
         stopTextAnimation();
-        BigDecimal usdBalance = ethBalance.multiply(new BigDecimal(ticker.price)).setScale(2, RoundingMode.HALF_DOWN);
+        BigDecimal usdBalance = ethBalance.multiply(new BigDecimal(ticker.price)).setScale(2, RoundingMode.DOWN);
         String converted = getUsdString(usdBalance.doubleValue());
         String formattedPercents = "";
         int color = Color.RED;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TotalBalanceHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TotalBalanceHolder.java
@@ -26,6 +26,6 @@ public class TotalBalanceHolder extends BinderViewHolder<BigDecimal> {
     public void bind(@Nullable BigDecimal data, @NonNull Bundle addition) {
         title.setText(data == null
             ? "--"
-            : "$" + data.setScale(2, RoundingMode.HALF_DOWN).stripTrailingZeros().toPlainString());
+            : "$" + data.setScale(2, RoundingMode.DOWN).stripTrailingZeros().toPlainString());
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -162,7 +162,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         pendingSpinner.setVisibility(View.VISIBLE);
         typeIcon.setVisibility(View.GONE);
         type.setText(R.string.pending_transaction);
-        String valueStr = getValueStr(transaction.value, true, getString(R.string.eth), 18);
+        String valueStr = getValueStr(transaction.value, true, getString(R.string.eth), 18, transaction.to.equalsIgnoreCase(transaction.from));
         value.setText(valueStr);
         value.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
         value.setVisibility(View.VISIBLE);
@@ -265,10 +265,20 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
     {
         boolean isSent = from.toLowerCase().equals(defaultAddress);
         type.setText(isSent ? getString(R.string.sent) : getString(R.string.received));
+        boolean self = false;
+
+        value.setTextColor(ContextCompat.getColor(getContext(), isSent ? R.color.red : R.color.green));
 
         if (txSuccess)
         {
-            if (!isSent)
+            if (from.equalsIgnoreCase(to))
+            {
+                self = true;
+                type.setText(R.string.self);
+                typeIcon.setImageResource(R.drawable.ic_transactions);
+                value.setTextColor(ContextCompat.getColor(getContext(), R.color.warning_dark_red));
+            }
+            else if (!isSent)
             {
                 typeIcon.setImageResource(R.drawable.ic_arrow_upward_black_24dp);
             }
@@ -279,16 +289,14 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         }
 
         address.setText(isSent ? to : from);
-        value.setTextColor(ContextCompat.getColor(getContext(), isSent ? R.color.red : R.color.green));
 
         setSuccessIndicator(txSuccess, "");
 
-        valueStr = getValueStr(valueStr, isSent, symbol, decimals);
-
+        valueStr = getValueStr(valueStr, isSent, symbol, decimals, self);
         this.value.setText(valueStr);
     }
 
-    private String getValueStr(String valueStr, boolean isSent, String symbol, long decimals)
+    private String getValueStr(String valueStr, boolean isSent, String symbol, long decimals, boolean self)
     {
         if (valueStr.equals("0")) {
             valueStr = "0 " + symbol;
@@ -296,7 +304,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
             valueStr = Token.getScaledValue(valueStr, decimals);
             if (!valueStr.startsWith("~"))
             {
-                valueStr = (isSent ? "-" : "+") + valueStr;
+                valueStr = (self ? "" : (isSent ? "-" : "+")) + valueStr;
             }
             valueStr = valueStr + " " + symbol;
         }
@@ -347,13 +355,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         }
         else
         {
-            valueStr = operation.value;
-
-            if (valueStr.equals("0") || !Character.isDigit(valueStr.charAt(0))) {
-                valueStr = valueStr + " " + symbol;
-            } else {
-                valueStr = (isSent ? "-" : "+") + Token.getScaledValue(valueStr, decimals) + " " + symbol;
-            }
+            valueStr = getValueStr(operation.value, isSent, symbol, decimals, from.equalsIgnoreCase(operation.to));
         }
 
         this.value.setText(valueStr);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -323,17 +323,26 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         Token token = tokensService.getToken(transaction.chainId, operation.contract.address);
 
         String from = operation.from;
-
         String supplimentalTxt = "";
 
         boolean isSent = from.toLowerCase().equals(defaultAddress.toLowerCase());
         String operationName = token != null ? token.getOperationName(transaction, getContext()) : null;
         if (operationName == null) operationName = isSent ? getString(R.string.sent) : getString(R.string.received);
         type.setText(operationName);
+        boolean self = false;
+
+        value.setTextColor(ContextCompat.getColor(getContext(), isSent ? R.color.red : R.color.green));
 
         if (txSuccess)
         {
-            if (!isSent)
+            if (operation.from.equalsIgnoreCase(operation.to))
+            {
+                self = true;
+                type.setText(R.string.self);
+                typeIcon.setImageResource(R.drawable.ic_transactions);
+                value.setTextColor(ContextCompat.getColor(getContext(), R.color.warning_dark_red));
+            }
+            else if (!isSent)
             {
                 typeIcon.setImageResource(R.drawable.ic_arrow_upward_black_24dp);
             }
@@ -344,8 +353,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         }
 
         address.setText(name);
-        value.setTextColor(ContextCompat.getColor(getContext(), isSent ? R.color.red : R.color.green));
-
         setSuccessIndicator(txSuccess, supplimentalTxt);
 
         String valueStr;
@@ -355,7 +362,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         }
         else
         {
-            valueStr = getValueStr(operation.value, isSent, symbol, decimals, from.equalsIgnoreCase(operation.to));
+            valueStr = getValueStr(operation.value, isSent, symbol, decimals, self);
         }
 
         this.value.setText(valueStr);

--- a/app/src/main/java/com/alphawallet/app/util/BalanceUtils.java
+++ b/app/src/main/java/com/alphawallet/app/util/BalanceUtils.java
@@ -15,7 +15,7 @@ public class BalanceUtils {
 
     public static String ethToUsd(String priceUsd, String ethBalance) {
         BigDecimal usd = new BigDecimal(ethBalance).multiply(new BigDecimal(priceUsd));
-        usd = usd.setScale(2, RoundingMode.HALF_DOWN);
+        usd = usd.setScale(2, RoundingMode.DOWN);
         return usd.toString();
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -201,4 +201,5 @@
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
     <string name="transaction_too_large">Transaction Too Large</string>
     <string name="unable_to_handle_tx">Transaction payload is too large</string>
+    <string name="self">Self</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -467,4 +467,5 @@
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
     <string name="transaction_too_large">Transaction Too Large</string>
     <string name="unable_to_handle_tx">Transaction payload is too large</string>
+    <string name="self">Self</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,4 +603,5 @@
     <string name="what_is_seed_phrase">A seed phrase, seed recovery phrase or backup seed phrase is a list of words which store all the information needed to recover a Bitcoin wallet. Wallet software will typically generate a seed phrase and instruct the user to write it down on paper.</string>
     <string name="transaction_too_large">Transaction Too Large</string>
     <string name="unable_to_handle_tx">Transaction payload is too large</string>
+    <string name="self">Self</string>
 </resources>


### PR DESCRIPTION
This is fixing a bug where a transaction written to block replaces a 'pending' transaction card.

EG:

Tx 0x2836478234 is user sending 0.1 eth to 0x236472364234
--- now is shown pending in the transaction view ---
...
Time passes, you wait.
...
Now user sees:
Tx 0x2836478234 send 0.1 eth
Tx 0x2836478234 send 0.1 eth

Because of order of adapter match checking.

Also implements the new Etherscan feature 'Self' where user sends to themselves.