### PR TITLE
checksum wallet address in app

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -38,6 +38,7 @@ import com.alphawallet.app.viewmodel.MyAddressViewModel;
 import com.alphawallet.app.viewmodel.MyAddressViewModelFactory;
 import com.alphawallet.app.widget.FunctionButtonBar;
 
+import org.web3j.crypto.Keys;
 import org.web3j.utils.Convert;
 
 import java.math.BigDecimal;
@@ -256,7 +257,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
             amountInput = null;
         }
 
-        displayAddress = wallet.address;
+        displayAddress = Keys.toChecksumAddress(wallet.address);
         setTitle(getString(R.string.my_wallet_address));
         address.setText(displayAddress);
         currentMode = MODE_ADDRESS;


### PR DESCRIPTION
Fixes #445

Note: it still is lower case for contract address as this comes from Lib and lib cannot import web3J without breaking app code which also uses web3J