### PR TITLE
Fix Title render

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletActionsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletActionsActivity.java
@@ -32,7 +32,6 @@ public class WalletActionsActivity extends BaseActivity implements View.OnClickL
     WalletActionsViewModelFactory walletActionsViewModelFactory;
     WalletActionsViewModel viewModel;
 
-    private TextView walletTitle;
     private TextView walletBalance;
     private TextView walletAddress;
     private LinearLayout successOverlay;
@@ -145,8 +144,6 @@ public class WalletActionsActivity extends BaseActivity implements View.OnClickL
     }
 
     private void initViews() {
-        walletTitle = findViewById(R.id.wallet_title);
-
         walletBalance = findViewById(R.id.wallet_balance);
         walletBalance.setText(String.format("%s %s", wallet.balance, currencySymbol));
 

--- a/app/src/main/res/layout/activity_rotating_signature.xml
+++ b/app/src/main/res/layout/activity_rotating_signature.xml
@@ -5,29 +5,30 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        layout="@layout/layout_simple_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true" />
+
     <FrameLayout
+        android:layout_below="@id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/colorPrimary">
-
-        <include
-            layout="@layout/layout_simple_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="30dp"
+            android:layout_marginBottom="10dp"
             android:layout_marginTop="10dp"
             android:fontFamily="@font/font_light"
             android:gravity="center"
             android:paddingLeft="40dp"
             android:paddingRight="40dp"
-            android:text="Show QR Code to Redemption Booth:"
-            android:textColor="@color/white"
+            android:text="@string/show_qr_code_to_redemption_booth"
+            android:textColor="@color/colorPrimaryDark"
             android:textSize="25sp" />
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_wallet_actions.xml
+++ b/app/src/main/res/layout/activity_wallet_actions.xml
@@ -9,24 +9,12 @@
     <include layout="@layout/layout_simple_toolbar" />
 
     <LinearLayout
+        android:layout_below="@id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="?android:actionBarSize"
         android:background="@drawable/background_card"
         android:orientation="vertical"
-        android:paddingTop="5dp">
-
-        <TextView
-            android:id="@+id/wallet_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:fontFamily="@font/font_bold"
-            android:gravity="center"
-            android:paddingLeft="30dp"
-            android:paddingRight="30dp"
-            android:textColor="@color/text_black"
-            android:textSize="20sp" />
+        android:paddingTop="16dp">
 
         <TextView
             android:id="@+id/wallet_balance"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -535,4 +535,5 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript Standard</string>
     <string name="version">Version</string>
+    <string name="show_qr_code_to_redemption_booth">Mostrar código QR al contador de canje</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -524,4 +524,5 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript 标准</string>
     <string name="version">版本</string>
+    <string name="show_qr_code_to_redemption_booth">呈递二维码到兑换台</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -535,4 +535,5 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript Standard</string>
     <string name="version">Version</string>
+    <string name="show_qr_code_to_redemption_booth">Show QR Code to Redemption Booth:</string>
 </resources>


### PR DESCRIPTION
This fixes two instances where text can overwrite other text where layouts were changed to relative layout with toolbar. Manifested mainly on the Redeem page where white text overlayed the title.