### PR TITLE
Debounce TokenScript and Dapp signing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
+++ b/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
@@ -36,14 +36,13 @@ public class ConfirmationRouter {
     }
 
     //Sign transaction for dapp browser
-    public void open(Activity context, Web3Transaction transaction, String networkName, boolean isMainNet, String requesterURL, int chainId) throws TransactionTooLargeException
+    public void open(Activity context, Web3Transaction transaction, String networkName, String requesterURL, int chainId) throws TransactionTooLargeException
     {
         Intent intent = new Intent(context, ConfirmationActivity.class);
         intent.putExtra(C.EXTRA_WEB3TRANSACTION, transaction);
         intent.putExtra(C.EXTRA_AMOUNT, Convert.fromWei(transaction.value.toString(10), Convert.Unit.WEI).toString());
         intent.putExtra(C.TOKEN_TYPE, ConfirmationType.WEB3TRANSACTION.ordinal());
         intent.putExtra(C.EXTRA_NETWORK_NAME, networkName);
-        intent.putExtra(C.EXTRA_NETWORK_MAINNET, isMainNet);
         intent.putExtra(C.EXTRA_ACTION_NAME, requesterURL);
         intent.putExtra(C.EXTRA_NETWORKID, chainId);
         intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -199,6 +199,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         {
             ((HomeActivity)getActivity()).ResetDappBrowser();
         }
+        if (viewModel != null) viewModel.resetDebounce();
     }
 
     @Nullable

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenscriptViewHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenscriptViewHolder.java
@@ -111,7 +111,7 @@ public class TokenscriptViewHolder extends BinderViewHolder<TicketRange> impleme
                 Intent intent = new Intent(getContext(), TokenFunctionActivity.class);
                 intent.putExtra(TICKET, token);
                 intent.putExtra(C.EXTRA_TOKEN_ID, token.bigIntListToString(data.tokenIds, false));
-                intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+                intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 getContext().startActivity(intent);
             });
         }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DappBrowserViewModel extends BaseViewModel  {
+    private static final long DEBOUNCE_LIMIT = 5L * 1000L; //5 seconds debounce time
     private final MutableLiveData<NetworkInfo> defaultNetwork = new MutableLiveData<>();
     private final MutableLiveData<Wallet> defaultWallet = new MutableLiveData<>();
     private final MutableLiveData<GasSettings> gasSettings = new MutableLiveData<>();
@@ -65,6 +66,7 @@ public class DappBrowserViewModel extends BaseViewModel  {
 
     private double ethToUsd = 0;
     private ArrayList<String> bookmarks;
+    private long debounceTime = 0;
 
     DappBrowserViewModel(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
@@ -225,9 +227,16 @@ public class DappBrowserViewModel extends BaseViewModel  {
 
     public void openConfirmation(Activity context, Web3Transaction transaction, String requesterURL, NetworkInfo networkInfo) throws TransactionTooLargeException
     {
-        String networkName = networkInfo.name;
-        boolean mainNet = networkInfo.isMainNetwork;
-        confirmationRouter.open(context, transaction, networkName, mainNet, requesterURL, networkInfo.chainId);
+        if (System.currentTimeMillis() > (debounceTime + DEBOUNCE_LIMIT)) //debounce transaction click
+        {
+            debounceTime = System.currentTimeMillis();
+            confirmationRouter.open(context, transaction, networkInfo.name, requesterURL, networkInfo.chainId);
+        }
+    }
+
+    public void resetDebounce()
+    {
+        debounceTime = 0;
     }
 
     private ArrayList<String> getBrowserBookmarksFromPrefs(Context context) {


### PR DESCRIPTION
- Debounce TokenScript function signing.
- Debounce DappBrowser signing.
- Debounce TokenScript view click.
- Tidy up confirmation call.

Example issues that are fixed:

- Go to NFT factory. Set up token. Click 'deploy contract' button as fast as you can.
- Go to tokenscript entry token, go to 'enter' and then spam the confirm button as fast as you can. You can sometimes get the app into a 'zombie' state where the signing dialog doesn't do anything and can't be dismissed. It's because the real signing dialog is buried underneath.

