### PR TITLE
Explicitly switch off cached results for multi-tokenId input functions.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
@@ -601,7 +601,7 @@ public abstract class TokenscriptFunction
             else useAddress = new ContractAddress(attr.function, cAddr.chainId, cAddr.address);
             TransactionResult cachedResult = attrIf.getFunctionResult(useAddress, attr, tokenId); //Needs to allow for multiple tokenIds
             if (cAddr != null && !useAddress.address.equalsIgnoreCase(cAddr.address)) transactionUpdate = 0; //If calling a function which isn't the main tokenscript function retrieve from contract call not cache
-            if (attrIf.resolveOptimisedAttr(useAddress, attr, cachedResult) || !cachedResult.needsUpdating(transactionUpdate)) //can we use wallet's known data or cached value?
+            if (!attr.isVolatile() && (attrIf.resolveOptimisedAttr(useAddress, attr, cachedResult) || !cachedResult.needsUpdating(transactionUpdate))) //can we use wallet's known data or cached value?
             {
                 return resultFromDatabase(cachedResult, attr);
             }

--- a/lib/src/main/java/com/alphawallet/token/entity/AttributeType.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/AttributeType.java
@@ -316,4 +316,33 @@ public class AttributeType {
     {
         this.as = as;
     }
+
+    /**
+     * Detects a function call with more than one tokenId present - this means we shouldn't cache the result.
+     *
+     * @return does the function rely on more than one tokenId input?
+     */
+    public boolean isMultiTokenCall()
+    {
+        int tokenIdCount = 0;
+        if (function != null && function.parameters != null && function.parameters.size() > 1)
+        {
+            for (MethodArg arg : function.parameters)
+            {
+                if (arg.isTokenId()) tokenIdCount++;
+            }
+        }
+
+        return tokenIdCount > 1;
+    }
+
+    /**
+     * Any property of the function that makes it volatile should go in here. Recommend we add a 'volatile' keyword.
+     *
+     * @return
+     */
+    public boolean isVolatile()
+    {
+        return isMultiTokenCall();
+    }
 }


### PR DESCRIPTION
If a function has multi-token input (eg 'Kitty breed check) then don't use the cached result.