### PR TITLE
Refactor Issuer Name

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -167,18 +167,7 @@ public class ERC721Ticket extends Token implements Parcelable {
     {
         tokenHolder.balanceCurrency.setText("--");
         tokenHolder.textAppreciation.setText("--");
-        String issuerName = asset.getIssuerName(tokenHolder.token);
-        tokenHolder.issuer.setText(asset.getIssuerName(tokenHolder.token));
-        if(issuerName != null)
-        {
-            tokenHolder.issuer.setText(issuerName);
-        }
-        else
-        {
-            tokenHolder.issuerPlaceholder.setVisibility(View.GONE);
-        }
         tokenHolder.contractType.setVisibility(View.VISIBLE);
-        tokenHolder.contractSeparator.setVisibility(View.VISIBLE);
         if (VisibilityFilter.getImageOverride() != 0)
         {
             tokenHolder.icon.setVisibility(View.VISIBLE);
@@ -194,28 +183,11 @@ public class ERC721Ticket extends Token implements Parcelable {
         tokenHolder.layoutValueDetails.setVisibility(View.GONE);
     }
 
-    @Override
-    public int[] getTicketIndices(String ticketIds)
-    {
-        return null;
-    }
-
     /*************************************
      *
      * Conversion functions used for manipulating indices
      *
      */
-
-    /**
-     * Convert a String list of ticket IDs into a list of ticket indices
-     * @param userList
-     * @return
-     */
-    @Override
-    public List<BigInteger> ticketIdStringToIndexList(String userList)
-    {
-        return null;
-    }
 
     /**
      * This is a single method that populates any instance of graphic ticket anywhere
@@ -325,12 +297,6 @@ public class ERC721Ticket extends Token implements Parcelable {
     }
 
     @Override
-    public int interfaceOrdinal()
-    {
-        return contractType.ordinal();
-    }
-
-    @Override
     public BigInteger getTokenID(int index)
     {
         if (balanceArray.size() > index && index >= 0) return balanceArray.get(index);
@@ -397,14 +363,6 @@ public class ERC721Ticket extends Token implements Parcelable {
         return isSent;
     }
 
-    @Override
-    public boolean isERC875() {
-        return false;
-    }
-    @Override
-    public boolean isToken() {
-        return false;
-    }
     @Override
     public boolean isERC721Ticket() { return true; }
 

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -120,15 +120,6 @@ public class ERC721Token extends Token implements Parcelable
         int balance = tokenBalanceAssets.size();
 
         holder.balanceEth.setText(String.valueOf(balance));
-        String issuerName = definition.getIssuerName(holder.token);
-        if(issuerName != null)
-        {
-            holder.issuer.setText(definition.getIssuerName(holder.token));
-        }
-        else
-        {
-            holder.issuerPlaceholder.setVisibility(View.GONE);
-        }
         holder.layoutValueDetails.setVisibility(View.GONE);
 
         holder.contractType.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
@@ -10,6 +10,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 
+import com.alphawallet.app.R;
 import com.alphawallet.token.entity.SigReturnType;
 import com.alphawallet.token.entity.XMLDsigDescriptor;
 
@@ -139,23 +140,36 @@ public class TokenScriptFile extends File
             if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_PASS;
             else sigDescriptor.type = SigReturnType.SIGNATURE_PASS;
         }
-        else if (sigDescriptor.subject != null)
+        else
         {
-            if (sigDescriptor.subject.contains("Invalid"))
-            {
-                if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_INVALID;
-                else sigDescriptor.type = SigReturnType.SIGNATURE_INVALID;
-            }
-            else
-            {
-                if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
-                else sigDescriptor.type = SigReturnType.NO_SIGNATURE;
-            }
+            setFailedIssuer(isDebug, sigDescriptor);
+        }
+    }
+
+    private void setFailedIssuer(boolean isDebug, XMLDsigDescriptor sigDescriptor)
+    {
+        if (isDebug)
+        {
+            sigDescriptor.keyName = context.getString(R.string.debug_script);
         }
         else
         {
-            if (isDebug) sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
-            else sigDescriptor.type = SigReturnType.NO_SIGNATURE;
+            sigDescriptor.keyName = context.getString(R.string.unsigned_script);
+        }
+
+        if (sigDescriptor.subject != null && sigDescriptor.subject.contains("Invalid"))
+        {
+            if (isDebug)
+                sigDescriptor.type = SigReturnType.DEBUG_SIGNATURE_INVALID;
+            else
+                sigDescriptor.type = SigReturnType.SIGNATURE_INVALID;
+        }
+        else
+        {
+            if (isDebug)
+                sigDescriptor.type = SigReturnType.DEBUG_NO_SIGNATURE;
+            else
+                sigDescriptor.type = SigReturnType.NO_SIGNATURE;
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -108,16 +108,7 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
             chainName.setVisibility(View.VISIBLE);
             chainName.setText(token.getNetworkName());
             Utils.setChainColour(chainName, token.tokenInfo.chainId);
-            String issuerName = assetDefinition.getIssuerName(token);
-            issuerPlaceholder.setVisibility(View.VISIBLE);
-            if(issuerName != null)
-            {
-                issuer.setText(issuerName);
-            }
-            else
-            {
-                issuerPlaceholder.setVisibility(View.GONE);
-            }
+            setIssuerDetails();
 
             if (token.ticker != null) animateTextWhileWaiting();
             if (EthereumNetworkRepository.isPriorityToken(token)) extendedInfo.setVisibility(View.GONE);
@@ -266,6 +257,24 @@ public class TokenHolder extends BinderViewHolder<Token> implements View.OnClick
         text24Hours.startAnimation(anim);
         textAppreciation.startAnimation(anim);
         balanceCurrency.startAnimation(anim);
+    }
+
+    private void setIssuerDetails()
+    {
+        String issuerName = assetDefinition.getIssuerName(token);
+        if(issuerName != null)
+        {
+            issuer.setVisibility(View.VISIBLE);
+            issuerPlaceholder.setVisibility(View.VISIBLE);
+            contractSeparator.setVisibility(View.VISIBLE);
+            issuer.setText(issuerName);
+        }
+        else
+        {
+            issuer.setVisibility(View.GONE);
+            issuerPlaceholder.setVisibility(View.GONE);
+            contractSeparator.setVisibility(View.GONE);
+        }
     }
 
     private void stopTextAnimation() {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -535,4 +535,6 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript Standard</string>
     <string name="version">Version</string>
+    <string name="debug_script">TokenScript depurar</string>
+    <string name="unsigned_script">no confiable</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -524,4 +524,6 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript 标准</string>
     <string name="version">版本</string>
+    <string name="debug_script">TokenScript 调试</string>
+    <string name="unsigned_script">不信任</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -535,4 +535,6 @@
     <string name="reddit">Reddit</string>
     <string name="tokenscript_standard">TokenScript Standard</string>
     <string name="version">Version</string>
+    <string name="debug_script">TokenScript debug</string>
+    <string name="unsigned_script">untrusted</string>
 </resources>


### PR DESCRIPTION
This PR consolidates the various ways that issuer text line is displayed and ensures consistency between all tokens. If a signature is invalid it shows either that it's a tokenscript debug (if sourced from the tokenscript debug drop area) or is untrusted, if downloaded from repo server and signature doesn't check out.

It fixes further inconsistencies with the shown issuer text on the token card seen during testing with ERC721, ERC721 ticket with tokenscripts and unsigned debug scripts for ERC875.

Also remove some unnecessary overloads which exactly duplicate the Token class base methods (ie don't change the default token behaviour).