### PR TITLE
Add static page viewer for Help & FAQ

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -261,6 +261,10 @@
         <activity
             android:name=".ui.BackupKeyActivity"
             android:windowSoftInputMode="stateHidden|adjustResize" />
+
+        <activity
+            android:name=".ui.StaticViewer"
+            android:label="View Text" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -79,6 +79,7 @@ public abstract class C {
     public static final String EXTRA_CHAIN_ID = "CHAIN_ID";
     public static final String EXTRA_CALLBACKID = "CALLBACK_ID";
     public static final String EXTRA_LOCALE = "LOCALE_STRING";
+    public static final String EXTRA_PAGE_TITLE = "PTITLE";
 
     public static final String PRUNE_ACTIVITY =
             "com.stormbird.wallet.PRUNE_ACTIVITY";

--- a/app/src/main/java/com/alphawallet/app/entity/HelpItem.java
+++ b/app/src/main/java/com/alphawallet/app/entity/HelpItem.java
@@ -6,17 +6,26 @@ import android.os.Parcelable;
 public class HelpItem implements Parcelable {
     private String question;
     private String answer;
+    private int resource;
 
     private String eventName;
 
     public HelpItem(String question, String answer) {
         this.question = question;
         this.answer = answer;
+        this.resource = 0;
+    }
+
+    public HelpItem(String question, int resource) {
+        this.question = question;
+        this.answer = "";
+        this.resource = resource;
     }
 
     private HelpItem(Parcel in) {
         question = in.readString();
         answer = in.readString();
+        resource = in.readInt();
     }
 
     public String getQuestion() {
@@ -25,6 +34,10 @@ public class HelpItem implements Parcelable {
 
     public String getAnswer() {
         return this.answer;
+    }
+
+    public int getResource() {
+        return this.resource;
     }
 
     public static final Creator<HelpItem> CREATOR = new Creator<HelpItem>() {
@@ -48,5 +61,6 @@ public class HelpItem implements Parcelable {
     public void writeToParcel(Parcel parcel, int i) {
         parcel.writeString(question);
         parcel.writeString(answer);
+        parcel.writeInt(resource);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/HelpActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HelpActivity.java
@@ -4,8 +4,10 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.LinearLayout;
@@ -18,6 +20,7 @@ import com.alphawallet.app.entity.HelpItem;
 import com.alphawallet.app.viewmodel.HelpViewModel;
 import com.alphawallet.app.viewmodel.HelpViewModelFactory;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,7 +67,8 @@ public class HelpActivity extends BaseActivity {
         adapter.setWebView(webView);
         List<HelpItem> helpItems = new ArrayList<>();
         for (int i = 0; i < questions.length; i++) {
-            if (getString(questions[i]).length() > 0) helpItems.add(new HelpItem(getString(questions[i]), getString(answers[i])));
+            if (isRawResource(answers[i])) helpItems.add(new HelpItem(getString(questions[i]), answers[i]));
+            else if (getString(questions[i]).length() > 0) helpItems.add(new HelpItem(getString(questions[i]), getString(answers[i])));
         }
         adapter.setHelpItems(helpItems);
 
@@ -135,4 +139,19 @@ public class HelpActivity extends BaseActivity {
         }.execute(request);*/
     }
 
+    private boolean isRawResource(@RawRes int rawRes) {
+        try {
+            InputStream in = getResources().openRawResource(rawRes);
+            if (in.available() > 0)
+            {
+                in.close();
+                return true;
+            }
+            in.close();
+        } catch (Exception ex) {
+            Log.d("READ_JS_TAG", "Ex", ex);
+        }
+
+        return false;
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/StaticViewer.java
+++ b/app/src/main/java/com/alphawallet/app/ui/StaticViewer.java
@@ -1,0 +1,49 @@
+package com.alphawallet.app.ui;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.webkit.WebView;
+
+import com.alphawallet.app.C;
+import com.alphawallet.app.R;
+
+public class StaticViewer extends BaseActivity
+{
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        setContentView(R.layout.activity_static_viewer);
+        super.onCreate(savedInstanceState);
+        toolbar();
+
+        String base64WebData = getIntent().getStringExtra(C.EXTRA_STATE);
+        String title = getIntent().getStringExtra(C.EXTRA_PAGE_TITLE);
+        WebView webView = findViewById(R.id.webview);
+        setTitle(title);
+
+        //load string
+        webView.loadData(base64WebData, "text/html; charset=utf-8", "base64");
+    }
+
+    //allow back
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home: {
+                onBackPressed();
+                return true;
+            }
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onBackPressed() {
+        finish();
+    }
+}

--- a/app/src/main/res/layout/activity_static_viewer.xml
+++ b/app/src/main/res/layout/activity_static_viewer.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/colorPrimaryDark">
+
+    <include layout="@layout/layout_white_toolbar" />
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible">
+
+    </WebView>
+
+</LinearLayout>


### PR DESCRIPTION
This new activity displays a static HTML page. 

Used for displaying extended help information that wouldn't be appropriate to fit into the extension bar underneath the help item, or for displaying static pages for information purposes.