### PR TITLE
Fix for when tokenscript function returns null

### DIFF
--- a/lib/src/main/java/com/alphawallet/token/entity/AttributeType.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/AttributeType.java
@@ -175,7 +175,11 @@ public class AttributeType {
                 return data;
             case Integer:
                 //convert to integer
-                if (Character.isDigit(data.charAt(0)))
+                if (data.length() == 0)
+                {
+                    return "0";
+                }
+                else if (Character.isDigit(data.charAt(0)))
                 {
                     return data;
                 }


### PR DESCRIPTION
If Tokenscript function has no return then integer output should be zero.