### PR TITLE
allows user added tokens to show up, even if balance is zero

### DIFF
--- a/app/src/awallet/java/com/alphawallet/app/entity/VisibilityFilter.java
+++ b/app/src/awallet/java/com/alphawallet/app/entity/VisibilityFilter.java
@@ -18,7 +18,6 @@ public class VisibilityFilter
     public static boolean filterToken(Token token, boolean filterResult)
     {
         boolean badToken = false;
-        if (!token.hasDebugTokenscript && !token.hasPositiveBalance()) filterResult = false;
         if (token.isTerminated() || token.isBad()) badToken = true;
 
         if (token.isEthereum()) filterResult = true;


### PR DESCRIPTION
If a user adds a token, it should show up, even if the balance is zero. 

Testers are routinely confused by this and I would be too as a user and wanted to add a token manually. 
