### PR TITLE
Use locale date format

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
@@ -11,7 +11,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.text.TextUtils;
 import android.view.View;
 
 import com.alphawallet.app.BuildConfig;
@@ -19,7 +18,6 @@ import com.alphawallet.app.R;
 import com.alphawallet.app.entity.CreateWalletCallbackInterface;
 import com.alphawallet.app.entity.CryptoFunctions;
 import com.alphawallet.app.entity.Operation;
-import com.alphawallet.app.entity.PinAuthenticationCallbackInterface;
 import com.alphawallet.app.entity.VisibilityFilter;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
@@ -27,6 +25,7 @@ import com.alphawallet.app.router.HomeRouter;
 import com.alphawallet.app.router.ImportTokenRouter;
 import com.alphawallet.app.router.ImportWalletRouter;
 import com.alphawallet.app.service.KeyService;
+import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.viewmodel.SplashViewModel;
 import com.alphawallet.app.viewmodel.SplashViewModelFactory;
 import com.alphawallet.app.widget.AWalletAlertDialog;
@@ -69,6 +68,8 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
             CrashlyticsCore core = new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build();
             Fabric.with(this, new Crashlytics.Builder().core(core).build());
         }
+
+        LocaleUtils.setDeviceLocale(getBaseContext());
 
         // Get the intent that started this activity
         Intent intent = getIntent();

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -17,6 +17,7 @@ import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionOperation;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.util.BalanceUtils;
+import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.util.Utils;
 
 import com.alphawallet.app.R;
@@ -27,6 +28,7 @@ import com.alphawallet.app.viewmodel.TransactionDetailViewModelFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 import javax.inject.Inject;
@@ -194,9 +196,10 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
     }
 
     private String getDate(long timeStampInSec) {
-        Calendar cal = Calendar.getInstance(Locale.ENGLISH);
-        cal.setTimeInMillis(timeStampInSec * 1000);
-        return DateFormat.getLongDateFormat(this).format(cal.getTime());
+        Date                 date       = LocaleUtils.getLocalDateFromTimestamp(timeStampInSec);
+        Locale               locale     = Locale.getDefault();
+        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, locale);
+        return dateFormat.format(date);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -26,9 +26,7 @@ import com.alphawallet.app.viewmodel.TransactionDetailViewModelFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DateFormat;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.TimeZone;
 
 import javax.inject.Inject;
 
@@ -79,7 +77,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
         ((TextView) findViewById(R.id.from)).setText(transaction.from);
         ((TextView) findViewById(R.id.to)).setText(transaction.to);
         ((TextView) findViewById(R.id.txn_hash)).setText(transaction.hash);
-        ((TextView) findViewById(R.id.txn_time)).setText(getDateAndTime(transaction.timeStamp));
+        ((TextView) findViewById(R.id.txn_time)).setText(localiseUnixTime(transaction.timeStamp));
 
         ((TextView) findViewById(R.id.block_number)).setText(blockNumber);
         findViewById(R.id.more_detail).setOnClickListener(this);
@@ -194,7 +192,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
         amount.setText(rawValue);
     }
 
-    private String getDateAndTime(long timeStampInSec)
+    private String localiseUnixTime(long timeStampInSec)
     {
         Date date = new java.util.Date(timeStampInSec*DateUtils.SECOND_IN_MILLIS);
         DateFormat timeFormat = java.text.DateFormat.getTimeInstance(DateFormat.SHORT, LocaleUtils.getDeviceLocale(this));

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -5,31 +5,26 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
-import android.text.format.DateFormat;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.alphawallet.app.R;
 import com.alphawallet.app.entity.NetworkInfo;
-import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionOperation;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.util.Utils;
-
-import com.alphawallet.app.R;
-
 import com.alphawallet.app.viewmodel.TransactionDetailViewModel;
 import com.alphawallet.app.viewmodel.TransactionDetailViewModelFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -197,8 +192,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
 
     private String getDate(long timeStampInSec) {
         Date                 date       = LocaleUtils.getLocalDateFromTimestamp(timeStampInSec);
-        Locale               locale     = Locale.getDefault();
-        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, locale);
+        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, LocaleUtils.getDeviceLocale(this));
         return dateFormat.format(date);
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -196,9 +196,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
 
     private String getDateAndTime(long timeStampInSec)
     {
-        Calendar calendar = Calendar.getInstance(TimeZone.getDefault());
-        calendar.setTimeInMillis(timeStampInSec * DateUtils.SECOND_IN_MILLIS);
-        Date date = calendar.getTime();
+        Date date = new java.util.Date(timeStampInSec*DateUtils.SECOND_IN_MILLIS);
         DateFormat timeFormat = java.text.DateFormat.getTimeInstance(DateFormat.SHORT, LocaleUtils.getDeviceLocale(this));
         DateFormat dateFormat = java.text.DateFormat.getDateInstance(DateFormat.MEDIUM, LocaleUtils.getDeviceLocale(this));
         return dateFormat.format(date) + " " + timeFormat.format(date);

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
+import android.text.format.DateUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -24,7 +25,10 @@ import com.alphawallet.app.viewmodel.TransactionDetailViewModelFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.DateFormat;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import javax.inject.Inject;
 
@@ -75,7 +79,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
         ((TextView) findViewById(R.id.from)).setText(transaction.from);
         ((TextView) findViewById(R.id.to)).setText(transaction.to);
         ((TextView) findViewById(R.id.txn_hash)).setText(transaction.hash);
-        ((TextView) findViewById(R.id.txn_time)).setText(getDate(transaction.timeStamp));
+        ((TextView) findViewById(R.id.txn_time)).setText(getDateAndTime(transaction.timeStamp));
 
         ((TextView) findViewById(R.id.block_number)).setText(blockNumber);
         findViewById(R.id.more_detail).setOnClickListener(this);
@@ -190,10 +194,14 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
         amount.setText(rawValue);
     }
 
