### PR TITLE
Fix chain symbol name in pending transactions

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -278,7 +278,7 @@ public class ERC721Ticket extends Token implements Parcelable {
      * @return token requires a transaction refresh
      */
     @Override
-    public boolean requiresTransactionRefresh()
+    public boolean requiresTransactionRefresh(int pendingChain)
     {
         boolean requiresUpdate = balanceChanged;
         balanceChanged = false;

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -270,7 +270,7 @@ public class ERC721Token extends Token implements Parcelable
     public boolean isNonFungible() { return true; }
 
     @Override
-    public boolean requiresTransactionRefresh()
+    public boolean requiresTransactionRefresh(int pendingChain)
     {
         return false;
     }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -413,7 +413,7 @@ public class Ticket extends Token implements Parcelable
      * @return token requires a transaction refresh
      */
     @Override
-    public boolean requiresTransactionRefresh()
+    public boolean requiresTransactionRefresh(int pendingChain)
     {
         boolean requiresUpdate = balanceChanged;
         balanceChanged = false;

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -863,7 +863,7 @@ public class Token implements Parcelable, Comparable<Token>
         return walletUIUpdateRequired;
     }
 
-    public boolean requiresTransactionRefresh()
+    public boolean requiresTransactionRefresh(int updateChain)
     {
         boolean requiresUpdate = balanceChanged;
         balanceChanged = false;
@@ -875,6 +875,12 @@ public class Token implements Parcelable, Comparable<Token>
         long currentTime = System.currentTimeMillis();
 
         long multiplier = isEthereum() || EthereumNetworkRepository.isPriorityToken(this) ? 1 : 5;
+
+        if (isEthereum() && tokenInfo.chainId == updateChain && (currentTime - lastTxCheck) > 10*1000) //check chain every 10 seconds while transaction is pending
+        {
+            lastTxCheck = currentTime;
+            requiresUpdate = true;
+        }
 
         //ensure chain transactions for the wallet are checked on a regular basis.
         if (checkBackgroundUpdate(currentTime) || (EthereumNetworkRepository.hasTicker(this) && hasPositiveBalance() && (currentTime - lastTxCheck) > multiplier*60*1000)) //need to check main chains once per minute

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -145,11 +145,12 @@ public class TokensService
         return symbol;
     }
 
-    public Token getRequiresTransactionUpdate()
+    public Token getRequiresTransactionUpdate(Token pending)
     {
+        int chainToUpdate = pending != null ? pending.tokenInfo.chainId : 0;
         for (Token check : getAllLiveTokens())
         {
-            if (check.requiresTransactionRefresh())
+            if (check.requiresTransactionRefresh(chainToUpdate))
             {
                 return check;
             }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -162,7 +162,11 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         pendingSpinner.setVisibility(View.VISIBLE);
         typeIcon.setVisibility(View.GONE);
         type.setText(R.string.pending_transaction);
-        String valueStr = getValueStr(transaction.value, true, getString(R.string.eth), 18, transaction.to.equalsIgnoreCase(transaction.from));
+        String symbol = getString(R.string.eth);
+        Token t = tokensService.getToken(transaction.chainId, tokensService.getCurrentAddress());
+        if (t != null) symbol = t.tokenInfo.symbol;
+
+        String valueStr = getValueStr(transaction.value, true, symbol, 18, transaction.to.equalsIgnoreCase(transaction.from));
         value.setText(valueStr);
         value.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
         value.setVisibility(View.VISIBLE);
@@ -175,7 +179,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         {
             address.setText(transaction.to);
         }
-
     }
 
     private void fillERC875(boolean txSuccess, Transaction trans, ERC875ContractTransaction ct)

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionsViewModel.java
@@ -172,7 +172,9 @@ public class TransactionsViewModel extends BaseViewModel
     {
         if (fetchTransactionDisposable == null)
         {
-            Token t = tokensService.getRequiresTransactionUpdate();
+            Token pending = getPendingTransaction();
+            //see if pending transaction is at top of list
+            Token t = tokensService.getRequiresTransactionUpdate(pending);
 
             if (t != null)
             {
@@ -186,6 +188,21 @@ public class TransactionsViewModel extends BaseViewModel
                                 .subscribe(transactions -> onUpdateTransactions(transactions, t), this::onTxError);
             }
         }
+    }
+
+    private Token getPendingTransaction()
+    {
+        Token t = null;
+        for (Transaction tx : txMap.values())
+        {
+            if (tx.blockNumber.equals("0"))
+            {
+                t = tokensService.getToken(tx.chainId, tokensService.getCurrentAddress());
+                break;
+            }
+        }
+
+        return t;
     }
 
     private void onTxError(Throwable throwable)


### PR DESCRIPTION
- show correct chain symbol for pending transaction (eg 0.01 ETH/1.2 ETC/21.1 XDAI etc - previously pending transaction showed the previous examples as 0.01 ETH/1.2 ETH/21.1 ETH).
- check chain which has pending transactions for new transactions more frequently, so transactions are shown as resolved more quickly using the wallet.