### PR TITLE
rename to private key

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/WalletType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/WalletType.java
@@ -11,5 +11,5 @@ public enum WalletType
     HDKEY,
     WATCH,
     TEXT_MARKER, // used as a separator in wallet view
-    KEYSTORE_LEGACY  // to support keys created from old wallets
+    PRIVATE_KEY  // to support keys created from old wallets
 }

--- a/app/src/main/java/com/alphawallet/app/repository/WalletDataRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletDataRealmSource.java
@@ -83,7 +83,7 @@ public class WalletDataRealmSource {
                 {
                     RealmKeyType realmKey = realm.createObject(RealmKeyType.class, wallet.address);
                     wallet.authLevel = KeyService.AuthenticationLevel.TEE_NO_AUTHENTICATION;
-                    wallet.type = WalletType.KEYSTORE_LEGACY;
+                    wallet.type = WalletType.PRIVATE_KEY;
                     realmKey.setType(wallet.type); //all keys are legacy
                     realmKey.setLastBackup(System.currentTimeMillis());
                     realmKey.setDateAdded(wallet.walletCreationTime);

--- a/app/src/main/java/com/alphawallet/app/service/KeyService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeyService.java
@@ -45,7 +45,6 @@ import java.util.List;
 
 import static android.os.VibrationEffect.DEFAULT_AMPLITUDE;
 import static com.alphawallet.app.entity.Operation.*;
-import static com.alphawallet.app.entity.ServiceErrorException.ServiceErrorCode.INVALID_KEY;
 import static com.alphawallet.app.entity.tokenscript.TokenscriptFunction.ZERO_ADDRESS;
 import static com.alphawallet.app.service.KeyService.AuthenticationLevel.STRONGBOX_NO_AUTHENTICATION;
 import static com.alphawallet.app.service.KeyService.AuthenticationLevel.TEE_NO_AUTHENTICATION;
@@ -254,7 +253,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
 
         switch (wallet.type)
         {
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
                 signCallback.GotAuthorisation(true); //Legacy keys don't require authentication
                 break;
             case KEYSTORE:
@@ -296,7 +295,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         switch (wallet.type)
         {
             case KEYSTORE:
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
                 checkAuthentication(UPGRADE_KEYSTORE_KEY);
                 return UpgradeKeyResult.REQUESTING_SECURITY;
             case HDKEY:
@@ -327,7 +326,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         currentWallet = wallet;
         switch (wallet.type)
         {
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
                 return signWithKeystore(transactionBytes);
             case KEYSTORE:
                 return signWithKeystore(transactionBytes);
@@ -382,7 +381,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
                     password = unpackMnemonic();
                     callback.FetchMnemonic(password);
                     break;
-                case KEYSTORE_LEGACY:
+                case PRIVATE_KEY:
                     password = new String(getLegacyPassword(context, wallet.address));
                     callback.FetchMnemonic(password);
                     break;
@@ -562,7 +561,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
                 case KEYSTORE:
                     secretData = unpackMnemonic();
                     break;
-                case KEYSTORE_LEGACY:
+                case PRIVATE_KEY:
                     secretData = new String(getLegacyPassword(context, currentWallet.address));
                     break;
                 default:
@@ -1055,7 +1054,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
                 case KEYSTORE:
                     password = unpackMnemonic();
                     break;
-                case KEYSTORE_LEGACY:
+                case PRIVATE_KEY:
                     password = new String(getLegacyPassword(context, currentWallet.address));
                     break;
                 default:
@@ -1241,7 +1240,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         for (Wallet w : walletList)
         {
             //Test legacy key
-            if (w.type == WalletType.KEYSTORE_LEGACY)
+            if (w.type == WalletType.PRIVATE_KEY)
             {
                 try
                 {

--- a/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
@@ -178,7 +178,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
         switch (wallet.type)
         {
             case KEYSTORE:
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
             case HDKEY:
                 switch (viewModel.upgradeKeySecurity(wallet, this, this))
                 {
@@ -210,7 +210,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
         {
             switch (wallet.type)
             {
-                case KEYSTORE_LEGACY:
+                case PRIVATE_KEY:
                 case KEYSTORE:
                 case HDKEY:
                     viewModel.upgradeWallet(address);
@@ -528,7 +528,7 @@ public class BackupKeyActivity extends BaseActivity implements View.OnClickListe
         Intent intent = new Intent();
         switch (wallet.type)
         {
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
             case KEYSTORE:
                 intent.putExtra("TYPE", BackupOperationType.BACKUP_KEYSTORE_KEY);
                 break;

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -334,7 +334,7 @@ public class NewSettingsFragment extends Fragment
             case HDKEY:
                 intent.putExtra("TYPE", BackupKeyActivity.BackupOperationType.BACKUP_HD_KEY);
                 break;
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
             case KEYSTORE:
                 intent.putExtra("TYPE", BackupKeyActivity.BackupOperationType.BACKUP_KEYSTORE_KEY);
                 break;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsAdapter.java
@@ -88,7 +88,7 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> imple
             default:
             case WATCH:
             case KEYSTORE:
-            case KEYSTORE_LEGACY:
+            case PRIVATE_KEY:
             case HDKEY:
                 return WalletHolder.VIEW_TYPE;
             case TEXT_MARKER:
@@ -117,7 +117,7 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> imple
             {
                 switch (w.type)
                 {
-                    case KEYSTORE_LEGACY:
+                    case PRIVATE_KEY:
                     case KEYSTORE:
                         hasLegacyWallet = true;
                         break;
@@ -140,7 +140,7 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> imple
 
                 for (Wallet w : wallets)
                 {
-                    if (w.type == WalletType.KEYSTORE || w.type == WalletType.KEYSTORE_LEGACY)
+                    if (w.type == WalletType.KEYSTORE || w.type == WalletType.PRIVATE_KEY)
                     {
                         this.wallets.add(w);
                     }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletHolder.java
@@ -86,7 +86,7 @@ public class WalletHolder extends BinderViewHolder<Wallet> implements View.OnCli
 
 		switch (wallet.type)
 		{
-			case KEYSTORE_LEGACY:
+			case PRIVATE_KEY:
 			case KEYSTORE:
 			case HDKEY:
 				switch (wallet.authLevel)


### PR DESCRIPTION
Found this while trying to debug #1091, seems that keys are being authenticated on their type rather than whether they are secured by the enclave or not. This PR simply renames an incorrectly named enum. 