### PR TITLE
Fix for switching between wallet addr/contract addr

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -256,6 +256,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
             amountInput = null;
         }
 
+        displayAddress = wallet.address;
         setTitle(getString(R.string.my_wallet_address));
         address.setText(displayAddress);
         currentMode = MODE_ADDRESS;
@@ -339,8 +340,6 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
     {
         wallet = getIntent().getParcelableExtra(WALLET);
         token = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
-
-        if (currentMode != MODE_CONTRACT) displayAddress = wallet.address;
     }
 
     @Override


### PR DESCRIPTION
- Only affects devs (normal users won't see the option to display contract address, only ppl who've clicked on the XML override directory).
- switch between contract address and wallet address the address in the copy area wasn't updated correctly.