### PR TITLE
Fix error display

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
@@ -1,5 +1,6 @@
 package com.alphawallet.app.ui;
 
+import android.app.Activity;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
@@ -52,7 +53,7 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     private PinAuthenticationCallbackInterface authInterface;
     private String importPath = null;
     private Handler handler = new Handler();
-    AWalletAlertDialog aDialog;
+    private String errorMessage;
 
     @Override
     protected void attachBaseContext(Context base) {
@@ -99,7 +100,11 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
 
         splashViewModel.fetchWallets();
         splashViewModel.checkVersionUpdate(getBaseContext(), getAppUpdateTime);
-        aDialog = new AWalletAlertDialog(this);
+    }
+
+    protected Activity getThisActivity()
+    {
+        return this;
     }
 
     //wallet created, now check if we need to import
@@ -234,23 +239,26 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     }
 
     @Override
-    public void onResume()
-    {
-        super.onResume();
-        if (aDialog == null) aDialog = new AWalletAlertDialog(this);
-    }
-
-    @Override
     public void keyFailure(String message)
     {
-        if (aDialog == null) return;
-        aDialog.setTitle(R.string.key_error);
-        aDialog.setIcon(AWalletAlertDialog.ERROR);
-        aDialog.setMessage(message);
-        aDialog.setButtonText(R.string.dialog_ok);
-        aDialog.setButtonListener(v -> aDialog.dismiss());
-        aDialog.show();
+        errorMessage = message;
+        handler.post(displayError);
     }
+
+    Runnable displayError = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            AWalletAlertDialog aDialog = new AWalletAlertDialog(getThisActivity());
+            aDialog.setTitle(R.string.key_error);
+            aDialog.setIcon(AWalletAlertDialog.ERROR);
+            aDialog.setMessage(errorMessage);
+            aDialog.setButtonText(R.string.dialog_ok);
+            aDialog.setButtonListener(v -> aDialog.dismiss());
+            aDialog.show();
+        }
+    };
 
     @Override
     public void cancelAuthentication()

--- a/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
@@ -239,10 +239,17 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     }
 
     @Override
+    public void onDestroy()
+    {
+        super.onDestroy();
+        handler = null;
+    }
+
+    @Override
     public void keyFailure(String message)
     {
         errorMessage = message;
-        handler.post(displayError);
+        if (handler != null) handler.post(displayError);
     }
 
     Runnable displayError = new Runnable()

--- a/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
@@ -52,6 +52,7 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     private PinAuthenticationCallbackInterface authInterface;
     private String importPath = null;
     private Handler handler = new Handler();
+    AWalletAlertDialog aDialog;
 
     @Override
     protected void attachBaseContext(Context base) {
@@ -98,6 +99,7 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
 
         splashViewModel.fetchWallets();
         splashViewModel.checkVersionUpdate(getBaseContext(), getAppUpdateTime);
+        aDialog = new AWalletAlertDialog(this);
     }
 
     //wallet created, now check if we need to import
@@ -232,9 +234,16 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     }
 
     @Override
+    public void onResume()
+    {
+        super.onResume();
+        if (aDialog == null) aDialog = new AWalletAlertDialog(this);
+    }
+
+    @Override
     public void keyFailure(String message)
     {
-        AWalletAlertDialog aDialog = new AWalletAlertDialog(this);
+        if (aDialog == null) return;
         aDialog.setTitle(R.string.key_error);
         aDialog.setIcon(AWalletAlertDialog.ERROR);
         aDialog.setMessage(message);


### PR DESCRIPTION
Fixes two related issues from crashlytics:

This is caused because the calling activity of the error is no longer current because it's coming from a different process. The patch sends the error to a handler that can only run if the activity is current.

```
Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@7218b99 is not valid; is your activity running?
       at android.view.ViewRootImpl.setView + 1056(ViewRootImpl.java:1056)
       at android.view.WindowManagerGlobal.addView + 381(WindowManagerGlobal.java:381)
       at android.view.WindowManagerImpl.addView + 93(WindowManagerImpl.java:93)
       at android.app.Dialog.show + 470(Dialog.java:470)
       at com.alphawallet.app.ui.SplashActivity.keyFailure + 243(SplashActivity.java:243)
       at com.alphawallet.app.service.KeyService.keyFailure + 902(KeyService.java:902)
       at com.alphawallet.app.service.KeyService.lambda$AuthorisationFailMessage$2$KeyService + 937(KeyService.java:937)
       at com.alphawallet.app.service.-$$Lambda$KeyService$qMSNhHv0DgowEJr2buDUyE88hGE.onClick + 2(:2)
       at android.view.View.performClick + 7333(View.java:7333)
       at android.widget.TextView.performClick + 14160(TextView.java:14160)
       at android.view.View.performClickInternal + 7299(View.java:7299)
       at android.view.View.access$3200 + 846(View.java:846)
       at android.view.View$PerformClick.run + 27773(View.java:27773)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 6986(ActivityThread.java:6986)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 494(RuntimeInit.java:494)
       at com.android.internal.os.ZygoteInit.main + 1445(ZygoteInit.java:1445)
```

and 

```
Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@b0e79f4 is not valid; is your activity running?
       at android.view.ViewRootImpl.setView + 858(ViewRootImpl.java:858)
       at android.view.WindowManagerGlobal.addView + 356(WindowManagerGlobal.java:356)
       at android.view.WindowManagerImpl.addView + 94(WindowManagerImpl.java:94)
       at android.app.Dialog.show + 329(Dialog.java:329)
       at com.alphawallet.app.ui.WalletsActivity.onCreateWalletError + 144(WalletsActivity.java:144)
       at com.alphawallet.app.ui.WalletsActivity.keyFailure + 338(WalletsActivity.java:338)
       at com.alphawallet.app.service.KeyService.keyFailure + 902(KeyService.java:902)
       at com.alphawallet.app.service.KeyService.lambda$AuthorisationFailMessage$2$KeyService + 937(KeyService.java:937)
       at com.alphawallet.app.service.-$$Lambda$KeyService$qMSNhHv0DgowEJr2buDUyE88hGE.onClick + 2(:2)
       at android.view.View.performClick + 6614(View.java:6614)
       at android.view.View.performClickInternal + 6591(View.java:6591)
       at android.view.View.access$3100 + 786(View.java:786)
       at android.view.View$PerformClick.run + 25948(View.java:25948)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 201(Looper.java:201)
       at android.app.ActivityThread.main + 6806(ActivityThread.java:6806)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 547(RuntimeInit.java:547)
       at com.android.internal.os.ZygoteInit.main + 873(ZygoteInit.java:873)
```