### PR TITLE
uses correct HTTP code and message for failed imports 

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
@@ -495,7 +495,7 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
         hideDialog();
         aDialog = new AWalletAlertDialog(this);
         aDialog.setIcon(AWalletAlertDialog.ERROR);
-        aDialog.setTitle(R.string.error_transaction_failed);
+        aDialog.setTitle(R.string.error_import_failed);
         aDialog.setMessage(error.message);
         aDialog.setCancelable(true);
         aDialog.setButtonText(R.string.button_ok);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/ImportTokenViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/ImportTokenViewModel.java
@@ -513,8 +513,8 @@ public class ImportTokenViewModel extends BaseViewModel
         {
             switch (result)
             {
-                case 501:
-                    txError.postValue(new ErrorEnvelope(C.ErrorCode.EMPTY_COLLECTION, "Duplicate transaction passed."));
+                case 400:
+                    txError.postValue(new ErrorEnvelope(C.ErrorCode.EMPTY_COLLECTION, "Token already claimed."));
                     break;
                 case 401:
                     txError.postValue(new ErrorEnvelope(C.ErrorCode.EMPTY_COLLECTION, "Signature invalid."));

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -75,6 +75,7 @@
     <string name="error_invalid_address">Invalid address</string>
     <string name="error_invalid_amount">Invalid amount</string>
     <string name="error_transaction_failed">Transaction error</string>
+    <string name="error_import_failed">Error al importar el token</string>
     <string name="error_must_numeric">must be a numeric value.</string>
     <string name="transaction_succeeded">Transaction successful</string>
     <string name="NA">N/A</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -67,6 +67,7 @@
     <string name="error_invalid_address">无效地址</string>
     <string name="error_invalid_amount">无效金额</string>
     <string name="error_transaction_failed">交易错误</string>
+    <string name="error_import_failed">导入令牌失败</string>
     <string name="error_must_numeric">必须为一个数值。</string>
     <string name="transaction_succeeded">交易成功</string>
     <string name="NA">不适用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="error_invalid_address">Invalid address</string>
     <string name="error_invalid_amount">Invalid amount</string>
     <string name="error_transaction_failed">Transaction error</string>
+    <string name="error_import_failed">Failed to import token</string>
     <string name="error_must_numeric">must be a numeric value.</string>
     <string name="transaction_succeeded">Transaction successful</string>
     <string name="NA">N/A</string>


### PR DESCRIPTION
Closes https://github.com/AlphaWallet/alpha-wallet-android/issues/854

https://github.com/AlphaWallet/alpha-wallet-android/issues/854 was already mostly solved but the wrong HTTP code and message are displayed for already claimed magic links