### PR TITLE
Token Balance Update Improvement

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -340,6 +340,7 @@ public class ERC721Ticket extends Token implements Parcelable {
     @Override
     public boolean checkBalanceChange(List<BigInteger> balanceArray)
     {
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
         if (balanceArray.size() != this.balanceArray.size()) return true; //quick check for new tokens
         for (int index = 0; index < balanceArray.size(); index++) //see if spawnable token ID has changed
         {

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -486,6 +486,7 @@ public class Ticket extends Token implements Parcelable
     @Override
     public boolean checkBalanceChange(List<BigInteger> balanceArray)
     {
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
         if (balanceArray.size() != this.balanceArray.size()) return true; //quick check for new tokens
         for (int index = 0; index < balanceArray.size(); index++) //see if spawnable token ID has changed
         {

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -796,6 +796,13 @@ public class Token implements Parcelable, Comparable<Token>
         return EthereumNetworkRepository.hasRealValue(tokenInfo.chainId);
     }
 
+    /**
+     * Determine how often we check balance of tokens.
+     *
+     * Note that if any transaction relating to a contract is received then we trigger a balance check
+     *
+     * @return
+     */
     protected float calculateBalanceUpdateWeight()
     {
         float updateWeight = 0;
@@ -806,11 +813,11 @@ public class Token implements Parcelable, Comparable<Token>
             {
                 if (isEthereum() || hasPositiveBalance())
                 {
-                    updateWeight = 1.0f;
+                    updateWeight = 1.0f; //30 seconds
                 }
                 else
                 {
-                    updateWeight = 0.5f;
+                    updateWeight = 0.5f; //1 minute
                 }
             }
             else
@@ -818,19 +825,15 @@ public class Token implements Parcelable, Comparable<Token>
                 //testnet: TODO: check time since last transaction - if greater than 1 month slow update further
                 if (isEthereum())
                 {
-                    updateWeight = 0.4f;
+                    updateWeight = 0.5f; //1 minute
                 }
                 else if (hasPositiveBalance())
                 {
-                    updateWeight = 0.25f;
-                }
-                else if (tokenInfo.name != null)
-                {
-                    updateWeight = 0.05f;
+                    updateWeight = 0.3f; //100 seconds
                 }
                 else
                 {
-                    updateWeight = 0.01f;
+                    updateWeight = 0.1f; //5 minutes
                 }
             }
         }
@@ -844,6 +847,7 @@ public class Token implements Parcelable, Comparable<Token>
 
     public boolean checkBalanceChange(BigDecimal balance)
     {
+        balanceUpdateWeight = calculateBalanceUpdateWeight();
         if (balance != null && this.balance != null)
         {
             return !this.balance.equals(balance);
@@ -1156,5 +1160,10 @@ public class Token implements Parcelable, Comparable<Token>
     {
         String id = getAddress() + "-" + tokenInfo.chainId;
         return id.hashCode();
+    }
+
+    public void setHighestPriorityCheck()
+    {
+        balanceUpdateWeight = 10.0f;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
@@ -68,6 +68,7 @@ public class TokenFactory
         switch (type)
         {
             case ETHEREUM:
+                tokenInfo.isEnabled = true; //native eth always enabled
             case ERC20:
                 if (realmBalance == null || realmBalance.length() == 0) realmBalance = "0";
                 BigDecimal balance = new BigDecimal(realmBalance);

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -364,28 +364,9 @@ public class TokensService
 
             //simply multiply the weighting by the last diff.
             float updateFactor = weighting * (float) lastUpdateDiff;
-            long cutoffCheck = 40*1000;
-            switch (check.getInterfaceSpec())
-            {
-                case ETHEREUM:
-                case CURRENCY:
-                    cutoffCheck = 20*1000;
-                    break;
-                case ERC875:
-                    cutoffCheck = 30*1000;
-                    break;
-                case ERC875_LEGACY:
-                    cutoffCheck = 60*1000;
-                    break;
-                case ERC721:
-                case ERC721_LEGACY:
-                    continue; //no need to check these token types here
-                case ERC721_TICKET:
-                    cutoffCheck = 20*1000;
-                    break;
-                default:
-                    break;
-            }
+            long cutoffCheck = 30*1000; //maximum update time given by formula (30 seconds / weighting)
+            if (check.isERC721()) continue; //no need to check ERC721
+            if (!check.isEthereum() && !check.tokenInfo.isEnabled) continue; //don't check disabled tokens
 
             if (updateFactor > highestWeighting && (updateFactor > (float)cutoffCheck || check.refreshCheck))
             {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
@@ -296,6 +296,7 @@ public class TransactionsViewModel extends BaseViewModel
                 newTxs.add(tx);
                 txMap.put(tx.hash, tx);
                 if (oldTx != null && oldTx.blockNumber.equals("0")) pendingUpdate = true;
+                checkContractEvents(tx);
             }
         }
 
@@ -327,6 +328,21 @@ public class TransactionsViewModel extends BaseViewModel
 
         //Need to log that we scanned transactions for this token, even if there weren't any transactions.
         addTokenInteract.updateBlockRead(token, defaultWallet().getValue());
+    }
+
+    private void checkContractEvents(Transaction tx)
+    {
+        //Check this received transaction to see if any known contracts are affected, if so promote a balance check for that token
+        TransactionContract tc = tx.getOperation();
+        if (tc != null)
+        {
+            Token token = tokensService.getToken(tx.chainId, tc.address);
+            if (token != null)
+            {
+                //this token needs to have a balance check update
+                token.setHighestPriorityCheck();
+            }
+        }
     }
 
     //run through the newly received tokens from a currency and see if there's any unknown tokens


### PR DESCRIPTION
This PR is a result of further investigation into issue #1138 , and to ensure that the token update infrastructure works well with the new token visibility management system. NB a previous PR switched the main net connection to the Amberdata node so the Infura usage is considerably reduced, which may also help this issue.

In this PR:
- simplify and add explanation of how regular balance calculation works.
- if tokens are updated from market feed, then reduce update rate slightly to reduce network load.
- if a transaction is received that affects a known token contract then update the balance of that contract (if the token contract isn't known then it's added to the scan list as usual).