### PR TITLE
Fixes for observed and potential async completion errors

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -280,7 +280,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
 
     @Override
     public void onAttachFragment(Fragment fragment) {
-        if (fragment.getTag() != null)
+        if (getContext() != null && fragment.getTag() != null)
         {
             switch (fragment.getTag())
             {
@@ -415,7 +415,6 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     @Override
     public void onDappClick(DApp dapp) {
         forwardFragmentStack.clear();
-        System.out.println("Luddite: Clear: " + currentFragment);
         addToBackStack(DAPP_BROWSER);
         loadUrl(dapp.getUrl());
     }
@@ -896,7 +895,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     //return from the openConfirmation above
     public void handleTransactionCallback(int resultCode, Intent data)
     {
-        if (data == null) return;
+        if (data == null || web3 == null) return;
         Web3Transaction web3Tx = data.getParcelableExtra(C.EXTRA_WEB3TRANSACTION);
         if (resultCode == RESULT_OK && web3Tx != null)
         {
@@ -1073,6 +1072,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     @Override
     public void onWebpageLoaded(String url, String title)
     {
+        if (getContext() == null) return; //could be a late return from dead fragment
         if (homePressed)
         {
             homePressed = false;


### PR DESCRIPTION
Fixes an error observed on crashlytics:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.alphawallet.app.web3.Web3View.onSignCancel(com.alphawallet.app.web3.entity.Web3Transaction)' on a null object reference
       at com.alphawallet.app.ui.DappBrowserFragment.handleTransactionCallback + 823(DappBrowserFragment.java:823)
       at com.alphawallet.app.ui.HomeActivity.onActivityResult + 861(HomeActivity.java:861)
       at android.app.Activity.dispatchActivityResult + 8110(Activity.java:8110)
       at android.app.ActivityThread.deliverResults + 4838(ActivityThread.java:4838)
       at android.app.ActivityThread.handleSendResult + 4886(ActivityThread.java:4886)
       at android.app.servertransaction.ActivityResultItem.execute + 51(ActivityResultItem.java:51)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 135(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute + 95(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage + 2016(ActivityThread.java:2016)
       at android.os.Handler.dispatchMessage + 107(Handler.java:107)
       at android.os.Looper.loop + 214(Looper.java:214)
       at android.app.ActivityThread.main + 7356(ActivityThread.java:7356)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 492(RuntimeInit.java:492)
       at com.android.internal.os.ZygoteInit.main + 930(ZygoteInit.java:930)
```

And other async returns which may complete after the originating context has shut down.