### PR TITLE
Formalise grouped token selection rule

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -513,6 +513,8 @@ public class Ticket extends Token implements Parcelable
     @Override
     public boolean isERC875() { return true; }
     public boolean isNonFungible() { return true; }
+    @Override
+    public boolean hasGroupedTransfer() { return true; }
 
     @Override
     public boolean groupWithToken(TicketRange currentGroupingRange, TicketRangeElement newElement, long currentGroupTime)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -967,7 +967,7 @@ public class Token implements Parcelable, Comparable<Token>
     public boolean hasGroupedTransfer() { return false; } //Can the NFT token's transfer function handle multiple tokens?
     public boolean checkSelectionValidity(List<BigInteger> selection) //check a selection of ID's for Transfer/Redeem/Sell
     {
-        return selection.size() != 0 && (selection.size() <= 1 || hasGroupedTransfer());
+        return selection.size() != 0 && (selection.size() == 1 || hasGroupedTransfer());
     }
 
 

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -964,6 +964,12 @@ public class Token implements Parcelable, Comparable<Token>
         return contractType == ContractType.ETHEREUM;
     }
     public boolean isERC721Ticket() { return false; }
+    public boolean hasGroupedTransfer() { return false; } //Can the NFT token's transfer function handle multiple tokens?
+    public boolean checkSelectionValidity(List<BigInteger> selection) //check a selection of ID's for Transfer/Redeem/Sell
+    {
+        return selection.size() != 0 && (selection.size() <= 1 || hasGroupedTransfer());
+    }
+
 
     public BigDecimal getCorrectedAmount(String newAmount)
     {

--- a/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
@@ -61,6 +61,7 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
         tokenView.setOnReadyCallback(this);
         functionBar.setupFunctions(this, viewModel.getAssetDefinitionService(), token, null);
         functionBar.revealButtons();
+        functionBar.setSelection(idList);
     }
 
     @Override
@@ -125,19 +126,19 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
     @Override
     public void selectRedeemTokens(List<BigInteger> selection)
     {
-        viewModel.selectRedeemToken(this, token, idList);
+        viewModel.selectRedeemToken(this, token, selection);
     }
 
     @Override
     public void sellTicketRouter(List<BigInteger> selection)
     {
-        viewModel.openUniversalLink(this, token, token.bigIntListToString(idList, false));
+        viewModel.openUniversalLink(this, token, token.bigIntListToString(selection, false));
     }
 
     @Override
     public void showTransferToken(List<BigInteger> selection)
     {
-        viewModel.showTransferToken(this, token, token.bigIntListToString(idList, false));
+        viewModel.showTransferToken(this, token, token.bigIntListToString(selection, false));
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -177,28 +177,26 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
             {
                 List<BigInteger> selected = selection;
                 if (adapter != null) selected = adapter.getSelectedTokenIds(selection);
+                boolean selectionValid = (token == null || token.checkSelectionValidity(selected));
 
                 switch (v.getId())
                 {
-                    case R.string.action_sell:
-                        //single token or grouping
-                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                    case R.string.action_sell:      //ERC875 only
+                        if (!selectionValid) flashButton(v);
                         else callStandardFunctions.sellTicketRouter(selected);
                         break;
-                    case R.string.action_send:
+                    case R.string.action_send:      //Eth + ERC20
                         callStandardFunctions.showSend();
                         break;
-                    case R.string.action_receive:
+                    case R.string.action_receive:   //Everything
                         callStandardFunctions.showReceive();
                         break;
-                    case R.string.action_transfer:
-                        //single token or grouping
-                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                    case R.string.action_transfer:  //Any NFT
+                        if (!selectionValid) flashButton(v);
                         else callStandardFunctions.showTransferToken(selected);
                         break;
-                    case R.string.action_use:
-                        //single token or grouping
-                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                    case R.string.action_use:    //NFT with Redeem
+                        if (!selectionValid) flashButton(v);
                         else callStandardFunctions.selectRedeemTokens(selected);
                         break;
                     default:

--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -41,6 +41,7 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
     private StandardFunctionInterface callStandardFunctions;
     private LinearLayout currentHolder = null;
     private int buttonCount;
+    private Token token = null;
 
     public FunctionButtonBar(Context ctx)
     {
@@ -77,6 +78,7 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
     {
         callStandardFunctions = functionInterface;
         adapter = adp;
+        this.token = token;
         functions = assetSvs.getTokenFunctionMap(token.tokenInfo.chainId, token.getAddress());
         removeAllViews();
         int intrinsicButtonCount = getTokenDefaultButtonCount(token);
@@ -180,8 +182,8 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
                 {
                     case R.string.action_sell:
                         //single token or grouping
-                        if (selected.size() == 1) callStandardFunctions.sellTicketRouter(selected);
-                        else flashButton(v);
+                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                        else callStandardFunctions.sellTicketRouter(selected);
                         break;
                     case R.string.action_send:
                         callStandardFunctions.showSend();
@@ -191,13 +193,13 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
                         break;
                     case R.string.action_transfer:
                         //single token or grouping
-                        if (selected.size() == 1) callStandardFunctions.showTransferToken(selected);
-                        else flashButton(v);
+                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                        else callStandardFunctions.showTransferToken(selected);
                         break;
                     case R.string.action_use:
                         //single token or grouping
-                        if (selected.size() == 1) callStandardFunctions.selectRedeemTokens(selected);
-                        else flashButton(v);
+                        if (token != null && !token.checkSelectionValidity(selected)) flashButton(v);
+                        else callStandardFunctions.selectRedeemTokens(selected);
                         break;
                     default:
                         callStandardFunctions.handleClick(v.getId());
@@ -389,4 +391,9 @@ public class FunctionButtonBar extends LinearLayout implements OnTokenClickListe
             v.setBackgroundResource(R.drawable.selector_round_button);
         }, 500);
     };
+
+    public void setSelection(List<BigInteger> idList)
+    {
+        selection = idList;
+    }
 }


### PR DESCRIPTION
Formalise grouping rule for tokens. Since the token contract determines if we can transfer multiple tokens in a single transfer it makes sense to add this property to the token contract definition.

This will make it easier to add new NFT's - you just specify if it has multiple token send and the group selection will function accordingly.

Tested with ERC875, 721 and 721T.