### PR TITLE
Fix Tokenscript Result fetch

### DIFF
--- a/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
@@ -30,6 +30,6 @@ public class TransactionResult
     public boolean needsUpdating(long lastTxTime)
     {
         //if contract had new transactions then update, or if last tx was -1 (always check)
-        return (resultTime == 0 || lastTxTime == -1 || lastTxTime > resultTime);
+        return (resultTime == 0 || lastTxTime <= 0 || lastTxTime > resultTime);
     }
 }


### PR DESCRIPTION
Ensure Tokenscript result is always re-fetched for external contract. Fixes test issue where the 'Enable' call wasn't registering.