### PR TITLE
Improve tokenscript cache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
             INFURA_API_KEY = infuraAPI
         }
 
-        buildConfigField 'int', 'DB_VERSION', '5'
+        buildConfigField 'int', 'DB_VERSION', '6'
         buildConfigField "String", CoinmarketCapAPI, COINMARKET_CAP_KEY
         buildConfigField "String", AmberdataAPI, AMBERDATA_API_KEY
         buildConfigField "String", InfuraAPI, INFURA_API_KEY

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -48,11 +48,13 @@ public class ERC721Ticket extends Token implements Parcelable {
     public ERC721Ticket(TokenInfo tokenInfo, List<BigInteger> balances, long blancaTime, String networkName, ContractType type) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = balances;
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
     }
 
     public ERC721Ticket(TokenInfo tokenInfo, String balances, long blancaTime, String networkName, ContractType type) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = stringHexToBigIntegerList(balances);
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
     }
 
     private ERC721Ticket(Parcel in) {

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -61,11 +61,13 @@ public class Ticket extends Token implements Parcelable
     public Ticket(TokenInfo tokenInfo, List<BigInteger> balances, long blancaTime, String networkName, ContractType type) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = balances;
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
     }
 
     public Ticket(TokenInfo tokenInfo, String balances, long blancaTime, String networkName, ContractType type) {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = stringHexToBigIntegerList(balances);
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
     }
 
     private Ticket(Parcel in) {

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
@@ -110,8 +110,7 @@ public class TokenFactory
 
         }
 
-        thisToken.lastBlockCheck = realmItem.getLastBlock();
-        thisToken.lastTxCheck = realmItem.getUpdatedTime();
+        thisToken.setupRealmToken(realmItem);
 
         return thisToken;
     }
