### PR TITLE
set gas limit to 1 million if function is unknown

### DIFF
--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -111,6 +111,7 @@ public abstract class C {
     public static final String DEFAULT_XDAI_GAS_PRICE = "1000000000";
     public static final String DEFAULT_GAS_LIMIT = "90000";
     public static final String DEFAULT_GAS_LIMIT_FOR_TOKENS = "144000";
+    public static final String DEFAULT_UNKNOWN_FUNCTION_GAS_LIMIT = "1000000"; //if we don't know the specific function, we default to 1 million gas limit
     public static final String DEFAULT_GAS_LIMIT_FOR_NONFUNGIBLE_TOKENS = "432000"; //NFT's typically require more gas
     public static final String DEFAULT_GAS_LIMIT_FOR_END_CONTRACT = "200000"; //TODO: determine appropriate gas limit for contract destruct
     public static final long GAS_PER_BYTE = 310; //from experimentation

--- a/app/src/main/java/com/alphawallet/app/service/GasService.java
+++ b/app/src/main/java/com/alphawallet/app/service/GasService.java
@@ -160,7 +160,7 @@ public class GasService implements ContractGasProvider
                 return new BigInteger(C.DEFAULT_GAS_LIMIT_FOR_NONFUNGIBLE_TOKENS).multiply(BigInteger.valueOf(2));
 
             default:
-                return new BigInteger(C.DEFAULT_GAS_LIMIT_FOR_TOKENS);
+                return new BigInteger(C.DEFAULT_UNKNOWN_FUNCTION_GAS_LIMIT);
         }
     }
 


### PR DESCRIPTION
Fixes #1102 

Gas limit defaults to 144000 for TokenScript functions that are unknown, this is too low for certain complex functions like the one in the issue. Instead we set it to 1 million (same in iOS) 