### PR TITLE
Ignore case when checking wallet match

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/Wallet.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Wallet.java
@@ -62,7 +62,7 @@ public class Wallet implements Parcelable {
 	};
 
 	public boolean sameAddress(String address) {
-		return this.address.equals(address);
+		return this.address.equalsIgnoreCase(address);
 	}
 
 	@Override


### PR DESCRIPTION
Because it's possible to get a case mismatch (stored wallet could be 0xda3123a... in database but we're checking to watch wallet 0xDa3123A...), need to compare ignoring case.