### PR TITLE
Add Safe Symbol usage method

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -243,6 +243,12 @@ public class Token implements Parcelable, Comparable<Token>
         }
     }
 
+    public String getSymbol()
+    {
+        if (tokenInfo.symbol == null) return "";
+        else return tokenInfo.symbol.toUpperCase();
+    }
+
     public void clickReact(BaseViewModel viewModel, Context context)
     {
         viewModel.showErc20TokenDetail(context, tokenInfo.address, tokenInfo.symbol, tokenInfo.decimals, this);

--- a/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
+++ b/app/src/main/java/com/alphawallet/app/router/ConfirmationRouter.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.TransactionTooLargeException;
 
 import com.alphawallet.app.C;
+import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.ui.ConfirmationActivity;
 import com.alphawallet.app.web3.entity.Web3Transaction;
 
@@ -49,7 +50,7 @@ public class ConfirmationRouter {
         context.startActivityForResult(intent, C.REQUEST_TRANSACTION_CALLBACK);
     }
 
-    public void openERC721Transfer(Context context, String to, String tokenId, String contractAddress, String name, String tokenName, String ensDetails, int chainId)
+    public void openERC721Transfer(Context context, String to, String tokenId, String contractAddress, String name, String tokenName, String ensDetails, Token token)
     {
         Intent intent = new Intent(context, ConfirmationActivity.class);
         intent.putExtra(C.EXTRA_TO_ADDRESS, to);
@@ -62,7 +63,8 @@ public class ConfirmationRouter {
         intent.putExtra(C.EXTRA_TOKENID_LIST, tokenId);
         intent.putExtra(C.EXTRA_ACTION_NAME, name);
         intent.putExtra(C.EXTRA_ENS_DETAILS, ensDetails);
-        intent.putExtra(C.EXTRA_NETWORKID, chainId);
+        intent.putExtra(C.EXTRA_TOKEN_ID, token);
+        intent.putExtra(C.EXTRA_NETWORKID, token.tokenInfo.chainId);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
     }

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -1305,7 +1305,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         }
 
         TokenScriptResult.addPair(attrs, "name", name);
-        TokenScriptResult.addPair(attrs, "symbol", token.tokenInfo.symbol);
+        TokenScriptResult.addPair(attrs, "symbol", token.getSymbol());
         TokenScriptResult.addPair(attrs, "_count", String.valueOf(count));
         TokenScriptResult.addPair(attrs, "contractAddress", token.tokenInfo.address);
         TokenScriptResult.addPair(attrs, "chainId", String.valueOf(token.tokenInfo.chainId));

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -139,7 +139,7 @@ public class TokensService
         Token token = getToken(chainId, addr);
         if (token != null)
         {
-            symbol = token.tokenInfo.symbol;
+            symbol = token.getSymbol();
         }
 
         return symbol;

--- a/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
@@ -242,7 +242,7 @@ public class ConfirmationActivity extends BaseActivity implements SignAuthentica
                 contractAddrLabel.setVisibility(View.VISIBLE);
                 String contractTxt = contractAddress + " " + contractName;
                 contractAddrText.setText(contractTxt);
-                symbolText.setText(token.tokenInfo.symbol);
+                symbolText.setText(token.getSymbol());
                 amountString = symbol;
                 transactionBytes = viewModel.getERC721TransferBytes(to, contractAddress, amountStr, chainId);
                 break;

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -622,7 +622,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         balance.setVisibility(View.VISIBLE);
         symbol.setVisibility(View.VISIBLE);
         balance.setText(token.getScaledBalance());
-        symbol.setText(token.tokenInfo.symbol);
+        symbol.setText(token.getSymbol());
     }
 
     private void onDefaultWallet(Wallet wallet) {

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -455,7 +455,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
             }
             else
             {
-                functionEffect = functionEffect + " " + token.tokenInfo.symbol + " to " + actionMethod;
+                functionEffect = functionEffect + " " + token.getSymbol() + " to " + actionMethod;
                 //functionEffect = functionEffect + " to " + actionMethod;
             }
 
