### PR TITLE
Fix ERC721 Token display for no script tokens

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -232,6 +232,9 @@ public class ERC721Ticket extends Token implements Parcelable {
         }
         else
         {
+            activity.findViewById(R.id.layout_legacy).setVisibility(View.VISIBLE);
+            activity.findViewById(R.id.layout_webwrapper).setVisibility(View.GONE);
+
             TextView amount = activity.findViewById(R.id.amount);
             TextView name = activity.findViewById(R.id.name);
 


### PR DESCRIPTION
Fix token display so all ERC721 tickets are still shown if there's no tokenscript for that token.