### PR TITLE
Implement common browser intents

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -684,8 +684,8 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
                 fileChooserParams = fCParams;
                 picker = fileChooserParams.createIntent();
 
-                if (!checkReadPermission()) return super.onShowFileChooser(webView, filePathCallback, fCParams);
-                else return requestUpload();
+                if (checkReadPermission()) return requestUpload();
+                else return true;
             }
         });
 
@@ -1369,7 +1369,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         boolean geoAccess = false;
         for (int i = 0; i < permissions.length; i++)
         {
-            if (permissions[i].contains("LOCATION") && grantResults[i] != -1) geoAccess = true;
+            if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION) && grantResults[i] != -1) geoAccess = true;
         }
         if (!geoAccess) Toast.makeText(getContext(), "Permission not given", Toast.LENGTH_SHORT).show();
         if (geoCallback != null && geoOrigin != null) geoCallback.invoke(geoOrigin, geoAccess, false);
@@ -1380,10 +1380,10 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         boolean fileAccess = false;
         for (int i = 0; i < permissions.length; i++)
         {
-            if (permissions[i].contains("FILE") && grantResults[i] != -1) fileAccess = true;
+            if (permissions[i].equals(Manifest.permission.READ_EXTERNAL_STORAGE) && grantResults[i] != -1) fileAccess = true;
         }
 
-        if (fileAccess && picker != null) startActivityForResult(picker, UPLOAD_FILE);
+        if (fileAccess && picker != null) requestUpload();
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -752,42 +752,52 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults)
     {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == DappBrowserFragment.REQUEST_FILE_ACCESS)
+        switch (requestCode)
         {
-            ((DappBrowserFragment)dappBrowserFragment).gotFileAccess(requestCode);
+            case DappBrowserFragment.REQUEST_FILE_ACCESS:
+                ((DappBrowserFragment)dappBrowserFragment).gotFileAccess(permissions, grantResults);
+                break;
+            case DappBrowserFragment.REQUEST_FINE_LOCATION:
+                ((DappBrowserFragment)dappBrowserFragment).gotGeoAccess(permissions, grantResults);
+                break;
+            case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
+            case RC_ASSET_EXTERNAL_WRITE_PERM:
+                handleWritePermissions(requestCode, permissions, grantResults);
+                break;
         }
-        else if (requestCode == RC_DOWNLOAD_EXTERNAL_WRITE_PERM || requestCode == RC_ASSET_EXTERNAL_WRITE_PERM)
+    }
+
+    private void handleWritePermissions(int requestCode, String[] permissions, int[] grantResults)
+    {
+        //check permission is granted
+        for (int i = 0; i < permissions.length; i++)
         {
-            //check permission is granted
-            for (int i = 0; i < permissions.length; i++)
+            String p = permissions[i];
+            if (p.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE))
             {
-                String p = permissions[i];
-                if (p.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE))
+                if (grantResults[i] != -1)
                 {
-                    if (grantResults[i] != -1)
+                    switch (requestCode)
                     {
-                        switch (requestCode)
-                        {
-                            case RC_ASSET_EXTERNAL_WRITE_PERM:
-                                viewModel.loadExternalXMLContracts();
-                                ((NewSettingsFragment)settingsFragment).refresh();
-                                break;
-                            case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
-                                viewModel.downloadAndInstall(buildVersion, this);
-                                break;
-                        }
+                        case RC_ASSET_EXTERNAL_WRITE_PERM:
+                            viewModel.loadExternalXMLContracts();
+                            ((NewSettingsFragment)settingsFragment).refresh();
+                            break;
+                        case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
+                            viewModel.downloadAndInstall(buildVersion, this);
+                            break;
                     }
-                    else
+                }
+                else
+                {
+                    switch (requestCode)
                     {
-                        switch (requestCode)
-                        {
-                            case RC_ASSET_EXTERNAL_WRITE_PERM:
-                                //no warning
-                                break;
-                            case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
-                                showRequirePermissionError();
-                                break;
-                        }
+                        case RC_ASSET_EXTERNAL_WRITE_PERM:
+                            //no warning
+                            break;
+                        case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
+                            showRequirePermissionError();
+                            break;
                     }
                 }
             }

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -761,47 +761,34 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 ((DappBrowserFragment)dappBrowserFragment).gotGeoAccess(permissions, grantResults);
                 break;
             case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
+                if (hasPermission(permissions, grantResults))
+                {
+                    viewModel.loadExternalXMLContracts();
+                    ((NewSettingsFragment)settingsFragment).refresh();
+                }
+                break;
             case RC_ASSET_EXTERNAL_WRITE_PERM:
-                handleWritePermissions(requestCode, permissions, grantResults);
+                if (hasPermission(permissions, grantResults))
+                {
+                    viewModel.downloadAndInstall(buildVersion, this);
+                }
+                else
+                {
+                    showRequirePermissionError();
+                }
                 break;
         }
     }
 
-    private void handleWritePermissions(int requestCode, String[] permissions, int[] grantResults)
+    private boolean hasPermission(String[] permissions, int[] grantResults)
     {
-        //check permission is granted
+        boolean hasPermission = true;
         for (int i = 0; i < permissions.length; i++)
         {
-            String p = permissions[i];
-            if (p.equals(Manifest.permission.WRITE_EXTERNAL_STORAGE))
-            {
-                if (grantResults[i] != -1)
-                {
-                    switch (requestCode)
-                    {
-                        case RC_ASSET_EXTERNAL_WRITE_PERM:
-                            viewModel.loadExternalXMLContracts();
-                            ((NewSettingsFragment)settingsFragment).refresh();
-                            break;
-                        case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
-                            viewModel.downloadAndInstall(buildVersion, this);
-                            break;
-                    }
-                }
-                else
-                {
-                    switch (requestCode)
-                    {
-                        case RC_ASSET_EXTERNAL_WRITE_PERM:
-                            //no warning
-                            break;
-                        case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
-                            showRequirePermissionError();
-                            break;
-                    }
-                }
-            }
+            if (grantResults[i] == -1) hasPermission = false;
         }
+
+        return hasPermission;
     }
 
     private void showRequirePermissionError()


### PR DESCRIPTION
Impement browser intents that may be useful, namely:

- Add Phone / dial intent (decoupled from calling - this is the non invasive version that asks how the user wants to call, then opens the chosen dialer with the supplied number filled in).
- Add File chooser intent (so user can upload files to sites, eg profile picture etc).
- Add Geo Location intent (for map location) - note that AlphaWallet doesn't ask for Location permission in the manifest so it won't work on our release, but should a forked wallet want geo-location they would need to add ACCESS_FINE_LOCATION permission to the manifest.

Hook up the intents smoothly so that on the first ask, the chooser intent should pop up after being given permission. If permission not given the app will just continue with a warning that it can't perform the action.

Note that these intents aren't given automatically by Android WebView; due to how devs may want these handled Android OS requires you to implement them manually yourself in your code.