### PR TITLE
Fix Import issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
@@ -354,14 +354,14 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         {
             case spawnable:
                 importTickets.setText(R.string.action_import);
-                token.displayTicketHolder(ticketRange, baseView, viewModel.getAssetDefinitionService(), getBaseContext());
+                if (token != null) token.displayTicketHolder(ticketRange, baseView, viewModel.getAssetDefinitionService(), getBaseContext());
                 break;
             case currencyLink:
                 importTickets.setText(R.string.action_import);
                 break;
             default:
                 importTxt.setText(R.string.ticket_import_valid);
-                token.displayTicketHolder(ticketRange, baseView, viewModel.getAssetDefinitionService(), getBaseContext());
+                if (token != null) token.displayTicketHolder(ticketRange, baseView, viewModel.getAssetDefinitionService(), getBaseContext());
                 break;
         }
     }


### PR DESCRIPTION
Ensure if token hasn't been processed the import can still continue. Token was still null when this message displayed.

Reported from crashlytics:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.alphawallet.app.entity.Token.displayTicketHolder(com.alphawallet.token.entity.TicketRange, android.view.View, com.alphawallet.app.service.AssetDefinitionService, android.content.Context)' on a null object reference
       at com.alphawallet.app.ui.ImportTokenActivity.displayImportAction + 366(ImportTokenActivity.java:366)
       at com.alphawallet.app.ui.ImportTokenActivity.onFeemasterAvailable + 402(ImportTokenActivity.java:402)
       at com.alphawallet.app.ui.ImportTokenActivity.lambda$c_SOVjllPXSV7ZJ-fR2ankLX2Gg()
       at com.alphawallet.app.ui.-$$Lambda$ImportTokenActivity$c_SOVjllPXSV7ZJ-fR2ankLX2Gg.onChanged + 4(:4)
       at android.arch.lifecycle.LiveData.considerNotify + 109(LiveData.java:109)
       at android.arch.lifecycle.LiveData.dispatchingValue + 126(LiveData.java:126)
       at android.arch.lifecycle.LiveData.setValue + 282(LiveData.java:282)
       at android.arch.lifecycle.MutableLiveData.setValue + 33(MutableLiveData.java:33)
       at android.arch.lifecycle.LiveData$1.run + 87(LiveData.java:87)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 207(Looper.java:207)
       at android.app.ActivityThread.main + 6878(ActivityThread.java:6878)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 547(RuntimeInit.java:547)
       at com.android.internal.os.ZygoteInit.main + 876(ZygoteInit.java:876)
```