### PR TITLE
Fix for crashlytics issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/PasswordInputView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/PasswordInputView.java
@@ -30,12 +30,11 @@ public class PasswordInputView extends LinearLayout implements TextView.OnEditor
 {
     private final Context context;
 
-    private TextView label;
-    private TextView error;
-    private EditText editText;
-    private CheckBox togglePassword;
-    private TextView instruction;
-    private RelativeLayout container;
+    private final TextView label;
+    private final TextView error;
+    private final EditText editText;
+    private final CheckBox togglePassword;
+    private final TextView instruction;
 
     private int labelResId;
     private int lines;
@@ -50,15 +49,19 @@ public class PasswordInputView extends LinearLayout implements TextView.OnEditor
     public PasswordInputView(Context context, AttributeSet attrs) {
         super(context, attrs);
         this.context = context;
-
         getAttrs(context, attrs);
 
-        bindViews();
+        inflate(context, R.layout.layout_password_input, this);
 
+        label = findViewById(R.id.label);
+        error = findViewById(R.id.error);
+        editText = findViewById(R.id.edit_text);
+        instruction = findViewById(R.id.instruction);
+        togglePassword = findViewById(R.id.toggle_password);
+
+        setViews();
         setLines();
-
         setImeOptions();
-
         setInputType();
         setMinHeight();
     }
@@ -78,17 +81,10 @@ public class PasswordInputView extends LinearLayout implements TextView.OnEditor
         return editText;
     }
 
-    private void bindViews() {
-        inflate(context, R.layout.layout_password_input, this);
-
-        label = findViewById(R.id.label);
+    private void setViews()
+    {
         label.setText(labelResId);
-        error = findViewById(R.id.error);
-        editText = findViewById(R.id.edit_text);
-        container = findViewById(R.id.box_layout);
-        instruction = findViewById(R.id.instruction);
         if (labelResId != R.string.empty) label.setVisibility(View.VISIBLE);
-        togglePassword = findViewById(R.id.toggle_password);
         togglePassword.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
                 editText.setTransformationMethod(HideReturnsTransformationMethod.getInstance());


### PR DESCRIPTION
Fix for crash issue seen in crashlytics: looks like the view was paged away, user looked something up and then got distracted. Came back to the view and the elements inside the password view had been scavenged.

Making them final ensures they would be re-set when the view comes back into focus.

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.CharSequence com.alphawallet.app.widget.PasswordInputView.getText()' on a null object reference
       at com.alphawallet.app.ui.BackupKeyActivity.FetchMnemonic + 752(BackupKeyActivity.java:752)
       at com.alphawallet.app.service.KeyService.authenticatePass + 823(KeyService.java:823)
       at com.alphawallet.app.service.KeyService.CompleteAuthentication + 800(KeyService.java:800)
       at com.alphawallet.app.ui.BackupKeyActivity.onActivityResult + 845(BackupKeyActivity.java:845)
       at android.app.Activity.dispatchActivityResult + 7276(Activity.java:7276)
       at android.app.ActivityThread.deliverResults + 4292(ActivityThread.java:4292)
       at android.app.ActivityThread.handleSendResult + 4340(ActivityThread.java:4340)
       at android.app.ActivityThread.-wrap19()
       at android.app.ActivityThread$H.handleMessage + 1650(ActivityThread.java:1650)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 164(Looper.java:164)
       at android.app.ActivityThread.main + 6543(ActivityThread.java:6543)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 440(RuntimeInit.java:440)
       at com.android.internal.os.ZygoteInit.main + 810(ZygoteInit.java:810)
```