### PR TITLE
Fix address view issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -89,12 +89,11 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         screenWidth = (int) ((float)DisplayUtils.getScreenResolution(this).x * 0.8f);
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
+        initViewModel();
         overrideNetwork = 0;
         getInfo();
-
-        getPreviousMode();
-
         viewModel.prepare();
+        getPreviousMode();
     }
 
     private void getPreviousMode() {
@@ -221,7 +220,6 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
     private void showPointOfSaleMode() {
         setContentView(R.layout.activity_eip681);
         initViews();
-        initViewModel();
         getInfo();
         //Generate QR link for receive payment.
         //Initially just generate simple payment.
@@ -248,7 +246,6 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         getInfo();
         setContentView(R.layout.activity_my_address);
         initViews();
-        initViewModel();
         findViewById(R.id.toolbar_title).setVisibility(View.VISIBLE);
 
         if (amountInput != null)
@@ -277,7 +274,6 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         getInfo();
         setContentView(R.layout.activity_contract_address);
         initViews();
-        initViewModel();
         findViewById(R.id.toolbar_title).setVisibility(View.VISIBLE);
 
         currentMode = MODE_CONTRACT;


### PR DESCRIPTION
Fix address view issue and tidy up code.

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'com.alphawallet.app.repository.EthereumNetworkRepositoryType com.alphawallet.app.viewmodel.MyAddressViewModel.getEthereumNetworkRepository()' on a null object reference
       at com.alphawallet.app.ui.MyAddressActivity.getPreviousMode + 109(MyAddressActivity.java:109)
       at com.alphawallet.app.ui.MyAddressActivity.onCreate + 94(MyAddressActivity.java:94)
       at android.app.Activity.performCreate + 7327(Activity.java:7327)
       at android.app.Activity.performCreate + 7318(Activity.java:7318)
       at android.app.Instrumentation.callActivityOnCreate + 1271(Instrumentation.java:1271)
       at android.app.ActivityThread.performLaunchActivity + 3096(ActivityThread.java:3096)
       at android.app.ActivityThread.handleLaunchActivity + 3259(ActivityThread.java:3259)
       at android.app.servertransaction.LaunchActivityItem.execute + 78(LaunchActivityItem.java:78)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 1950(ActivityThread.java:1950)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 7073(ActivityThread.java:7073)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 494(RuntimeInit.java:494)
       at com.android.internal.os.ZygoteInit.main + 964(ZygoteInit.java:964)
```
