### PR TITLE
Fix for balance discrepancy between opensea and contract method

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -535,6 +535,8 @@ public class TokensService
             Token existingToken = getToken(newToken.tokenInfo.chainId, newToken.tokenInfo.address);
             if (existingToken == null || existingToken.checkBalanceChange(newToken))
             {
+                //opensea is potentially unreliable for ERC721 Ticket class
+                if (existingToken != null && existingToken.isERC721Ticket()) continue; //don't take the opensea balance for ERC721 ticket if the token is already known (use contract's getBalance instead).
                 balanceChangedTokens.add(newToken);
                 addToken(newToken);
             }


### PR DESCRIPTION
Give priority to ERC721Ticket type getBalance rather than opensea balance.

Tokens can still be discovered by opensea, but once discovered, the internal 'getBalance' method will take over checking.