### PR TITLE
Refresh wallet data on delete and re-import

### DIFF
--- a/app/src/main/java/com/alphawallet/app/interact/DeleteWalletInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/DeleteWalletInteract.java
@@ -18,8 +18,8 @@ public class DeleteWalletInteract {
 
 	public Single<Wallet[]> delete(Wallet wallet)
 	{
-		return walletRepository.deleteWalletFromRealm(wallet.address)
-				.flatMapCompletable(addr -> walletRepository.deleteWallet(addr, ""))
+		return walletRepository.deleteWalletFromRealm(wallet)
+				.flatMapCompletable(deletedWallet -> walletRepository.deleteWallet(deletedWallet.address, ""))
 				.andThen(walletRepository.fetchWallets())
 				.observeOn(AndroidSchedulers.mainThread());
 	}

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
@@ -179,6 +179,11 @@ public class WalletRepository implements WalletRepositoryType
 	@Override
     public boolean keystoreExists(String address)
     {
-        return accountKeystoreService.hasAccount(address);
+		Wallet[] wallets = fetchWallets().blockingGet();
+		for (Wallet w : wallets)
+		{
+			if (w.sameAddress(address)) return true;
+		}
+		return false;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
@@ -90,9 +90,9 @@ public class WalletRepository implements WalletRepositoryType
 	}
 
 	@Override
-	public Single<String> deleteWalletFromRealm(String address)
+	public Single<Wallet> deleteWalletFromRealm(Wallet wallet)
 	{
-		return walletDataRealmSource.deleteWallet(address);
+		return walletDataRealmSource.deleteWallet(wallet);
 	}
 
 	@Override

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepositoryType.java
@@ -22,7 +22,7 @@ public interface WalletRepositoryType {
     Single<String> exportWallet(Wallet wallet, String password, String newPassword);
 
     Completable deleteWallet(String address, String password);
-    Single<String> deleteWalletFromRealm(String address);
+    Single<Wallet> deleteWalletFromRealm(Wallet wallet);
 
     Completable setDefaultWallet(Wallet wallet);
 

--- a/app/src/main/java/com/alphawallet/app/service/RealmManager.java
+++ b/app/src/main/java/com/alphawallet/app/service/RealmManager.java
@@ -15,11 +15,15 @@ public class RealmManager {
 
     private final Map<String, RealmConfiguration> realmConfigurations = new HashMap<>();
 
-    public Realm getRealmInstance(Wallet wallet) {
-        return getRealmInstance(wallet.address + "-db.realm");
+    public String getRealmInstanceName(Wallet wallet) {
+        return wallet.address + "-db.realm";
     }
 
-    public Realm getRealmInstance(String name) {
+    public Realm getRealmInstance(Wallet wallet) {
+        return getRealmInstance(getRealmInstanceName(wallet));
+    }
+
+    Realm getRealmInstance(String name) {
         try
         {
             RealmConfiguration config = realmConfigurations.get(name);
@@ -49,25 +53,12 @@ public class RealmManager {
         }
     }
 
-    private String getName(NetworkInfo networkInfo, Wallet wallet) {
-        return wallet.address + "-" + networkInfo.name + "-db.realm";
-    }
-
-    public Realm getERC721RealmInstance(Wallet wallet) {
-        String name = get721Name(wallet);
-        return getRealmInstance(name);
-    }
-
     public Realm getWalletDataRealmInstance() {
         return getRealmInstance("WalletData-db.realm");
     }
 
     public Realm getWalletTypeRealmInstance() {
         return getRealmInstance("WalletType-db.realm");
-    }
-
-    private String get721Name(Wallet wallet) {
-        return wallet.address + "-721-db.realm";
     }
 
     public Realm getAuxRealmInstance(String walletAddress)

--- a/app/src/main/java/com/alphawallet/app/ui/ImportWalletActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportWalletActivity.java
@@ -502,7 +502,7 @@ public class ImportWalletActivity extends BaseActivity implements OnImportSeedLi
 
         dialog = new AWalletAlertDialog(this);
         dialog.setIcon(AWalletAlertDialog.WARNING);
-        dialog.setTitle(R.string.reimport_wallet_title);
+        dialog.setTitle(R.string.title_dialog_error);
         dialog.setMessage(getString(R.string.watch_exists, address));
         dialog.setButtonText(R.string.action_cancel);
         dialog.setButtonListener(v -> {

--- a/app/src/main/java/com/alphawallet/app/ui/ImportWalletActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportWalletActivity.java
@@ -131,6 +131,7 @@ public class ImportWalletActivity extends BaseActivity implements OnImportSeedLi
         importWalletViewModel.error().observe(this, this::onError);
         importWalletViewModel.wallet().observe(this, this::onWallet);
         importWalletViewModel.badSeed().observe(this, this::onBadSeed);
+        importWalletViewModel.watchExists().observe(this, this::onWatchExists);
 
         TabUtils.changeTabsFont(this, tabLayout);
     }
@@ -490,6 +491,21 @@ public class ImportWalletActivity extends BaseActivity implements OnImportSeedLi
         dialog.setButtonText(R.string.dialog_ok);
         dialog.setSecondaryButtonText(R.string.action_cancel);
         dialog.setSecondaryButtonListener(v -> {
+            dialog.dismiss();
+        });
+        dialog.show();
+    }
+
+    private void onWatchExists(String address)
+    {
+        if (dialog != null && dialog.isShowing()) dialog.dismiss();
+
+        dialog = new AWalletAlertDialog(this);
+        dialog.setIcon(AWalletAlertDialog.WARNING);
+        dialog.setTitle(R.string.reimport_wallet_title);
+        dialog.setMessage(getString(R.string.watch_exists, address));
+        dialog.setButtonText(R.string.action_cancel);
+        dialog.setButtonListener(v -> {
             dialog.dismiss();
         });
         dialog.show();

--- a/app/src/main/java/com/alphawallet/app/viewmodel/ImportWalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/ImportWalletViewModel.java
@@ -36,6 +36,7 @@ public class ImportWalletViewModel extends BaseViewModel implements OnSetWatchWa
 
     private final MutableLiveData<Wallet> wallet = new MutableLiveData<>();
     private final MutableLiveData<Boolean> badSeed = new MutableLiveData<>();
+    private final MutableLiveData<String> watchExists = new MutableLiveData<>();
 
     ImportWalletViewModel(ImportWalletInteract importWalletInteract, KeyService keyService, GasService gasService) {
         this.importWalletInteract = importWalletInteract;
@@ -63,6 +64,13 @@ public class ImportWalletViewModel extends BaseViewModel implements OnSetWatchWa
     @Override
     public void onWatchWallet(String address)
     {
+        //do we already have this as a wallet?
+        if (keystoreExists(address))
+        {
+            watchExists.postValue(address);
+            return;
+        }
+
         progress.postValue(true);
         //user just asked for a watch wallet
         disposable = importWalletInteract.storeWatchWallet(address, ensResolver)
@@ -75,6 +83,7 @@ public class ImportWalletViewModel extends BaseViewModel implements OnSetWatchWa
         return wallet;
     }
     public LiveData<Boolean> badSeed() { return badSeed; }
+    public LiveData<String> watchExists() { return watchExists; }
 
     private void onWallet(Wallet wallet) {
         progress.postValue(false);

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -506,6 +506,7 @@
     <string name="reimport_wallet_title">Re-Import Wallet?</string>
     <string name="provide_authentication">Provide authentication to create key</string>
     <string name="import_error">Import Error, Try re-import again.</string>
+    <string name="watch_exists">Wallet %1$s already full wallet - no need to watch</string>
     <string name="welcome_to_alphawallet">Welcome to AlphaWallet</string>
     <string name="lock_seed_phrase">LOCK SEED PHRASE</string>
     <string name="no_key">No Key found</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -495,6 +495,7 @@
     <string name="reimport_wallet_title">是否重新导入钱包？</string>
     <string name="provide_authentication">提供身份验证以创建密钥</string>
     <string name="import_error">导入错误，请再次尝试重新导入。</string>
+    <string name="watch_exists">你为什么想看道现有的钱包 %1$s？</string>
     <string name="welcome_to_alphawallet">欢迎使用 AlphaWallet</string>
     <string name="lock_seed_phrase">锁定助记词</string>
     <string name="no_key">未找到密钥</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,6 +506,7 @@
     <string name="reimport_wallet_title">Re-Import Wallet?</string>
     <string name="provide_authentication">Provide authentication to create key</string>
     <string name="import_error">Import Error, Try re-import again.</string>
+    <string name="watch_exists">Wallet %1$s already full wallet - no need to watch</string>
     <string name="welcome_to_alphawallet">Welcome to AlphaWallet</string>
     <string name="lock_seed_phrase">LOCK SEED PHRASE</string>
     <string name="no_key">No Key found</string>


### PR DESCRIPTION
Delete full wallet data when wallet is deleted or re-imported.

Fixes this reproducible issue:

1. Have non wallet with balance and transactions.
2. Delete wallet.
3. Import wallet.
4. See that there are no transactions (because wallet is picking up old tokens).

And simultaneously fixes issue where watch wallet duplicates full wallet.