### PR TITLE
make EthereumNetworkRepository not importing android classes so that …

### DIFF
--- a/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
+++ b/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
@@ -1,7 +1,6 @@
 package com.alphawallet.app.repository;
 
 import android.content.Context;
-import android.text.TextUtils;
 import android.view.View;
 
 import com.alphawallet.app.R;
@@ -18,10 +17,6 @@ public class EthereumNetworkRepository extends EthereumNetworkBase
     public EthereumNetworkRepository(PreferenceRepositoryType preferenceRepository, TickerService tickerService, Context ctx)
     {
         super(preferenceRepository, tickerService, new NetworkInfo[0], true);
-        /* defaultNetwork should already have a value by now */
-        if (getByName(preferences.getDefaultNetwork()) != null) {
-            defaultNetwork = getByName(preferences.getDefaultNetwork());
-        }
         context = ctx;
     }
 
@@ -65,16 +60,4 @@ public class EthereumNetworkRepository extends EthereumNetworkBase
         }
         return knownContracts;
     }
-
-    private NetworkInfo getByName(String name) {
-        if (!TextUtils.isEmpty(name)) {
-            for (NetworkInfo NETWORK : NETWORKS) {
-                if (name.equals(NETWORK.name)) {
-                    return NETWORK;
-                }
-            }
-        }
-        return null;
-    }
-
 }

--- a/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
+++ b/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
@@ -9,9 +9,7 @@ import com.alphawallet.app.entity.ContractResult;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.service.TickerService;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class EthereumNetworkRepository extends EthereumNetworkBase
 {
@@ -51,45 +49,22 @@ public class EthereumNetworkRepository extends EthereumNetworkBase
         return EthereumNetworkBase.getEtherscanURLbyNetwork(networkId);
     }
 
-    @Override
+    /* can't turn this one into one-liners like every other function
+     * in this file, without making either EthereumNetworkBase or
+     * ContractResult import android (therefore preventing their use
+     * in non-Android projects) or introducing a new trivial
+     * interface/class */
     public List<ContractResult> getAllKnownContracts(List<Integer> networkFilters)
     {
-        List<ContractResult> knownContracts = new ArrayList<>(getAllKnownContractsOnNetwork(context, EthereumNetworkRepository.MAINNET_ID, networkFilters));
-        knownContracts.addAll(getAllKnownContractsOnNetwork(context, EthereumNetworkRepository.XDAI_ID, networkFilters));
+        List<ContractResult> knownContracts = new ArrayList<>();
+        if (networkFilters.contains(EthereumNetworkRepository.MAINNET_ID)) {
+            knownContracts = Arrays.asList(ContractResult.fromAddresses(context.getResources().getStringArray(R.array.MainNet), EthereumNetworkRepository.MAINNET_ID));
+        }
+        if (networkFilters.contains(EthereumNetworkRepository.XDAI_ID)) {
+            knownContracts.addAll(Arrays.asList(ContractResult.fromAddresses(context.getResources().getStringArray(R.array.xDAI), EthereumNetworkRepository.XDAI_ID)));
+        }
         return knownContracts;
     }
-
-    private static List<ContractResult> getAllKnownContractsOnNetwork(Context context, int chainId, List<Integer> filters)
-    {
-        int index = 0;
-
-        if (!filters.contains((Integer)chainId)) return new ArrayList<>();
-
-        List<ContractResult> result = new ArrayList<>();
-        switch (chainId)
-        {
-            case EthereumNetworkRepository.XDAI_ID:
-                index = R.array.xDAI;
-                break;
-            case EthereumNetworkRepository.MAINNET_ID:
-                index = R.array.MainNet;
-                break;
-            default:
-                break;
-        }
-
-        if (index > 0)
-        {
-            String[] strArray = context.getResources().getStringArray(index);
-            for (String addr : strArray)
-            {
-                result.add(new ContractResult(addr, chainId));
-            }
-        }
-
-        return result;
-    }
-
 
     private NetworkInfo getByName(String name) {
         if (!TextUtils.isEmpty(name)) {

--- a/app/src/main/java/com/alphawallet/app/entity/ContractResult.java
+++ b/app/src/main/java/com/alphawallet/app/entity/ContractResult.java
@@ -2,8 +2,6 @@ package com.alphawallet.app.entity;
 
 import com.alphawallet.app.entity.tokens.Token;
 
-import java.util.List;
-
 /**
  * Created by James on 2/02/2019.
  * Stormbird in Singapore
@@ -33,21 +31,13 @@ public class ContractResult
         return (token != null && name != null && name.equalsIgnoreCase(token.getAddress()) && chainId == token.tokenInfo.chainId);
     }
 
-    public static void addIfNotInList(List<ContractResult> contractList, ContractResult candidate)
-    {
-        boolean inList = false;
-        for (ContractResult r : contractList)
-        {
-            if (r.name.equals(candidate.name) && r.chainId == candidate.chainId)
-            {
-                inList = true;
-                break;
-            }
+    /* replace this with a one-liner use of stream when we up our minSdkVersion to 24 */
+    public static ContractResult[] fromAddresses(String[] addresses, int chainID) {
+        ContractResult[] retval = new ContractResult[addresses.length];
+        for (int i=0; i<addresses.length; i++) {
+            retval[i] = new ContractResult(addresses[i], chainID);
         }
-
-        if (!inList)
-        {
-            contractList.add(candidate);
-        }
+        return retval;
     }
+
 }

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -1,5 +1,8 @@
 package com.alphawallet.app.repository;
 
+/* Please don't add import android at this point. Later this file will be shared
+ * between projects including non-Android projects */
+
 import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.ContractResult;

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -157,6 +157,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         /* then store the result list in a network variable */
         NETWORKS = networks.toArray(new NetworkInfo[0]);
 
+        defaultNetwork = getByName(preferences.getDefaultNetwork());
         if (defaultNetwork == null) {
             defaultNetwork = NETWORKS[0];
         }
@@ -181,6 +182,17 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         {
             if (EthereumNetworkRepository.hasRealValue(network.chainId) == withValue) result.add(network);
         }
+    }
+
+    private NetworkInfo getByName(String name) {
+        if (name != null && name != "") {
+            for (NetworkInfo NETWORK : NETWORKS) {
+                if (name.equals(NETWORK.name)) {
+                    return NETWORK;
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -391,7 +403,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
     {
         return MagicLinkInfo.getEtherscanURLbyNetwork(networkId);
     }
-    
+
     public static boolean hasGasOverride(int chainId)
     {
         return false;


### PR DESCRIPTION
…they can be used outside of android project (e.g. in dmz and util)

(DMZ and Util is not yet using this class newly stripped off its Android dependency. I am just staging the change in this PR)

to speed up @JamesSmartCell reading the diff, all changes are

- Moving stuff from abstract class to the sub-class so that only sub-class use android.Context and android.TextInput (previously the abstract class also used them)

- Changing variable types so that they can be accessed from the sub-class (given some code is moved to that sub class, variables needs to be accessible by them)

- Deleting functions that are no longer used.

- adding comments.