### PR TITLE
Validate user input

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SetWatchWalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SetWatchWalletFragment.java
@@ -63,6 +63,8 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
 
     private void setupView()
     {
+        View.inflate(getActivity(), R.layout.fragment_watch_wallet, null);
+
         watchAddress = getActivity().findViewById(R.id.input_watch_address);
         importButton = getActivity().findViewById(R.id.import_action_ww);
         importButton.setOnClickListener(this);
@@ -73,11 +75,13 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
         watchAddress.setLayoutListener(getActivity(), this, getActivity().findViewById(R.id.bottom_marker_ww));
     }
 
+    private boolean paused = false;
+
     @Override
     public void onResume()
     {
         super.onResume();
-        if (watchAddress == null && getActivity() != null) setupView();
+        if ((watchAddress == null || watchAddress.getEditText() == null) && getActivity() != null) setupView();
     }
 
     @Override
@@ -142,6 +146,7 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
         if (watchAddress.isErrorState())
             watchAddress.setError(null);
         String value = watchAddress.getText().toString();
+        value = value.replaceAll("\\s+", "");
         final Matcher matcher = pattern.matcher(value);
         if (matcher.find())
         {
@@ -154,6 +159,7 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
         }
         else
         {
+            if (value.length() > 42) watchAddress.setError(getString(R.string.ethereum_address_hint));
             updateButtonState(false);
         }
     }
@@ -164,8 +170,10 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
 
         try
         {
-            Address check = new Address(address);
-            watchAddress.getEditText().setText(check.getValue());
+            if (Utils.isAddressValid(address))
+            {
+                watchAddress.getEditText().setText(address);
+            }
         }
         catch (Exception e)
         {

--- a/app/src/main/java/com/alphawallet/app/ui/SetWatchWalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SetWatchWalletFragment.java
@@ -20,6 +20,8 @@ import com.alphawallet.app.R;
 import com.alphawallet.app.widget.LayoutCallbackListener;
 import com.alphawallet.app.widget.PasswordInputView;
 
+import org.web3j.abi.datatypes.Address;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,7 +160,17 @@ public class SetWatchWalletFragment extends Fragment implements View.OnClickList
 
     public void setAddress(String address)
     {
-        watchAddress.getEditText().setText(address);
+        if (address == null) return;
+
+        try
+        {
+            Address check = new Address(address);
+            watchAddress.getEditText().setText(check.getValue());
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -484,7 +484,7 @@
     <string name="already_have_a_wallet">I already have a wallet:</string>
     <string name="watch_wallet">Watch Wallet</string>
     <string name="suggestion_address">Enter Ethereum Address</string>
-    <string name="ethereum_address_hint">Ethereum Address: 0x then 20 characters of 0–9 a-f A-F</string>
+    <string name="ethereum_address_hint">Ethereum Address: 0x then 40 characters of 0–9 a-f A-F</string>
     <string name="action_watch_account">Watch an account</string>
     <string name="receive_payment">Receive Payment</string>
     <string name="title_back_up_your_wallet">Back up your Wallet</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -473,7 +473,7 @@
     <string name="already_have_a_wallet">我已经有一个钱包：</string>
     <string name="watch_wallet">查看钱包</string>
     <string name="suggestion_address">输入以大太坊地址</string>
-    <string name="ethereum_address_hint">Ethereum Address: 0x then 20 characters of 0-9 a-f A-F</string>
+    <string name="ethereum_address_hint">Ethereum Address: 0x then 40 characters of 0–9 a-f A-F</string>
     <string name="action_watch_account">查看账户</string>
     <string name="receive_payment">接收付款</string>
     <string name="title_back_up_your_wallet">备份您的钱包</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,7 +484,7 @@
     <string name="already_have_a_wallet">I already have a wallet:</string>
     <string name="watch_wallet">Watch Wallet</string>
     <string name="suggestion_address">Enter Ethereum Address</string>
-    <string name="ethereum_address_hint">Ethereum Address: 0x then 20 characters of 0–9 a-f A-F</string>
+    <string name="ethereum_address_hint">Ethereum Address: 0x then 40 characters of 0–9 a-f A-F</string>
     <string name="action_watch_account">Watch an account</string>
     <string name="receive_payment">Receive Payment</string>
     <string name="title_back_up_your_wallet">Back up your Wallet</string>


### PR DESCRIPTION
Validate user input for watch address and ensure view is kept fresh (vs memory scavenge).

Fixes crashlytics issue:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.widget.EditText com.alphawallet.app.widget.PasswordInputView.getEditText()' on a null object reference
       at com.alphawallet.app.ui.SetWatchWalletFragment.setAddress + 161(SetWatchWalletFragment.java:161)
       at com.alphawallet.app.ui.ImportWalletActivity.handleScanQR + 428(ImportWalletActivity.java:428)
       at com.alphawallet.app.ui.ImportWalletActivity.onActivityResult + 401(ImportWalletActivity.java:401)
       at android.app.Activity.dispatchActivityResult + 6919(Activity.java:6919)
       at android.app.ActivityThread.deliverResults + 4204(ActivityThread.java:4204)
       at android.app.ActivityThread.performResumeActivity + 3499(ActivityThread.java:3499)
       at android.app.ActivityThread.handleResumeActivity + 3571(ActivityThread.java:3571)
       at android.app.ActivityThread.handleLaunchActivity + 2817(ActivityThread.java:2817)
       at android.app.ActivityThread.-wrap12(ActivityThread.java)
       at android.app.ActivityThread$H.handleMessage + 1533(ActivityThread.java:1533)
       at android.os.Handler.dispatchMessage + 110(Handler.java:110)
       at android.os.Looper.loop + 203(Looper.java:203)
       at android.app.ActivityThread.main + 6302(ActivityThread.java:6302)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run + 1085(ZygoteInit.java:1085)
       at com.android.internal.os.ZygoteInit.main + 946(ZygoteInit.java:946)
```