### PR TITLE
Reuse ethereum node configuration outside app project

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
+++ b/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
@@ -1,37 +1,8 @@
 package com.alphawallet.app.entity;
 
-public class NetworkInfo {
-    public final String name;
-    public final String symbol;
-    public final String rpcServerUrl;
-    public final String etherscanUrl;
-    public final int chainId;
-    public final boolean isMainNetwork;
-    public final String backupNodeUrl;
-    public final String etherscanTxUrl;
-    public final String tickerId;
-    public final String blockscoutAPI;
-
-    public NetworkInfo(
-            String name,
-            String symbol,
-            String rpcServerUrl,
-            String etherscanUrl,
-            int chainId,
-            boolean isMainNetwork,
-            String tickerId,
-            String blockscoutAPI) {
-        this.name = name;
-        this.symbol = symbol;
-        this.rpcServerUrl = rpcServerUrl;
-        this.etherscanUrl = etherscanUrl;
-        this.chainId = chainId;
-        this.isMainNetwork = isMainNetwork;
-        this.backupNodeUrl = null;
-        this.etherscanTxUrl = null;
-        this.tickerId = tickerId;
-        this.blockscoutAPI = blockscoutAPI;
-    }
+public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
+    public String backupNodeUrl = null;
+    public String etherscanTxUrl = null;
 
     public NetworkInfo(
             String name,
@@ -44,16 +15,9 @@ public class NetworkInfo {
             String etherscanTxUrl,
             String tickerId,
             String blockscoutAPI) {
-        this.name = name;
-        this.symbol = symbol;
-        this.rpcServerUrl = rpcServerUrl;
-        this.etherscanUrl = etherscanUrl;
-        this.chainId = chainId;
-        this.isMainNetwork = isMainNetwork;
+        super(name, symbol, rpcServerUrl, etherscanUrl, chainId, isMainNetwork, tickerId, blockscoutAPI);
         this.backupNodeUrl = backupNodeUrl;
         this.etherscanTxUrl = etherscanTxUrl;
-        this.tickerId = tickerId;
-        this.blockscoutAPI = blockscoutAPI;
     }
 
     public String getShortName()

--- a/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
+++ b/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
@@ -4,6 +4,19 @@ public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
     public String backupNodeUrl = null;
     public String etherscanTxUrl = null;
 
+
+    public NetworkInfo(
+            String name,
+            String symbol,
+            String rpcServerUrl,
+            String etherscanUrl,
+            int chainId,
+            boolean isMainNetwork,
+            String tickerId,
+            String blockscoutAPI) {
+        super(name, symbol, rpcServerUrl, etherscanUrl, chainId, isMainNetwork, tickerId, blockscoutAPI);
+    }
+
     public NetworkInfo(
             String name,
             String symbol,

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -149,6 +149,11 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
 
         /* merging static compile time network list with runtime network list */
         List<NetworkInfo> networks = new ArrayList<>();
+
+        /* the order is passed to the uesr interface. So if a user has a token on one
+         * of the additionalNetworks, the same token on DEFAULT_NETWORKS, and on a few
+         * test nets, they are displayed by that order.
+         */
         addNetworks(additionalNetworks, networks, true);
         addNetworks(DEFAULT_NETWORKS, networks, true);
         addNetworks(additionalNetworks, networks, false);

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -1,0 +1,95 @@
+package com.alphawallet.ethereum;
+
+/* Weiwu 12 Jan 2020: My original intention is to move this class from
+ * :app to :lib so all projects can utilize Ethereum node
+ * configuration and API keys configured in build.gradle.
+
+ * However, when I started this James Brown is in the middle of
+ * refactoring token classes in com.alphawallet.app.entity.tokens and
+ * EthereumNetworkBase.java uses the Token.java in that package.
+
+ * I see the need to make token class into those who handle token
+ * generically, and those who handle token in Android context,
+ * therefore I hope James Brown's refactoring is about moving certain
+ * logic to lib, but this is not confirmed.
+
+ * Eitherway, he marked all classes in
+ * com.alphawallet.app.entity.tokens untouchable until he finishes
+ * refactoring, so I created this
+ * com.alphawallet.ethereum.EthereumNetworkBase to partially duplicate
+ * the functionalities of
+ * com.alphawallet.app.repository.EthereumNetworkBase so that non-app
+ * projects can use node configurations
+ */
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public abstract class EthereumNetworkBase { // implements EthereumNetworkRepositoryType
+    public static final int MAINNET_ID = 1;
+    public static final int CLASSIC_ID = 61;
+    public static final int POA_ID = 99;
+    public static final int KOVAN_ID = 42;
+    public static final int ROPSTEN_ID = 3;
+    public static final int SOKOL_ID = 77;
+    public static final int RINKEBY_ID = 4;
+    public static final int XDAI_ID = 100;
+    public static final int GOERLI_ID = 5;
+    public static final int ARTIS_SIGMA1_ID = 246529;
+    public static final int ARTIS_TAU1_ID = 246785;
+
+    public static final String MAINNET_RPC_URL = "https://mainnet.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
+    public static final String CLASSIC_RPC_URL = "https://ethereumclassic.network";
+    public static final String XDAI_RPC_URL = "https://dai.poa.network";
+    public static final String POA_RPC_URL = "https://core.poa.network/";
+    public static final String ROPSTEN_RPC_URL = "https://ropsten.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
+    public static final String RINKEBY_RPC_URL = "https://rinkeby.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
+    public static final String KOVAN_RPC_URL = "https://kovan.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
+    public static final String SOKOL_RPC_URL = "https://sokol.poa.network";
+    public static final String GOERLI_RPC_URL = "https://goerli.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
+    public static final String ARTIS_SIGMA1_RPC_URL = "https://rpc.sigma1.artis.network";
+    public static final String ARTIS_TAU1_RPC_URL = "https://rpc.tau1.artis.network";
+
+    public static final String MAINNET_BLOCKSCOUT = "eth/mainnet";
+    public static final String CLASSIC_BLOCKSCOUT = "etc/mainnet";
+    public static final String XDAI_BLOCKSCOUT = "poa/dai";
+    public static final String POA_BLOCKSCOUT = "poa/core";
+    public static final String ROPSTEN_BLOCKSCOUT = "eth/ropsten";
+    public static final String RINKEBY_BLOCKSCOUT = "eth/rinkeby";
+    public static final String SOKOL_BLOCKSCOUT = "poa/sokol";
+    public static final String KOVAN_BLOCKSCOUT = "eth/kovan";
+    public static final String GOERLI_BLOCKSCOUT = "eth/goerli";
+
+    static Map<Integer, NetworkInfo> networkMap = new LinkedHashMap<Integer, NetworkInfo>() {
+        {
+            put(MAINNET_ID, new NetworkInfo("Ethereum", "ETH", MAINNET_RPC_URL, "https://etherscan.io/tx/",
+                    MAINNET_ID, true, "ethereum", MAINNET_BLOCKSCOUT));
+            put(CLASSIC_ID, new NetworkInfo("Ethereum Classic", "ETC", CLASSIC_RPC_URL, "https://gastracker.io/tx/",
+                    CLASSIC_ID, true, "ethereum-classic", CLASSIC_BLOCKSCOUT));
+            put(XDAI_ID, new NetworkInfo("xDAI", "xDAI", XDAI_RPC_URL, "https://blockscout.com/poa/dai/tx/",
+                    XDAI_ID, false, "dai", XDAI_BLOCKSCOUT));
+            put(POA_ID, new NetworkInfo("POA", "POA", POA_RPC_URL, "https://poaexplorer.com/txid/search/",
+                    POA_ID, false, "ethereum", POA_BLOCKSCOUT));
+            put(ARTIS_SIGMA1_ID, new NetworkInfo("ARTIS sigma1", "ATS", ARTIS_SIGMA1_RPC_URL, "https://explorer.sigma1.artis.network/tx/",
+                    ARTIS_SIGMA1_ID, false, "artis", ""));
+            put(KOVAN_ID, new NetworkInfo("Kovan (Test)", "ETH", KOVAN_RPC_URL, "https://kovan.etherscan.io/tx/",
+                    KOVAN_ID, false, "ethereum", KOVAN_BLOCKSCOUT));
+            put(ROPSTEN_ID, new NetworkInfo("Ropsten (Test)", "ETH", ROPSTEN_RPC_URL, "https://ropsten.etherscan.io/tx/",
+                    ROPSTEN_ID, false, "ethereum", ROPSTEN_BLOCKSCOUT));
+            put(SOKOL_ID, new NetworkInfo("Sokol (Test)", "POA", SOKOL_RPC_URL, "https://sokol-explorer.poa.network/account/",
+                    SOKOL_ID, false, "ethereum", SOKOL_BLOCKSCOUT));
+            put(RINKEBY_ID, new NetworkInfo("Rinkeby (Test)", "ETH", RINKEBY_RPC_URL, "https://rinkeby.etherscan.io/tx/",
+                    RINKEBY_ID, false, "ethereum", RINKEBY_BLOCKSCOUT));
+            put(GOERLI_ID, new NetworkInfo("Görli (Test)", "GÖETH", GOERLI_RPC_URL, "https://goerli.etherscan.io/tx/",
+                    GOERLI_ID, false, "ethereum", GOERLI_BLOCKSCOUT));
+            put(ARTIS_TAU1_ID, new NetworkInfo("ARTIS tau1 (Test)", "ATS", ARTIS_TAU1_RPC_URL, "https://explorer.tau1.artis.network/tx/",
+                    ARTIS_TAU1_ID, false, "artis", ""));
+        }
+    };
+
+    public static NetworkInfo getNetworkByChain(int chainId) {
+        return networkMap.get(chainId);
+    }
+
+}

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -1,27 +1,8 @@
 package com.alphawallet.ethereum;
 
-/* Weiwu 12 Jan 2020: My original intention is to move this class from
- * :app to :lib so all projects can utilize Ethereum node
- * configuration and API keys configured in build.gradle.
-
- * However, when I started this James Brown is in the middle of
- * refactoring token classes in com.alphawallet.app.entity.tokens and
- * EthereumNetworkBase.java uses the Token.java in that package.
-
- * I see the need to make token class into those who handle token
- * generically, and those who handle token in Android context,
- * therefore I hope James Brown's refactoring is about moving certain
- * logic to lib, but this is not confirmed.
-
- * Eitherway, he marked all classes in
- * com.alphawallet.app.entity.tokens untouchable until he finishes
- * refactoring, so I created this
- * com.alphawallet.ethereum.EthereumNetworkBase to partially duplicate
- * the functionalities of
- * com.alphawallet.app.repository.EthereumNetworkBase so that non-app
- * projects can use node configurations
+/* Weiwu 12 Jan 2020: This class eventually will replace the EthereumNetworkBase class in :app
+ * one all inteface methods are implemented.
  */
-
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/lib/src/main/java/com/alphawallet/ethereum/NetworkInfo.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/NetworkInfo.java
@@ -1,0 +1,37 @@
+package com.alphawallet.ethereum;
+
+/* it's some kind of Trust Ethereum Wallet naming convention that a
+ * class that has no behaviour (equivalent of C's struct) is called
+ * SomethingInfo. I didn't agree with this naming convention but I'll
+ * keep it here */
+
+public class NetworkInfo {
+    public final String name;
+    public final String symbol;
+    public final String rpcServerUrl;
+    public final String etherscanUrl;
+    public final int chainId;
+    public final boolean isMainNetwork;
+    public final String tickerId;
+    public final String blockscoutAPI;
+
+    public NetworkInfo(
+            String name,
+            String symbol,
+            String rpcServerUrl,
+            String etherscanUrl,
+            int chainId,
+            boolean isMainNetwork,
+            String tickerId,
+            String blockscoutAPI) {
+        this.name = name;
+        this.symbol = symbol;
+        this.rpcServerUrl = rpcServerUrl;
+        this.etherscanUrl = etherscanUrl;
+        this.chainId = chainId;
+        this.isMainNetwork = isMainNetwork;
+        this.tickerId = tickerId;
+        this.blockscoutAPI = blockscoutAPI;
+    }
+
+}

--- a/util/src/main/java/com/alphawallet/scripttool/Entity/TokenscriptFunction.java
+++ b/util/src/main/java/com/alphawallet/scripttool/Entity/TokenscriptFunction.java
@@ -116,6 +116,7 @@ import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Numeric;
+import com.alphawallet.ethereum.EthereumNetworkBase;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -609,7 +610,8 @@ public abstract class TokenscriptFunction
                     .retryOnConnectionFailure(false)
                     .build();
 
-            HttpService nodeService = new HttpService(MagicLinkInfo.getNodeURLByNetworkId(useAddress.chainId), okClient, false);
+            String nodeURL = EthereumNetworkBase.getNetworkByChain(useAddress.chainId).rpcServerUrl;
+            HttpService nodeService = new HttpService(nodeURL, okClient, false);
 
             Web3j web3j = Web3j.build(nodeService);
 

--- a/util/src/main/java/com/alphawallet/scripttool/Ethereum/TransactionHandler.java
+++ b/util/src/main/java/com/alphawallet/scripttool/Ethereum/TransactionHandler.java
@@ -1,7 +1,7 @@
 package com.alphawallet.scripttool.Ethereum;
 
 
-import com.alphawallet.token.entity.MagicLinkInfo;
+import com.alphawallet.ethereum.EthereumNetworkBase;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.FunctionReturnDecoder;
 import org.web3j.abi.TypeReference;
@@ -34,7 +34,7 @@ public class TransactionHandler
 
     public TransactionHandler(int networkId)
     {
-        String nodeURL = MagicLinkInfo.getNodeURLByNetworkId(networkId);
+        String nodeURL = EthereumNetworkBase.getNetworkByChain(networkId).rpcServerUrl;
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.connectTimeout(20, TimeUnit.SECONDS);
         builder.readTimeout(20, TimeUnit.SECONDS);


### PR DESCRIPTION
this solves #1063 

This won't break anything in app because minor change applied. It stages for the next improvement which will come in a few weeks which is to make both class reusable (currently simply class with same name are created with part of the content and one inherit the other).