### PR TITLE
Update token cards more gracefully when there's a matching script

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenInterface.java
@@ -3,6 +3,6 @@ package com.alphawallet.app.entity.tokens;
 public interface TokenInterface
 {
     void resetTokens();
-    void addedToken();
     void changedLocale();
+    void addedToken(int[] chainIds, String[] addrs);
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokensReceiver.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokensReceiver.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Bundle;
 
 import com.alphawallet.app.C;
 
@@ -24,13 +25,16 @@ public class TokensReceiver extends BroadcastReceiver
     {
         if (intent != null && intent.getAction() != null)
         {
+            Bundle bundle = intent.getExtras();
             switch (intent.getAction())
             {
                 case C.RESET_WALLET:
                     tokenInterface.resetTokens();
                     break;
                 case C.ADDED_TOKEN:
-                    tokenInterface.addedToken();
+                    String[] addrs = intent.getStringArrayExtra(C.EXTRA_TOKENID_LIST);
+                    int[] chainIds = intent.getIntArrayExtra(C.EXTRA_CHAIN_ID);
+                    tokenInterface.addedToken(chainIds, addrs);
                     break;
                 case C.CHANGED_LOCALE:
                     tokenInterface.changedLocale();

--- a/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
@@ -245,11 +245,16 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
         }
     }
 
-    private void onSaved(boolean result)
+    private void onSaved(Token result)
     {
-        if (result)
+        if (result != null)
         {
-            sendBroadcast(new Intent(ADDED_TOKEN)); //inform walletview there is a new token
+            String[] addrs = { result.getAddress() };
+            int[] chainIds = { result.tokenInfo.chainId };
+            Intent intent = new Intent(ADDED_TOKEN);
+            intent.putExtra(C.EXTRA_TOKENID_LIST, addrs);
+            intent.putExtra(C.EXTRA_CHAIN_ID, chainIds);
+            sendBroadcast(intent);
             finish();
         }
     }

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
@@ -13,23 +13,22 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.alphawallet.app.R;
 import com.alphawallet.app.entity.ErrorEnvelope;
-import com.alphawallet.app.entity.tokens.TokenInterface;
-import com.alphawallet.app.entity.tokens.TokensReceiver;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.entity.tokens.TokenInterface;
+import com.alphawallet.app.entity.tokens.TokensReceiver;
 import com.alphawallet.app.ui.widget.adapter.RecycleViewDivider;
 import com.alphawallet.app.ui.widget.adapter.TransactionsAdapter;
-
-import dagger.android.support.AndroidSupportInjection;
-import com.alphawallet.app.R;
-
 import com.alphawallet.app.viewmodel.TransactionsViewModel;
 import com.alphawallet.app.viewmodel.TransactionsViewModelFactory;
 import com.alphawallet.app.widget.EmptyTransactionsView;
 import com.alphawallet.app.widget.SystemView;
 
 import javax.inject.Inject;
+
+import dagger.android.support.AndroidSupportInjection;
 
 import static com.alphawallet.app.C.ErrorCode.EMPTY_COLLECTION;
 
@@ -182,7 +181,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     }
 
     @Override
-    public void addedToken()
+    public void addedToken(int[] chainIds, String[] addrs)
     {
 
     }

--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -383,10 +383,20 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
     }
 
     @Override
-    public void addedToken()
+    public void addedToken(int[] chainIds, String[] addrs)
     {
-        //token was added, refresh token list
-        refreshList();
+        //token was added
+        if (chainIds.length != addrs.length)
+        {
+            System.out.println("Receiver data mismatch");
+            return;
+        }
+
+        for (int i = 0; i < chainIds.length; i++)
+        {
+            Token t = viewModel.getTokenFromService(chainIds[i], addrs[i]);
+            if (t != null) adapter.updateToken(t, false);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
@@ -45,7 +45,7 @@ public class AddTokenViewModel extends BaseViewModel {
     private final MutableLiveData<Integer> switchNetwork = new MutableLiveData<>();
     private final MutableLiveData<Token> finalisedToken = new MutableLiveData<>();
     private final MutableLiveData<Token> tokentype = new MutableLiveData<>();
-    private final MutableLiveData<Boolean> result = new MutableLiveData<>();
+    private final MutableLiveData<Token> result = new MutableLiveData<>();
     private final MutableLiveData<Boolean> noContract = new MutableLiveData<>();
 
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
@@ -68,7 +68,7 @@ public class AddTokenViewModel extends BaseViewModel {
     public MutableLiveData<Token> tokenFinalised() { return finalisedToken; }
     public MutableLiveData<Token> tokenType() { return tokentype; }
     public MutableLiveData<Boolean> noContract() { return noContract; }
-    public LiveData<Boolean> result() { return result; }
+    public LiveData<Token> result() { return result; }
     public LiveData<Integer> switchNetwork() { return switchNetwork; }
     public LiveData<TokenInfo> tokenInfo() {
         return tokenInfo;
@@ -123,7 +123,7 @@ public class AddTokenViewModel extends BaseViewModel {
         assetDefinitionService.getAssetDefinition(token.tokenInfo.chainId, token.getAddress());
         tokensService.addToken(token);
         progress.postValue(false);
-        result.postValue(true);
+        result.postValue(token);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -513,6 +513,11 @@ public class WalletViewModel extends BaseViewModel
         return (serviceToken != null) ? serviceToken : token;
     }
 
+    public Token getTokenFromService(int chainId, String addr)
+    {
+        return tokensService.getToken(chainId, addr);
+    }
+
     private void tkError(Throwable throwable)
     {
         if (!BuildConfig.DEBUG) Crashlytics.logException(throwable);


### PR DESCRIPTION
Fixes token update glitch seen when debug tokenscript matches address of token but not the chain - ie token with same address on different chains is created by same account and there's a script for one of those token but not the other. Rare but annoying.

Smooths out update when debug script is dropped in and closes a TODO.