### PR TITLE
Fix for builtin script loading

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenScriptFile.java
@@ -54,9 +54,11 @@ public class TokenScriptFile extends File
         {
             try
             {
+                if (!pathname.isEmpty() && pathname.startsWith("/")) pathname = pathname.substring(1); //.getAbsolute() adds a '/' to the filename
                 InputStream is = context.getResources().getAssets().open(pathname);
                 if (is.available() > 0) resourceFile = true;
                 is.close();
+                fileName = pathname; // correct the filename if required
             }
             catch (IOException e)
             {


### PR DESCRIPTION
Noticed that the xdai script wasn't loading correctly - the function didn't appear on the button bar when you clicked on xdai chain card.

Reason was because the ```getAbsolutePath()``` method of the Java ```File``` class adds a path separator (```/```), which causes the Android OS asset input stream fetcher to fail.
