### PR TITLE
Fix Debug Tokenscript Issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 
 import com.alphawallet.token.entity.SigReturnType;
+import com.alphawallet.token.entity.XMLDsigDescriptor;
 
 public class TokenScriptFile extends File
 {
@@ -130,31 +131,31 @@ public class TokenScriptFile extends File
         return !getAbsolutePath().startsWith(privateArea);
     }
 
-    public void determineSignatureType(TokenScriptFileData fd)
+    public void determineSignatureType(XMLDsigDescriptor sigDescriptor)
     {
         boolean isDebug = isDebug();
-        if (fd.sigDescriptor.result.equals("pass"))
+        if (sigDescriptor.result.equals("pass"))
         {
-            if (isDebug) fd.sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_PASS;
-            else fd.sigDescriptor.type = SigReturnType.SIGNATURE_PASS;
+            if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_PASS;
+            else sigDescriptor.type = SigReturnType.SIGNATURE_PASS;
         }
-        else if (fd.sigDescriptor.subject != null)
+        else if (sigDescriptor.subject != null)
         {
-            if (fd.sigDescriptor.subject.contains("Invalid"))
+            if (sigDescriptor.subject.contains("Invalid"))
             {
-                if (isDebug) fd.sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_INVALID;
-                else fd.sigDescriptor.type = SigReturnType.SIGNATURE_INVALID;
+                if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_INVALID;
+                else sigDescriptor.type = SigReturnType.SIGNATURE_INVALID;
             }
             else
             {
-                if (isDebug) fd.sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
-                else fd.sigDescriptor.type = SigReturnType.NO_SIGNATURE;
+                if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
+                else sigDescriptor.type = SigReturnType.NO_SIGNATURE;
             }
         }
         else
         {
-            if (isDebug) fd.sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
-            else fd.sigDescriptor.type = SigReturnType.NO_SIGNATURE;
+            if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
+            else sigDescriptor.type = SigReturnType.NO_SIGNATURE;
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -629,6 +629,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                     AWSig.issuer = "AlphaWallet";
                     AWSig.keyName = "AlphaWallet";
                     AWSig.type = SigReturnType.SIGNATURE_PASS;
+                    tsf.determineSignatureType(AWSig);
                     storeCertificateData(hash, AWSig);
                 }
                 return true;
@@ -770,6 +771,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
             {
                 //fetch signature and store in realm
                 sig = alphaWalletService.checkTokenScriptSignature(tsf);
+                tsf.determineSignatureType(sig);
                 storeCertificateData(hash, sig);
             }
 
@@ -1014,9 +1016,10 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
                 if (sig == null)
                 {
                     sig = alphaWalletService.checkTokenScriptSignature(tsf);
+                    tsf.determineSignatureType(sig);
                     storeCertificateData(hash, sig);
                 }
-                if (sig != null) sigDescriptor = sig;
+                sigDescriptor = sig;
             }
 
             return sigDescriptor;

--- a/app/src/main/java/com/alphawallet/app/widget/CertifiedToolbarView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/CertifiedToolbarView.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.alphawallet.token.entity.SigReturnType;
 import com.alphawallet.token.entity.XMLDsigDescriptor;
 import com.alphawallet.app.R;
 
@@ -34,14 +35,15 @@ public class CertifiedToolbarView extends android.support.v7.widget.Toolbar
         activity = act;
         findViewById(R.id.certificate_spinner).setVisibility(View.GONE);
         ImageView lockStatus = findViewById(R.id.image_lock);
-        //TextView signatureMessage = findViewById(R.id.text_verified);
         lockStatus.setVisibility(View.VISIBLE);
 
         lockStatus.setOnClickListener(view -> {
             showCertificateDetails(sigData);
         });
 
-        switch (sigData.type)
+        SigReturnType type = sigData.type != null ? sigData.type : SigReturnType.NO_TOKENSCRIPT;
+
+        switch (type)
         {
             case NO_TOKENSCRIPT:
                 lockStatus.setVisibility(View.GONE);
@@ -52,7 +54,6 @@ public class CertifiedToolbarView extends android.support.v7.widget.Toolbar
             case DEBUG_SIGNATURE_INVALID:
                 lockResource = R.mipmap.ic_unlocked_debug;
                 lockStatus.setImageResource(R.mipmap.ic_unlocked_debug);
-                //signatureMessage.setText(R.string.certificate_fail);
                 break;
             case DEBUG_SIGNATURE_PASS:
                 lockResource = R.mipmap.ic_locked_debug;


### PR DESCRIPTION
Fix issue where debug scripts did work correctly because the signature type isn't set. Ensure the signature type is set so the correct lock symbol can be displayed.

Introduced by the Certificate cache patch.