### PR TITLE
Fix contract search fail

### DIFF
--- a/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
@@ -280,6 +280,7 @@ public class AddTokenViewModel extends BaseViewModel {
             //test all the other networks
             List<Integer> networkIds = getNetworkIds();
             networkIds.remove((Integer)result.chainId);
+            networkCount--;
 
             scanNetworksDisposable = Observable.fromCallable(() -> networkIds)
                     .flatMapIterable(networkId -> networkId)


### PR DESCRIPTION
ensure network search completes (we already checked one of the networks; take that into account).

Previously the search didn't complete if the contract wasn't found.