### PR TITLE
Cache certificate data

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ android {
             INFURA_API_KEY = infuraAPI
         }
 
-        buildConfigField 'int', 'DB_VERSION', '6'
+        buildConfigField 'int', 'DB_VERSION', '7'
         buildConfigField "String", CoinmarketCapAPI, COINMARKET_CAP_KEY
         buildConfigField "String", AmberdataAPI, AMBERDATA_API_KEY
         buildConfigField "String", InfuraAPI, INFURA_API_KEY
@@ -68,7 +68,7 @@ android {
     productFlavors {
 	awallet {
 		dimension "targetting"
-        versionCode 84
+        versionCode 88
         versionName "2.20.0"
 	}
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ android {
     productFlavors {
 	awallet {
 		dimension "targetting"
-        versionCode 88
+        versionCode 84
         versionName "2.20.0"
 	}
     }

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmCertificateData.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmCertificateData.java
@@ -1,0 +1,123 @@
+package com.alphawallet.app.repository.entity;
+
+import com.alphawallet.token.entity.SigReturnType;
+import com.alphawallet.token.entity.XMLDsigDescriptor;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+/**
+ * Created by JB on 4/02/2020.
+ */
+public class RealmCertificateData extends RealmObject
+{
+    @PrimaryKey
+    private String instanceKey; //should be token address and tokenID
+    private String result;
+    private String subject;
+    private String keyName;
+    private String keyType;
+    private String issuer;
+    private String certificateName;
+    private int type;
+
+    public String getInstanceKey()
+    {
+        return instanceKey;
+    }
+
+    public void setInstanceKey(String instanceKey)
+    {
+        this.instanceKey = instanceKey;
+    }
+
+    public void setFromSig(XMLDsigDescriptor sig)
+    {
+        result = sig.result;
+        subject = sig.subject;
+        keyName = sig.keyName;
+        keyType = sig.keyType;
+        issuer = sig.issuer;
+        certificateName = sig.certificateName;
+        if (sig.type == null)
+        {
+            if (sig.result != null && sig.result.equals("pass")) type = SigReturnType.SIGNATURE_PASS.ordinal();
+            else type = SigReturnType.SIGNATURE_INVALID.ordinal();
+        }
+        else
+        {
+            type = sig.type.ordinal();
+        }
+    }
+
+    public String getResult()
+    {
+        return result;
+    }
+
+    public void setResult(String result)
+    {
+        this.result = result;
+    }
+
+    public String getKeyName()
+    {
+        return keyName;
+    }
+
+    public void setKeyName(String keyName)
+    {
+        this.keyName = keyName;
+    }
+
+    public String getSubject()
+    {
+        return subject;
+    }
+
+    public void setSubject(String subject)
+    {
+        this.subject = subject;
+    }
+
+    public SigReturnType getType()
+    {
+        return SigReturnType.values()[type];
+    }
+
+    public void setType(SigReturnType type)
+    {
+        if (type == null && this.result.equals("pass"))
+        this.type = type.ordinal();
+    }
+
+    public String getIssuer()
+    {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer)
+    {
+        this.issuer = issuer;
+    }
+
+    public String getCertificateName()
+    {
+        return certificateName;
+    }
+
+    public void setCertificateName(String certificateName)
+    {
+        this.certificateName = certificateName;
+    }
+
+    public String getKeyType()
+    {
+        return keyType;
+    }
+
+    public void setKeyType(String keyType)
+    {
+        this.keyType = keyType;
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmCertificateData.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmCertificateData.java
@@ -12,7 +12,7 @@ import io.realm.annotations.PrimaryKey;
 public class RealmCertificateData extends RealmObject
 {
     @PrimaryKey
-    private String instanceKey; //should be token address and tokenID
+    private String instanceKey; //File hash
     private String result;
     private String subject;
     private String keyName;

--- a/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
+++ b/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
@@ -1,6 +1,9 @@
 package com.alphawallet.app.service;
 
+import com.alphawallet.app.repository.entity.RealmCertificateData;
+
 import io.realm.DynamicRealm;
+import io.realm.FieldAttribute;
 import io.realm.RealmMigration;
 import io.realm.RealmObjectSchema;
 import io.realm.RealmSchema;
@@ -22,6 +25,21 @@ public class AWRealmMigration implements RealmMigration
         {
             RealmObjectSchema realmToken = schema.get("RealmToken");
             if (!realmToken.hasField("lastTxTime")) realmToken.addField("lastTxTime", long.class); //add the last transaction update time, used to check tokenscript cached result validity
+            oldVersion++;
+        }
+
+        //Version 6
+        if (oldVersion == 6)
+        {
+            schema.create("RealmCertificateData")
+                    .addField("instanceKey", String.class, FieldAttribute.PRIMARY_KEY)
+                    .addField("result", String.class, FieldAttribute.INDEXED)
+                    .addField("subject", String.class, FieldAttribute.INDEXED)
+                    .addField("keyName", String.class, FieldAttribute.INDEXED)
+                    .addField("keyType", String.class, FieldAttribute.INDEXED)
+                    .addField("issuer", String.class, FieldAttribute.INDEXED)
+                    .addField("certificateName", String.class, FieldAttribute.INDEXED)
+                    .addField("type", int.class, FieldAttribute.INDEXED);
             oldVersion++;
         }
     }

--- a/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
+++ b/app/src/main/java/com/alphawallet/app/service/AWRealmMigration.java
@@ -33,13 +33,13 @@ public class AWRealmMigration implements RealmMigration
         {
             schema.create("RealmCertificateData")
                     .addField("instanceKey", String.class, FieldAttribute.PRIMARY_KEY)
-                    .addField("result", String.class, FieldAttribute.INDEXED)
-                    .addField("subject", String.class, FieldAttribute.INDEXED)
-                    .addField("keyName", String.class, FieldAttribute.INDEXED)
-                    .addField("keyType", String.class, FieldAttribute.INDEXED)
-                    .addField("issuer", String.class, FieldAttribute.INDEXED)
-                    .addField("certificateName", String.class, FieldAttribute.INDEXED)
-                    .addField("type", int.class, FieldAttribute.INDEXED);
+                    .addField("result", String.class)
+                    .addField("subject", String.class)
+                    .addField("keyName", String.class)
+                    .addField("keyType", String.class)
+                    .addField("issuer", String.class)
+                    .addField("certificateName", String.class)
+                    .addField("type", int.class);
             oldVersion++;
         }
     }

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -90,7 +90,7 @@ import static com.alphawallet.token.tools.TokenDefinition.TOKENSCRIPT_REPO_SERVE
 
 public class AssetDefinitionService implements ParseResult, AttributeInterface
 {
-    private static final String CERTIFICATE_DB = "REALM_CERTS";
+    private static final String CERTIFICATE_DB = "CERTIFICATE_CACHE-db.realm";
 
     private final Context context;
     private final OkHttpClient okHttpClient;
@@ -445,11 +445,6 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
     private void loadScriptFromServer(String correctedAddress)
     {
-        Token t = tokensService.getToken(1, correctedAddress);
-        if (t != null && t.tokenInfo.name.contains("SAI"))
-        {
-            System.out.println("yoless");
-        }
         //first check the last time we tried this session
         if (assetChecked.get(correctedAddress) == null || (System.currentTimeMillis() - assetChecked.get(correctedAddress)) > 1000*60*60)
         {

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -26,6 +26,7 @@ import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
 import com.alphawallet.app.repository.TokenLocalSource;
 import com.alphawallet.app.repository.TransactionsRealmCache;
 import com.alphawallet.app.repository.entity.RealmAuxData;
+import com.alphawallet.app.repository.entity.RealmCertificateData;
 import com.alphawallet.app.ui.HomeActivity;
 import com.alphawallet.app.viewmodel.HomeViewModel;
 import com.alphawallet.token.entity.AttributeInterface;
@@ -67,6 +68,7 @@ import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -88,14 +90,14 @@ import static com.alphawallet.token.tools.TokenDefinition.TOKENSCRIPT_REPO_SERVE
 
 public class AssetDefinitionService implements ParseResult, AttributeInterface
 {
+    private static final String CERTIFICATE_DB = "REALM_CERTS";
+
     private final Context context;
     private final OkHttpClient okHttpClient;
 
     private SparseArray<Map<String, TokenScriptFile>> assetDefinitions;
     private Map<String, Long> assetChecked;                //Mapping of contract address to when they were last fetched from server
     private FileObserver fileObserver;                     //Observer which scans the override directory waiting for file change
-    private Map<String, TokenScriptFileData> fileHashes;                //Mapping of files and hashes.
-
     private final NotificationService notificationService;
     private final RealmManager realmManager;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
@@ -115,7 +117,6 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         okHttpClient = client;
         assetChecked = new HashMap<>();
         tokenTypeName = new SparseArray<>();
-        fileHashes = new ConcurrentHashMap<>();
         notificationService = svs;
         realmManager = rm;
         ethereumNetworkRepository = eth;
@@ -431,11 +432,8 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         try
         {
             TokenScriptFile tsf = getTokenScriptFile(chainId, address);
-            TokenScriptFileData fd = fileHashes.get(tsf.getAbsolutePath());
-            if (tsf.fileUnchanged(fd))
-            {
-                issuer = fd.sigDescriptor.keyName;
-            }
+            XMLDsigDescriptor sig = getCertificateFromRealm(tsf.calcMD5());
+            if (sig != null) issuer = sig.keyName;
         }
         catch (Exception e)
         {
@@ -447,10 +445,16 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
     private void loadScriptFromServer(String correctedAddress)
     {
+        Token t = tokensService.getToken(1, correctedAddress);
+        if (t != null && t.tokenInfo.name.contains("SAI"))
+        {
+            System.out.println("yoless");
+        }
         //first check the last time we tried this session
         if (assetChecked.get(correctedAddress) == null || (System.currentTimeMillis() - assetChecked.get(correctedAddress)) > 1000*60*60)
         {
             fetchXMLFromServer(correctedAddress)
+                    .flatMap(this::updateSignature)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(this::handleFileLoad, this::onError).isDisposed();
@@ -496,6 +500,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
             //peek to see if this file exists
             File existingFile = getXMLFile(address);
+            result = existingFile;
             long fileTime = 0;
             if (existingFile != null && existingFile.exists())
             {
@@ -623,11 +628,13 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                 for (int network : holdingContracts.addresses.keySet())
                 {
                     addContractsToNetwork(network, networkAddresses(holdingContracts.addresses.get(network), asset));
-                    TokenScriptFileData fd = new TokenScriptFileData();
-                    fd.hash = tsf.calcMD5();
-                    fd.sigDescriptor = new XMLDsigDescriptor();
-                    fd.sigDescriptor.result = "pass";
-                    fileHashes.put(asset, fd);
+                    XMLDsigDescriptor AWSig = new XMLDsigDescriptor();
+                    String hash = tsf.calcMD5();
+                    AWSig.result = "pass";
+                    AWSig.issuer = "AlphaWallet";
+                    AWSig.keyName = "AlphaWallet";
+                    AWSig.type = SigReturnType.SIGNATURE_PASS;
+                    storeCertificateData(hash, AWSig);
                 }
                 return true;
             }
@@ -751,9 +758,81 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         //check all definitions in the download zone
         Disposable d = Observable.fromIterable(getScriptsInSecureZone())
                 .concatMap(addr -> fetchXMLFromServer(addr).toObservable())
+                .flatMap(f -> updateSignature(f).toObservable())
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::handleFileLoad, this::onError);
+    }
+
+    private Single<File> updateSignature(File file)
+    {
+        return Single.fromCallable(() -> {
+            TokenScriptFile tsf = new TokenScriptFile(context, file.getAbsolutePath());
+            String hash = tsf.calcMD5();
+            //pull data from realm
+            XMLDsigDescriptor sig = getCertificateFromRealm(hash);
+            if (sig == null)
+            {
+                //fetch signature and store in realm
+                sig = alphaWalletService.checkTokenScriptSignature(tsf);
+                storeCertificateData(hash, sig);
+            }
+
+            return file;
+        });
+    }
+
+    private void storeCertificateData(String hash, XMLDsigDescriptor sig)
+    {
+        try (Realm realm = realmManager.getRealmInstance(CERTIFICATE_DB))
+        {
+            //if signature present, then just update
+            RealmCertificateData realmData = realm.where(RealmCertificateData.class)
+                    .equalTo("instanceKey", hash)
+                    .findFirst();
+
+            TransactionsRealmCache.addRealm();
+            realm.beginTransaction();
+            if (realmData == null) realmData = realm.createObject(RealmCertificateData.class, hash);
+            realmData.setFromSig(sig);
+            realm.commitTransaction();
+            realm.close();
+            TransactionsRealmCache.subRealm();
+        }
+        catch (Exception e)
+        {
+            TransactionsRealmCache.subRealm();
+            e.printStackTrace();
+        }
+    }
+
+    private XMLDsigDescriptor getCertificateFromRealm(String hash)
+    {
+        XMLDsigDescriptor sig = null;
+        try (Realm realm = realmManager.getRealmInstance(CERTIFICATE_DB))
+        {
+            RealmCertificateData realmCert = realm.where(RealmCertificateData.class)
+                    .equalTo("instanceKey", hash)
+                    .findFirst();
+
+            if (realmCert != null)
+            {
+                sig = new XMLDsigDescriptor();
+                sig.issuer = realmCert.getIssuer();
+                sig.certificateName = realmCert.getCertificateName();
+                sig.keyName = realmCert.getKeyName();
+                sig.keyType = realmCert.getKeyType();
+                sig.result = realmCert.getResult();
+                sig.subject = realmCert.getSubject();
+                sig.type = realmCert.getType();
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return sig;
     }
 
     /**
@@ -874,15 +953,15 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                                         Environment.getExternalStorageDirectory()
                                                 + File.separator + HomeViewModel.ALPHAWALLET_DIR, s);
 
-                                TokenScriptFileData fData = fileHashes.get(newTSFile.getAbsolutePath());
+                                //TokenScriptFileData fData = fileHashes.get(newTSFile.getAbsolutePath());
                                 if (addContractAddresses(newTSFile))
                                 {
-                                    if (fData == null) fData = new TokenScriptFileData();
-                                    fData.hash = newTSFile.calcMD5();
-                                    fData.sigDescriptor = null;
                                     notificationService.DisplayNotification("Definition Updated", s, NotificationCompat.PRIORITY_MAX);
                                     cachedDefinition = null;
-                                    fileHashes.put(newTSFile.getAbsolutePath(), fData);
+                                    updateSignature(newTSFile) //update signature data if necessary
+                                            .subscribeOn(Schedulers.io())
+                                            .observeOn(AndroidSchedulers.mainThread())
+                                            .subscribe().isDisposed();
                                 }
                             }
                         }
@@ -933,25 +1012,16 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
             sigDescriptor.type = SigReturnType.NO_TOKENSCRIPT;
 
             TokenScriptFile tsf = getTokenScriptFile(chainId, contractAddress);
-            if (tsf.isValidTokenScript())
+            if (tsf != null)
             {
-                TokenScriptFileData fd = fileHashes.get(tsf.getAbsolutePath());
-                if (tsf.fileUnchanged(fd))
+                String hash = tsf.calcMD5();
+                XMLDsigDescriptor sig = getCertificateFromRealm(hash);
+                if (sig == null)
                 {
-                    return fd.sigDescriptor;
+                    sig = alphaWalletService.checkTokenScriptSignature(tsf);
+                    storeCertificateData(hash, sig);
                 }
-                else
-                {
-                    if (fd == null)
-                    {
-                        fd = new TokenScriptFileData();
-                        fileHashes.put(tsf.getAbsolutePath(), fd);
-                    }
-                    fd.sigDescriptor = alphaWalletService.checkTokenScriptSignature(tsf);
-                    tsf.determineSignatureType(fd);
-                }
-                fd.hash = tsf.calcMD5();
-                sigDescriptor = fd.sigDescriptor;
+                if (sig != null) sigDescriptor = sig;
             }
 
             return sigDescriptor;
@@ -1181,6 +1251,8 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
             e.printStackTrace();
         }
     }
+
+    //private Token
 
     private void addOpenSeaAttributes(StringBuilder attrs, Token erc721Token, BigInteger tokenId)
     {

--- a/app/src/main/java/com/alphawallet/app/service/RealmManager.java
+++ b/app/src/main/java/com/alphawallet/app/service/RealmManager.java
@@ -19,7 +19,7 @@ public class RealmManager {
         return getRealmInstance(wallet.address + "-db.realm");
     }
 
-    private Realm getRealmInstance(String name) {
+    public Realm getRealmInstance(String name) {
         try
         {
             RealmConfiguration config = realmConfigurations.get(name);


### PR DESCRIPTION
Due to the recent mod where TokenScript certificate issuer is used in the token card, for consistent UI experience it was necessary to cache the certificate details.

Certificate details are now cached against the file hash of the tokenscript. This means if the script is changed the cached details become invalid and are re-synced. Also the tokenscript is periodically re-checked, at this time the certificate is also re-cached.