### PR TITLE
Add confirmations to transaction view to match iOS app.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/TransactionDetailModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/TransactionDetailModule.java
@@ -3,6 +3,7 @@ package com.alphawallet.app.di;
 import com.alphawallet.app.interact.FindDefaultNetworkInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
+import com.alphawallet.app.repository.TokenRepositoryType;
 import com.alphawallet.app.repository.WalletRepositoryType;
 import com.alphawallet.app.router.ExternalBrowserRouter;
 import com.alphawallet.app.service.TokensService;
@@ -17,11 +18,11 @@ public class TransactionDetailModule {
     @Provides
     TransactionDetailViewModelFactory provideTransactionDetailViewModelFactory(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
-            GenericWalletInteract genericWalletInteract,
             ExternalBrowserRouter externalBrowserRouter,
+            TokenRepositoryType tokenRepository,
             TokensService tokensService) {
         return new TransactionDetailViewModelFactory(
-                findDefaultNetworkInteract, genericWalletInteract, externalBrowserRouter, tokensService);
+                findDefaultNetworkInteract, externalBrowserRouter, tokenRepository, tokensService);
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/router/TransactionDetailRouter.java
+++ b/app/src/main/java/com/alphawallet/app/router/TransactionDetailRouter.java
@@ -4,14 +4,16 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.alphawallet.app.C;
+import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.ui.TransactionDetailActivity;
 import com.alphawallet.app.entity.Transaction;
 
 public class TransactionDetailRouter {
 
-    public void open(Context context, Transaction transaction) {
+    public void open(Context context, Transaction transaction, Wallet wallet) {
         Intent intent = new Intent(context, TransactionDetailActivity.class);
         intent.putExtra(C.Key.TRANSACTION, transaction);
+        intent.putExtra(C.Key.WALLET, wallet);
         intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         context.startActivity(intent);
     }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
@@ -241,7 +241,7 @@ public class Erc20DetailViewModel extends BaseViewModel {
     }
 
     public void showDetails(Context context, Transaction transaction) {
-        transactionDetailRouter.open(context, transaction);
+        transactionDetailRouter.open(context, transaction, wallet.getValue());
     }
 
     public AssetDefinitionService getAssetDefinitionService() {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModelFactory.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModelFactory.java
@@ -6,25 +6,26 @@ import android.support.annotation.NonNull;
 
 import com.alphawallet.app.interact.FindDefaultNetworkInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
+import com.alphawallet.app.repository.TokenRepositoryType;
 import com.alphawallet.app.router.ExternalBrowserRouter;
 import com.alphawallet.app.service.TokensService;
 
 public class TransactionDetailViewModelFactory implements ViewModelProvider.Factory {
 
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
-    private final GenericWalletInteract genericWalletInteract;
     private final ExternalBrowserRouter externalBrowserRouter;
     private final TokensService tokensService;
+    private final TokenRepositoryType tokenRepository;
 
     public TransactionDetailViewModelFactory(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
-            GenericWalletInteract genericWalletInteract,
             ExternalBrowserRouter externalBrowserRouter,
+            TokenRepositoryType tokenRepository,
             TokensService tokensService) {
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
-        this.genericWalletInteract = genericWalletInteract;
         this.externalBrowserRouter = externalBrowserRouter;
         this.tokensService = tokensService;
+        this.tokenRepository = tokenRepository;
     }
 
     @NonNull
@@ -32,8 +33,8 @@ public class TransactionDetailViewModelFactory implements ViewModelProvider.Fact
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
         return (T) new TransactionDetailViewModel(
                 findDefaultNetworkInteract,
-                genericWalletInteract,
                 externalBrowserRouter,
+                tokenRepository,
                 tokensService);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
@@ -382,7 +382,7 @@ public class TransactionsViewModel extends BaseViewModel
     }
 
     public void showDetails(Context context, Transaction transaction) {
-        transactionDetailRouter.open(context, transaction);
+        transactionDetailRouter.open(context, transaction, wallet.getValue());
     }
 
     public TokensService getTokensService()

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -141,6 +141,7 @@
                 tools:text="" />
 
             <TextView
+                android:id="@+id/title_gas_fee"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/font_semibold"
@@ -157,6 +158,25 @@
                 android:fontFamily="@font/font_regular"
                 android:textSize="14sp"
                 tools:text="0.000044" />
+
+            <TextView
+                android:id="@+id/title_confirmations"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/font_semibold"
+                android:textAllCaps="true"
+                android:textSize="12sp"
+                android:text="@string/confirmations" />
+
+            <TextView
+                android:id="@+id/confirmations"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/normal_margin"
+                android:layout_marginTop="@dimen/small_margin"
+                android:fontFamily="@font/font_regular"
+                android:textSize="14sp"
+                tools:text="0" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -550,4 +550,5 @@
     <string name="fingerprint_authentication_failed">Fingerprint authentication failed</string>
     <string name="action_snackbar_undo">UNDO</string>
     <string name="token_hidden">hidden</string>
+    <string name="confirmations">Confirmations</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -539,4 +539,5 @@
     <string name="fingerprint_authentication_failed">指纹认证失败</string>
     <string name="action_snackbar_undo">撤销刚才动作</string>
     <string name="token_hidden">隐藏了</string>
+    <string name="confirmations">Confirmations</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -550,4 +550,5 @@
     <string name="fingerprint_authentication_failed">Fingerprint authentication failed</string>
     <string name="action_snackbar_undo">UNDO</string>
     <string name="token_hidden">hidden</string>
+    <string name="confirmations">Confirmations</string>
 </resources>


### PR DESCRIPTION
Match iOS transaction display by showing confirmation count.

NB: Not needed for the 2.21 release.