### PR TITLE
Fix: malicious takeover of previously owned ENS names

### DIFF
--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -40,7 +40,7 @@ public abstract class C {
     public static final String ARTIS_TAU1_SYMBOL = "ATS";
 
     public static final String BURN_ADDRESS = "0x0000000000000000000000000000000000000000";
-    public static final String ENSCONTRACT = "0x314159265dD8dbb310642f98f50C066173C1259b";
+    public static final String ENSCONTRACT = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
     public static final String GWEI_UNIT = "Gwei";
 


### PR DESCRIPTION
This PR handles the change required by https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a by updating the registrar contract

Replaces #1117 