### PR TITLE
fix for undo token swipe issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -490,7 +490,7 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
                                 .make(viewHolder.itemView, token.tokenInfo.name + " " + getContext().getString(R.string.token_hidden), Snackbar.LENGTH_LONG)
                                 .setAction(getString(R.string.action_snackbar_undo), view -> {
                                     viewModel.setTokenEnabled(token, true);
-                                    adapter.addToken(token);
+                                    adapter.updateToken(token, true);
                                 });
 
                         snackbar.show();

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
@@ -212,11 +212,6 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
         }
     }
 
-    public void addToken(Token token) {
-        int insertPos = items.add(new TokenSortedItem(token, token.getNameWeight()));
-        notifyItemInserted(insertPos);
-    }
-
     private boolean canDisplayToken(Token token)
     {
         if (token == null) return false;


### PR DESCRIPTION
Recycler view update issue fix. A timing issue can cause a recycler view crash issue - swipe a token out then hit 'undo' quickly before the toast bar disappears.

- This fix needs to go into the release.