### PR TITLE
Prevent rendering previous locale before new locale is loaded 

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -69,6 +69,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.lang.reflect.Method;
 
+import static com.alphawallet.app.C.CHANGED_LOCALE;
 import static com.alphawallet.app.widget.AWalletBottomNavigationView.*;
 
 public class HomeActivity extends BaseNavigationActivity implements View.OnClickListener, HomeCommsInterface, FragmentMessenger, Runnable, SignAuthenticationCallback
@@ -148,6 +149,10 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
 
+        viewModel = ViewModelProviders.of(this, homeViewModelFactory)
+                .get(HomeViewModel.class);
+        viewModel.setLocale(this);
+
         setContentView(R.layout.activity_home);
 
         DisplayMetrics displayMetrics = new DisplayMetrics();
@@ -189,11 +194,8 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         systemView.attachRecyclerView(list);
         systemView.attachSwipeRefreshLayout(refreshLayout);
 
-        viewModel = ViewModelProviders.of(this, homeViewModelFactory)
-                .get(HomeViewModel.class);
         viewModel.progress().observe(this, systemView::showProgress);
         viewModel.error().observe(this, this::onError);
-        viewModel.setLocale(this);
         viewModel.installIntent().observe(this, this::onInstallIntent);
         viewModel.walletName().observe(this, this::onWalletName);
         viewModel.backUpMessage().observe(this, this::onBackup);
@@ -858,7 +860,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 }
                 break;
             case C.UPDATE_LOCALE:
-                ((NewSettingsFragment)settingsFragment).updateLocale(data);
+                updateLocale(data);
                 break;
             default:
                 super.onActivityResult(requestCode, resultCode, data);
@@ -919,5 +921,13 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     void postponeWalletBackupWarning(String walletAddress)
     {
         removeSettingsBadgeKey(C.KEY_NEEDS_BACKUP);
+    }
+
+    public void updateLocale(Intent data)
+    {
+        if (data == null) return;
+        String newLocale = data.getStringExtra(C.EXTRA_LOCALE);
+        sendBroadcast(new Intent(CHANGED_LOCALE));
+        viewModel.updateLocale(newLocale, this);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -519,14 +519,4 @@ public class NewSettingsFragment extends Fragment
         layoutBackup.setVisibility(View.GONE);
         if (getActivity() != null) ((HomeActivity)getActivity()).postponeWalletBackupWarning(walletAddress);
     }
-
-    public void updateLocale(Intent data)
-    {
-        String currentLocale = viewModel.getDefaultLocale();
-        if (data == null) return;
-        String newLocale = data.getStringExtra(C.EXTRA_LOCALE);
-        viewModel.setDefaultLocale(getContext(), newLocale);
-        localeSubtext.setText(LocaleUtils.getDisplayLanguage(newLocale, currentLocale));
-        getActivity().sendBroadcast(new Intent(CHANGED_LOCALE));
-    }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -163,6 +163,15 @@ public class HomeViewModel extends BaseViewModel {
         addTokenRouter.open(context, address);
     }
 
+    public void updateLocale(String newLocale, Context context)
+    {
+        localeRepository.setDefaultLocale(context, newLocale);
+        //restart activity
+        Intent intent = new Intent(context, HomeActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        context.startActivity(intent);
+    }
+
     public void setLocale(HomeActivity activity) {
         //get the current locale
         String currentLocale = localeRepository.getDefaultLocale();

--- a/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModel.java
@@ -109,11 +109,6 @@ public class NewSettingsViewModel extends BaseViewModel {
         return localeRepository.getDefaultLocale();
     }
 
-    public void setDefaultLocale(Context context, String locale) {
-        localeRepository.setDefaultLocale(context, locale);
-        showHome(context, true); //Refresh activity to reflect changes
-    }
-
     public NetworkInfo[] getNetworkList() {
         return ethereumNetworkRepository.getAvailableNetworkList();
     }


### PR DESCRIPTION
During extensive testing of language switching (ie changing app language) a potential race condition was discovered. This was fixed through some simplification and re-ordering of code.