@@ -467,7 +467,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
                 value = action.function.tx.args.get("value").value;
                 BigDecimal valCorrected = getCorrectedBalance(value, 18);
                 Token currency = viewModel.getCurrency(token.tokenInfo.chainId);
-                functionEffect = valCorrected.toString() + " " + currency.tokenInfo.symbol + " to " + actionMethod;
+                functionEffect = valCorrected.toString() + " " + currency.getSymbol() + " to " + actionMethod;
             }
 
             //finished resolving attributes, blank definition cache so definition is re-loaded when next needed
@@ -520,7 +520,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         }
 
         //eg Send 2(*1) ETH(*2) to Alex's Amazing Coffee House(*3) (0xdeadacec0ffee(*4))
-        String extraInfo = String.format(getString(R.string.tokenscript_send_native), functionEffect, token.tokenInfo.symbol, actionMethod, to);
+        String extraInfo = String.format(getString(R.string.tokenscript_send_native), functionEffect, token.getSymbol(), actionMethod, to);
 
         //Clear the cache to refresh any resolved values
         viewModel.getAssetDefinitionService().clearCache();
@@ -548,7 +548,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         alertDialog = new AWalletAlertDialog(this);
         alertDialog.setIcon(AWalletAlertDialog.ERROR);
         alertDialog.setTitle(R.string.error_insufficient_funds);
-        alertDialog.setMessage(getString(R.string.current_funds, currency.getCorrectedBalance(currency.tokenInfo.decimals), currency.tokenInfo.symbol));
+        alertDialog.setMessage(getString(R.string.current_funds, currency.getCorrectedBalance(currency.tokenInfo.decimals), currency.getSymbol()));
         alertDialog.setButtonText(R.string.button_ok);
         alertDialog.setButtonListener(v ->alertDialog.dismiss());
         alertDialog.show();

--- a/app/src/main/java/com/alphawallet/app/ui/SendActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SendActivity.java
@@ -223,7 +223,7 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
         if (isValid) {
             BigInteger amountInSubunits = BalanceUtils.baseToSubunit(currentAmount, decimals);
             boolean sendingTokens = !token.isEthereum();
-            viewModel.openConfirmation(this, to, amountInSubunits, token.getAddress(), token.tokenInfo.decimals, token.tokenInfo.symbol, sendingTokens, ensHandler.getEnsName(), currentChain);
+            viewModel.openConfirmation(this, to, amountInSubunits, token.getAddress(), token.tokenInfo.decimals, token.getSymbol(), sendingTokens, ensHandler.getEnsName(), currentChain);
         }
     }
 
@@ -523,7 +523,7 @@ public class SendActivity extends BaseActivity implements Runnable, ItemClickLis
         tokenSymbolText = findViewById(R.id.symbol);
         chainName = findViewById(R.id.text_chain_name);
 
