### PR TITLE
Fix for token select inconsistency with multiple token select.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -173,7 +173,8 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
             }
             else
             {
-                List<BigInteger> selected = adapter.getSelectedTokenIds(selection);
+                List<BigInteger> selected = selection;
+                if (adapter != null) selected = adapter.getSelectedTokenIds(selection);
 
                 switch (v.getId())
                 {

--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -41,7 +41,6 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
     private StandardFunctionInterface callStandardFunctions;
     private LinearLayout currentHolder = null;
     private int buttonCount;
-    private boolean buttonSetupMode = false;
 
     public FunctionButtonBar(Context ctx)
     {

--- a/app/src/main/res/drawable/button_round_error.xml
+++ b/app/src/main/res/drawable/button_round_error.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/warning_red" />
+    <corners android:radius="5dp" />
+</shape>


### PR DESCRIPTION
- Fix for token select inconsistency with multiple token select. Only seen with multi-token select TokenScripts (eg cryptokitties). To reproduce issue: Use Cryptokitties breeding script, have multiple kitties; select a kitty, then select another kitty, deselect the first kitty, then transfer.

- Refactor and make it easier to add new tokens.