### PR TITLE
Spotfix for dapp signing error

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -760,15 +760,14 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     public void handleTransactionCallback(int resultCode, Intent data)
     {
         if (data == null) return;
-        if (resultCode == RESULT_OK)
+        Web3Transaction web3Tx = data.getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
+        if (resultCode == RESULT_OK && web3Tx != null)
         {
-            Web3Transaction web3Tx = data.getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
             String hashData = data.getStringExtra(C.EXTRA_TRANSACTION_DATA);
             web3.onSignTransactionSuccessful(web3Tx, hashData);
         }
-        else
+        else if (web3Tx != null)
         {
-            Web3Transaction web3Tx = data.getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
             web3.onSignCancel(web3Tx);
         }
     }


### PR DESCRIPTION
Fix for bad callback return reported from crashlytics:

Most likely caused by a key failure in the confirmation page, so user is aware that the dapp transaction won't go through.

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.alphawallet.app.web3.Web3View.onSignTransactionSuccessful(com.alphawallet.app.web3.entity.Web3Transaction, java.lang.String)' on a null object reference
       at com.alphawallet.app.ui.DappBrowserFragment.handleTransactionCallback + 767(DappBrowserFragment.java:767)
       at com.alphawallet.app.ui.HomeActivity.onActivityResult + 849(HomeActivity.java:849)
       at android.app.Activity.dispatchActivityResult + 7761(Activity.java:7761)
       at android.app.ActivityThread.deliverResults + 4581(ActivityThread.java:4581)
       at android.app.ActivityThread.handleSendResult + 4630(ActivityThread.java:4630)
       at android.app.servertransaction.ActivityResultItem.execute + 49(ActivityResultItem.java:49)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 1926(ActivityThread.java:1926)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 6990(ActivityThread.java:6990)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 1445(ZygoteInit.java:1445)
```