-        String symbol = TextUtils.isEmpty(token.tokenInfo.symbol) ? "" : token.tokenInfo.symbol.toUpperCase();
+        String symbol = token.getSymbol();
 
         tokenSymbolText.setText(TextUtils.isEmpty(token.tokenInfo.name)
                 ? symbol

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/AmountEntryItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/AmountEntryItem.java
@@ -122,8 +122,8 @@ public class AmountEntryItem
         tokenEquivalentSymbol = activity.findViewById(R.id.text_token_symbol);
         if (token != null)
         {
-            tokenSymbolLabel.setText(token.tokenInfo.symbol);
-            tokenEquivalentSymbol.setText(token.tokenInfo.symbol);
+            tokenSymbolLabel.setText(token.getSymbol());
+            tokenEquivalentSymbol.setText(token.getSymbol());
         }
 
         tokenEquivalentLayout = activity.findViewById(R.id.layout_token_equivalent_value);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -104,7 +104,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         String tokenSymbol = "";
         if (token != null)
         {
-            tokenSymbol = token.tokenInfo.symbol;
+            tokenSymbol = token.getSymbol();
             if (chainName != null)
             {
                 Utils.setChainColour(chainName, token.tokenInfo.chainId);
@@ -164,7 +164,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         type.setText(R.string.pending_transaction);
         String symbol = getString(R.string.eth);
         Token t = tokensService.getToken(transaction.chainId, tokensService.getCurrentAddress());
-        if (t != null) symbol = t.tokenInfo.symbol;
+        if (t != null) symbol = t.getSymbol();
 
         String valueStr = getValueStr(transaction.value, true, symbol, 18, transaction.to.equalsIgnoreCase(transaction.from));
         value.setText(valueStr);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
@@ -247,7 +247,7 @@ public class Erc20DetailViewModel extends BaseViewModel {
     {
         if (token != null)
         {
-            new SendTokenRouter().open(ctx, address, token.tokenInfo.symbol, token.tokenInfo.decimals,
+            new SendTokenRouter().open(ctx, address, token.getSymbol(), token.tokenInfo.decimals,
                                        wallet.getValue(), token, token.tokenInfo.chainId);
         }
     }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -163,7 +163,7 @@ public class TokenFunctionViewModel extends BaseViewModel
         intent.putExtra(C.EXTRA_TO_ADDRESS, toAddress);
         intent.putExtra(C.EXTRA_AMOUNT, value.toString());
         intent.putExtra(C.EXTRA_DECIMALS, nativeEth.tokenInfo.decimals);
-        intent.putExtra(C.EXTRA_SYMBOL, nativeEth.tokenInfo.symbol);
+        intent.putExtra(C.EXTRA_SYMBOL, nativeEth.getSymbol());
         intent.putExtra(C.EXTRA_SENDING_TOKENS, false);
         intent.putExtra(C.EXTRA_ENS_DETAILS, info);
         intent.putExtra(C.EXTRA_NETWORKID, nativeEth.tokenInfo.chainId);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransferTicketDetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransferTicketDetailViewModel.java
@@ -242,7 +242,7 @@ public class TransferTicketDetailViewModel extends BaseViewModel {
 
         if (asset != null)
         {
-            confirmationRouter.openERC721Transfer(ctx, to, hexTokenId, token.getAddress(), token.getFullName(), asset.getName(), ensDetails, token.tokenInfo.chainId);
+            confirmationRouter.openERC721Transfer(ctx, to, hexTokenId, token.getAddress(), token.getFullName(), asset.getName(), ensDetails, token);
         }
     }
 


### PR DESCRIPTION
Add safe symbol fetch to avoid issues arising from when symbol of token is legitimately null.

Could lead to this issue from Crashlytics:

```
Caused by java.lang.NullPointerException: Attempt to read from field 'com.alphawallet.app.entity.tokens.TokenInfo com.alphawallet.app.entity.tokens.Token.tokenInfo' on a null object reference
       at com.alphawallet.app.ui.ConfirmationActivity.onCreate + 236(ConfirmationActivity.java:236)
       at android.app.Activity.performCreate + 7183(Activity.java:7183)
       at android.app.Instrumentation.callActivityOnCreate + 1220(Instrumentation.java:1220)
       at android.app.ActivityThread.performLaunchActivity + 2910(ActivityThread.java:2910)
       at android.app.ActivityThread.handleLaunchActivity + 3032(ActivityThread.java:3032)
       at android.app.ActivityThread.-wrap11()
       at android.app.ActivityThread$H.handleMessage + 1696(ActivityThread.java:1696)
       at android.os.Handler.dispatchMessage + 105(Handler.java:105)
       at android.os.Looper.loop + 164(Looper.java:164)
       at android.app.ActivityThread.main + 6944(ActivityThread.java:6944)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.Zygote$MethodAndArgsCaller.run + 327(Zygote.java:327)
       at com.android.internal.os.ZygoteInit.main + 1374(ZygoteInit.java:1374)
```