-    private String getDate(long timeStampInSec) {
-        Date                 date       = LocaleUtils.getLocalDateFromTimestamp(timeStampInSec);
-        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, LocaleUtils.getDeviceLocale(this));
-        return dateFormat.format(date);
+    private String getDateAndTime(long timeStampInSec)
+    {
+        Calendar calendar = Calendar.getInstance(TimeZone.getDefault());
+        calendar.setTimeInMillis(timeStampInSec * DateUtils.SECOND_IN_MILLIS);
+        Date date = calendar.getTime();
+        DateFormat timeFormat = java.text.DateFormat.getTimeInstance(DateFormat.SHORT, LocaleUtils.getDeviceLocale(this));
+        DateFormat dateFormat = java.text.DateFormat.getDateInstance(DateFormat.MEDIUM, LocaleUtils.getDeviceLocale(this));
+        return dateFormat.format(date) + " " + timeFormat.format(date);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionDateHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionDateHolder.java
@@ -3,16 +3,13 @@ package com.alphawallet.app.ui.widget.holder;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.format.DateFormat;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.alphawallet.app.R;
+import com.alphawallet.app.util.LocaleUtils;
 
-import java.util.Calendar;
 import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 
 public class TransactionDateHolder extends BinderViewHolder<Date> {
 
@@ -35,8 +32,7 @@ public class TransactionDateHolder extends BinderViewHolder<Date> {
     }
 
     private String getDate(Date date) {
-        Locale               locale     = Locale.getDefault();
-        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, locale);
+        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, LocaleUtils.getDeviceLocale(getContext()));
         return dateFormat.format(date);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionDateHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionDateHolder.java
@@ -11,11 +11,10 @@ import com.alphawallet.app.R;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class TransactionDateHolder extends BinderViewHolder<Date> {
-
-    private static final String DATE_TEMPLATE = "MMM, dd yyyy";
 
     public static final int VIEW_TYPE = 1004;
     private final TextView title;
@@ -31,10 +30,13 @@ public class TransactionDateHolder extends BinderViewHolder<Date> {
         if (data == null) {
             title.setText(null);
         } else {
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-            calendar.setTime(data);
-            title.setText(DateFormat.format(DATE_TEMPLATE, calendar));
+            title.setText(getDate(data));
         }
+    }
+
+    private String getDate(Date date) {
+        Locale               locale     = Locale.getDefault();
+        java.text.DateFormat dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM, locale);
+        return dateFormat.format(date);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/util/LocaleUtils.java
+++ b/app/src/main/java/com/alphawallet/app/util/LocaleUtils.java
@@ -3,6 +3,9 @@ package com.alphawallet.app.util;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
+import android.os.LocaleList;
+import android.preference.PreferenceManager;
 import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 
@@ -36,5 +39,33 @@ public class LocaleUtils {
         calendar.set(Calendar.MINUTE, 59);
         calendar.set(Calendar.HOUR_OF_DAY, 23);
         return calendar.getTime();
+    }
+
+    // Store device locale at app startup to read the device's setting
+    public static void setDeviceLocale(Context ctx)
+    {
+        PreferenceManager
+                .getDefaultSharedPreferences(ctx)
+                .edit()
+                .putString("device_locale", getCurrentLanguage())
+                .apply();
+    }
+
+    public static Locale getDeviceLocale(Context ctx)
+    {
+        String deviceLocaleStr = PreferenceManager.getDefaultSharedPreferences(ctx).getString("device_locale", "en");
+        return new Locale(deviceLocaleStr);
+    }
+
+    private static String getCurrentLanguage()
+    {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            return LocaleList.getDefault().get(0).getLanguage();
+        }
+        else
+        {
+            return Locale.getDefault().getLanguage();
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/util/LocaleUtils.java
+++ b/app/src/main/java/com/alphawallet/app/util/LocaleUtils.java
@@ -48,13 +48,15 @@ public class LocaleUtils {
                 .getDefaultSharedPreferences(ctx)
                 .edit()
                 .putString("device_locale", getCurrentLanguage())
+                .putString("device_country", getCurrentCountry())
                 .apply();
     }
 
     public static Locale getDeviceLocale(Context ctx)
     {
         String deviceLocaleStr = PreferenceManager.getDefaultSharedPreferences(ctx).getString("device_locale", "en");
-        return new Locale(deviceLocaleStr);
+        String deviceCountryStr = PreferenceManager.getDefaultSharedPreferences(ctx).getString("device_country", "US");
+        return new Locale(deviceLocaleStr, deviceCountryStr);
     }
 
     private static String getCurrentLanguage()
@@ -66,6 +68,18 @@ public class LocaleUtils {
         else
         {
             return Locale.getDefault().getLanguage();
+        }
+    }
+
+    private static String getCurrentCountry()
+    {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            return LocaleList.getDefault().get(0).getCountry();
+        }
+        else
+        {
+            return Locale.getDefault().getCountry();
         }
     }
 }


### PR DESCRIPTION
Use the phone's locale setting to render dates eg:

15 Mars 2020
instead of Mar 15, 2020

More pleasant for our continental European friends. Tested for French, Chinese, US locale, Spanish and Japanese.