@@ -165,12 +164,5 @@ public class TokenFactory
     {
         return new TokenInfo(realmItem.getAddress(), realmItem.getName(), realmItem.getSymbol(),
                 realmItem.getDecimals(), true, realmItem.getChainId());
-    }
-
-    public Token createERC721Token(RealmERC721Token realmItem, List<Asset> assets, long updateTime, String networkName)
-    {
-        TokenInfo tf = new TokenInfo(realmItem.getAddress(), realmItem.getName(), realmItem.getSymbol(), 0, true, realmItem.getChainId());
-        ContractType type = ContractType.values()[realmItem.getContractType()];
-        return new ERC721Token(tf, assets, updateTime, networkName, type);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -366,7 +366,7 @@ public class TokensRealmSource implements TokenLocalSource {
             {
                 TokenFactory tf = new TokenFactory();
                 TokenInfo info = tf.createTokenInfo(realmToken);
-                result = tf.createToken(info, realmToken, realmToken.getAddedTime(), network.getShortName());
+                result = tf.createToken(info, realmToken, realmToken.getUpdateTime(), network.getShortName());
                 result.setTokenWallet(wallet.address);
                 result.setupRealmToken(realmToken);
             }
@@ -395,9 +395,8 @@ public class TokensRealmSource implements TokenLocalSource {
                     TokenFactory tf = new TokenFactory();
                     TokenInfo info = tf.createTokenInfo(rt);
                     NetworkInfo network = ethereumNetworkRepository.getNetworkByChain(info.chainId);
-                    Token newToken = tf.createToken(info, rt, rt.getAddedTime(), network.getShortName());//; new Token(info, balance, realmItem.getUpdatedTime());
+                    Token newToken = tf.createToken(info, rt, rt.getUpdateTime(), network.getShortName());//; new Token(info, balance, realmItem.getUpdatedTime());
                     newToken.setTokenWallet(wallet.address);
-                    newToken.setupRealmToken(rt);
                     if (address.equals(wallet.address)) newToken.setIsEthereum();
                     result.put(info.chainId, newToken);
                 }
@@ -521,7 +520,9 @@ public class TokensRealmSource implements TokenLocalSource {
             realmToken.setName(token.tokenInfo.name);
             realmToken.setSymbol(token.tokenInfo.symbol);
             realmToken.setDecimals(token.tokenInfo.decimals);
-            realmToken.setAddedTime(token.updateBlancaTime);
+            realmToken.setUpdateTime(token.updateBlancaTime);
+            realmToken.setTXUpdateTime(token.lastTxUpdate);
+            realmToken.setLastTxTime(token.lastTxTime);
             token.setRealmBalance(realmToken);
             token.setRealmInterfaceSpec(realmToken);
             token.setRealmLastBlock(realmToken);
@@ -538,9 +539,10 @@ public class TokensRealmSource implements TokenLocalSource {
             if (token.checkRealmBalanceChange(realmToken))
             {
                 //has token changed?
-                realmToken.setAddedTime(token.updateBlancaTime);
+                realmToken.setUpdateTime(token.updateBlancaTime);
                 token.setRealmInterfaceSpec(realmToken);
                 token.setRealmBalance(realmToken);
+                token.setRealmLastBlock(realmToken);
                 if (token.isERC721())
                 {
                     saveERC721Assets(realm, token);
@@ -701,9 +703,7 @@ public class TokensRealmSource implements TokenLocalSource {
         TokenInfo    info    = tf.createTokenInfo(realmItem);
 
         NetworkInfo  network = ethereumNetworkRepository.getNetworkByChain(info.chainId);
-        result = tf.createToken(info, realmItem, realmItem.getAddedTime(), network.getShortName());
-        result.lastBlockCheck = realmItem.getLastBlock();
-        result.lastTxCheck = realmItem.getUpdatedTime();
+        result = tf.createToken(info, realmItem, realmItem.getUpdateTime(), network.getShortName());
         result.setTokenWallet(wallet.address);
 
         if (result.isERC721()) //add erc721 assets
@@ -722,8 +722,7 @@ public class TokensRealmSource implements TokenLocalSource {
         realmToken.setName(token.tokenInfo.name);
         realmToken.setSymbol(token.tokenInfo.symbol);
         realmToken.setDecimals(0);
-        realmToken.setAddedTime(-1);
-        realmToken.setAddedTime(-1);
+        realmToken.setUpdateTime(-1);
         realmToken.setEnabled(false);
         realmToken.setInterfaceSpec(0);
         realmToken.setChainId(token.tokenInfo.chainId);

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
@@ -15,6 +15,7 @@ public class RealmToken extends RealmObject {
     private int decimals;
     private long addedTime;
     private long updatedTime;
+    private long lastTxTime;
     private String balance;
     private boolean isEnabled;
     private int tokenId;
@@ -55,19 +56,18 @@ public class RealmToken extends RealmObject {
         this.address = address;
     }
 
-    public long getAddedTime() {
+    public long getUpdateTime() {
         return addedTime;
     }
 
-    public void setAddedTime(long addedTime) {
+    public void setUpdateTime(long addedTime) {
         this.addedTime = addedTime;
     }
 
-    public long getUpdatedTime() {
+    public long getTXUpdateTime() {
         return updatedTime;
     }
-
-    public void setUpdatedTime(long updatedTime) {
+    public void setTXUpdateTime(long updatedTime) {
         this.updatedTime = updatedTime;
     }
 
@@ -135,4 +135,14 @@ public class RealmToken extends RealmObject {
 
     public int getChainId() { return chainId; }
     public void setChainId(int chainId) { this.chainId = chainId; }
+
+    public long getLastTxTime()
+    {
+        return lastTxTime;
+    }
+
+    public void setLastTxTime(long lastTxTime)
+    {
+        this.lastTxTime = lastTxTime;
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
+++ b/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
@@ -17,5 +17,12 @@ public class AWRealmMigration implements RealmMigration
             if (!realmTicker.hasField("currencySymbol")) realmTicker.addField("currencySymbol", String.class);
             oldVersion++;
         }
+        //Note: these version updates drop through; eg if oldVersion was 4, then the above code AND this code will execute
+        if (oldVersion == 5)
+        {
+            RealmObjectSchema realmToken = schema.get("RealmToken");
+            if (!realmToken.hasField("lastTxTime")) realmToken.addField("lastTxTime", long.class); //add the last transaction update time, used to check tokenscript cached result validity
+            oldVersion++;
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
@@ -21,7 +21,6 @@ public class TokenSortedItem extends SortedItem<Token> {
         {
             Token oldToken = value;
             Token newToken = (Token) newItem.value;
-
             if (!oldToken.getAddress().equals(newToken.getAddress())) return false;
             else if (weight != newItem.weight) return false;
             else if (!oldToken.getFullBalance().equals(newToken.getFullBalance())) return false;

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
@@ -11,6 +11,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
 import com.alphawallet.app.entity.NetworkInfo;
+import com.alphawallet.app.entity.TransactionContract;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.UnknownToken;
@@ -268,6 +269,7 @@ public class TransactionsViewModel extends BaseViewModel
         Log.d("TRANSACTION", "Queried for " + token.tokenInfo.name + " : " + transactions.length + " Network transactions");
 
         token.lastTxCheck = System.currentTimeMillis();
+        token.lastTxUpdate = System.currentTimeMillis();
         List<Transaction> newTxs = new ArrayList<>();
 
         //NB: final transaction is block marker transaction, it's not used. If it is relevant, then it's a duplicate.
@@ -298,7 +300,9 @@ public class TransactionsViewModel extends BaseViewModel
         //The final transaction is the last transaction read, and will have the highest block number we read
         if (transactions.length > 0)
         {
-            token.lastBlockCheck = Long.parseLong(transactions[transactions.length - 1].blockNumber);
+            Transaction lastTx = transactions[transactions.length - 1];
+            token.lastBlockCheck = Long.parseLong(lastTx.blockNumber);
+            token.lastTxTime = lastTx.timeStamp*1000; //update last transaction received time
 
             if (token.hasTokenScript) assetDefinitionService.updateEthereumResults(token)
                     .subscribeOn(Schedulers.io())

--- a/dmz/src/main/java/com/alphawallet/token/web/Ethereum/TokenscriptFunction.java
+++ b/dmz/src/main/java/com/alphawallet/token/web/Ethereum/TokenscriptFunction.java
@@ -670,7 +670,7 @@ public abstract class TokenscriptFunction
             if (cAddr == null) useAddress = new ContractAddress(attr.function);
             else useAddress = new ContractAddress(attr.function, cAddr.chainId, cAddr.address);
             TransactionResult transactionResult = attrIf.getFunctionResult(useAddress, attr, tokenId);
-            if (attrIf.resolveOptimisedAttr(useAddress, attr, transactionResult) || !transactionResult.needsUpdating(0)) //can we use wallet's known data or cached value?
+            if (attrIf.resolveOptimisedAttr(useAddress, attr, transactionResult) || !transactionResult.needsUpdating(-1)) //can we use wallet's known data or cached value?
             {
                 return resultFromDatabase(transactionResult, attr);
             }

--- a/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
@@ -27,8 +27,9 @@ public class TransactionResult
         resultTime = 0;
     }
 
-    public boolean needsUpdating(long lastTxCheck)
+    public boolean needsUpdating(long lastTxTime)
     {
-        return (lastTxCheck == 0 || (resultTime - lastTxCheck) <= 0);
+        //if contract had new transactions then update, or if last tx was -1 (always check)
+        return (resultTime == 0 || lastTxTime == -1 || lastTxTime > resultTime);
     }
 }


### PR DESCRIPTION
 - make dependent on the time of the last transaction to the block. After event handling goes in this can be instantly improved by updating the contract dependent tokenscript data when a new event is received.

- Fix for token update intervals. NFT's with balance were being treated the same as NFT's without balance.