### PR TITLE
Fix for Tokenscript persistence issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/AssetDisplayModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/AssetDisplayModule.java
@@ -7,10 +7,9 @@ import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
 import com.alphawallet.app.repository.TokenRepositoryType;
 import com.alphawallet.app.repository.WalletRepositoryType;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.router.RedeemAssetSelectRouter;
-import com.alphawallet.app.router.TransferTicketRouter;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.OpenseaService;
+import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.viewmodel.AssetDisplayViewModelFactory;
 
 import dagger.Module;
@@ -26,14 +25,13 @@ public class AssetDisplayModule {
     AssetDisplayViewModelFactory redeemTokenViewModelFactory(
             FetchTokensInteract fetchTokensInteract,
             GenericWalletInteract genericWalletInteract,
-            TransferTicketRouter transferTicketRouter,
-            RedeemAssetSelectRouter redeemAssetSelectRouter,
             FindDefaultNetworkInteract findDefaultNetworkInteract,
             MyAddressRouter myAddressRouter,
             AssetDefinitionService assetDefinitionService,
-            OpenseaService openseaService) {
+            OpenseaService openseaService,
+            TokensService tokensService) {
         return new AssetDisplayViewModelFactory(
-                fetchTokensInteract, genericWalletInteract, transferTicketRouter, redeemAssetSelectRouter, findDefaultNetworkInteract, myAddressRouter, assetDefinitionService, openseaService);
+                fetchTokensInteract, genericWalletInteract, findDefaultNetworkInteract, myAddressRouter, assetDefinitionService, openseaService, tokensService);
     }
 
     @Provides
@@ -51,16 +49,6 @@ public class AssetDisplayModule {
     @Provides
     GenericWalletInteract provideFindDefaultWalletInteract(WalletRepositoryType walletRepository) {
         return new GenericWalletInteract(walletRepository);
-    }
-
-    @Provides
-    TransferTicketRouter provideTransferTicketRouter() {
-        return new TransferTicketRouter();
-    }
-
-    @Provides
-    RedeemAssetSelectRouter provideRedeemAssetRouter() {
-        return new RedeemAssetSelectRouter();
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -222,8 +222,6 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             showPage(WALLET);
         }
 
-        viewModel.loadExternalXMLContracts();
-
         if (VisibilityFilter.hideDappBrowser())
         {
             removeDappBrowser();

--- a/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
@@ -47,12 +47,41 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
     private FunctionButtonBar functionBar;
     private boolean reloaded;
 
-    private void initViews() {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        AndroidInjection.inject(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_script_view);
+
+        getIntents();
+        setupViewModel();
+        initViews();
+        toolbar();
+        setTitle(getString(R.string.token_function));
+    }
+
+    private void getIntents()
+    {
         token = getIntent().getParcelableExtra(TICKET);
         String displayIds = getIntent().getStringExtra(C.EXTRA_TOKEN_ID);
+        idList = token.stringHexToBigIntegerList(displayIds);
+    }
+
+    private void setupViewModel()
+    {
+        viewModel = ViewModelProviders.of(this, tokenFunctionViewModelFactory)
+                .get(TokenFunctionViewModel.class);
+        viewModel.startGasPriceUpdate(token.tokenInfo.chainId);
+        viewModel.getCurrentWallet();
+        viewModel.reloadScriptsIfRequired();
+    }
+
+    private void initViews()
+    {
         RelativeLayout frameLayout = findViewById(R.id.layout_select_ticket);
         tokenView = findViewById(R.id.web3_tokenview);
-        idList = token.stringHexToBigIntegerList(displayIds);
+        functionBar = findViewById(R.id.layoutButtons);
+
         reloaded = false;
 
         TicketRange data = new TicketRange(idList, token.tokenInfo.address, false);
@@ -61,28 +90,22 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
         tokenView.setOnReadyCallback(this);
         functionBar.setupFunctions(this, viewModel.getAssetDefinitionService(), token, null);
         functionBar.revealButtons();
-    }
 
-    @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        AndroidInjection.inject(this);
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_script_view);
-
-        viewModel = ViewModelProviders.of(this, tokenFunctionViewModelFactory)
-                .get(TokenFunctionViewModel.class);
         SystemView systemView = findViewById(R.id.system_view);
         ProgressView progressView = findViewById(R.id.progress_view);
         systemView.hide();
         progressView.hide();
-        functionBar = findViewById(R.id.layoutButtons);
+    }
 
+    @Override
+    public void onRestart()
+    {
+        super.onRestart();
+        getIntents();
+        setupViewModel();
         initViews();
         toolbar();
         setTitle(getString(R.string.token_function));
-
-        viewModel.startGasPriceUpdate(token.tokenInfo.chainId);
-        viewModel.getCurrentWallet();
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AssetDisplayViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AssetDisplayViewModel.java
@@ -15,10 +15,9 @@ import com.alphawallet.app.interact.FetchTokensInteract;
 import com.alphawallet.app.interact.FindDefaultNetworkInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.router.RedeemAssetSelectRouter;
-import com.alphawallet.app.router.TransferTicketRouter;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.OpenseaService;
+import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.ui.RedeemAssetSelectActivity;
 import com.alphawallet.app.ui.SellDetailActivity;
 import com.alphawallet.app.ui.TransferTicketDetailActivity;
@@ -49,11 +48,10 @@ public class AssetDisplayViewModel extends BaseViewModel
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
     private final FetchTokensInteract fetchTokensInteract;
     private final GenericWalletInteract genericWalletInteract;
-    private final TransferTicketRouter transferTicketRouter;
-    private final RedeemAssetSelectRouter redeemAssetSelectRouter;
     private final MyAddressRouter myAddressRouter;
     private final AssetDefinitionService assetDefinitionService;
     private final OpenseaService openseaService;
+    private final TokensService tokensService;
 
     private Token refreshToken;
 
@@ -68,20 +66,18 @@ public class AssetDisplayViewModel extends BaseViewModel
     AssetDisplayViewModel(
             FetchTokensInteract fetchTokensInteract,
             GenericWalletInteract genericWalletInteract,
-            TransferTicketRouter transferTicketRouter,
-            RedeemAssetSelectRouter redeemAssetSelectRouter,
             FindDefaultNetworkInteract findDefaultNetworkInteract,
             MyAddressRouter myAddressRouter,
             AssetDefinitionService assetDefinitionService,
-            OpenseaService openseaService) {
+            OpenseaService openseaService,
+            TokensService tokensService) {
         this.fetchTokensInteract = fetchTokensInteract;
         this.genericWalletInteract = genericWalletInteract;
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
-        this.redeemAssetSelectRouter = redeemAssetSelectRouter;
-        this.transferTicketRouter = transferTicketRouter;
         this.myAddressRouter = myAddressRouter;
         this.assetDefinitionService = assetDefinitionService;
         this.openseaService = openseaService;
+        this.tokensService = tokensService;
     }
 
     @Override
@@ -99,13 +95,6 @@ public class AssetDisplayViewModel extends BaseViewModel
         return ticket;
     }
     public LiveData<XMLDsigDescriptor> sig() { return sig; }
-
-    public void selectAssetIdsToRedeem(Context context, Token token) {
-        if (getBalanceDisposable != null) {
-            getBalanceDisposable.dispose();
-        }
-        redeemAssetSelectRouter.open(context, token);
-    }
 
     public OpenseaService getOpenseaService()
     {
@@ -153,13 +142,6 @@ public class AssetDisplayViewModel extends BaseViewModel
         disposable = genericWalletInteract
                 .find()
                 .subscribe(this::onDefaultWallet, this::onError);
-    }
-
-    public void showTransferToken(Context context, Token ticket) {
-        if (getBalanceDisposable != null) {
-            getBalanceDisposable.dispose();
-        }
-        transferTicketRouter.open(context, ticket);
     }
 
     public void showContractInfo(Context ctx, Token token)
@@ -227,5 +209,15 @@ public class AssetDisplayViewModel extends BaseViewModel
         failSig.type = SigReturnType.NO_TOKENSCRIPT;
         failSig.subject = throwable.getMessage();
         sig.postValue(failSig);
+    }
+
+    public void setTokenViewDimensions(Token token)
+    {
+        tokensService.addToken(token);
+    }
+
+    public void reloadScriptsIfRequired()
+    {
+        assetDefinitionService.reloadAssets();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AssetDisplayViewModelFactory.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AssetDisplayViewModelFactory.java
@@ -8,10 +8,9 @@ import com.alphawallet.app.interact.FetchTokensInteract;
 import com.alphawallet.app.interact.FindDefaultNetworkInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.router.RedeemAssetSelectRouter;
-import com.alphawallet.app.router.TransferTicketRouter;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.OpenseaService;
+import com.alphawallet.app.service.TokensService;
 
 /**
  * Created by James on 22/01/2018.
@@ -21,35 +20,32 @@ public class AssetDisplayViewModelFactory implements ViewModelProvider.Factory {
 
     private final FetchTokensInteract fetchTokensInteract;
     private final GenericWalletInteract genericWalletInteract;
-    private final TransferTicketRouter transferTicketRouter;
-    private final RedeemAssetSelectRouter redeemAssetSelectRouter;
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
     private final MyAddressRouter myAddressRouter;
     private final AssetDefinitionService assetDefinitionService;
     private final OpenseaService openseaService;
+    private final TokensService tokensService;
 
     public AssetDisplayViewModelFactory(
             FetchTokensInteract fetchTokensInteract,
             GenericWalletInteract genericWalletInteract,
-            TransferTicketRouter transferTicketRouter,
-            RedeemAssetSelectRouter redeemAssetSelectRouter,
             FindDefaultNetworkInteract findDefaultNetworkInteract,
             MyAddressRouter myAddressRouter,
             AssetDefinitionService assetDefinitionService,
-            OpenseaService openseaService) {
+            OpenseaService openseaService,
+            TokensService tokensService) {
         this.fetchTokensInteract = fetchTokensInteract;
         this.genericWalletInteract = genericWalletInteract;
         this.findDefaultNetworkInteract = findDefaultNetworkInteract;
-        this.redeemAssetSelectRouter = redeemAssetSelectRouter;
-        this.transferTicketRouter = transferTicketRouter;
         this.myAddressRouter = myAddressRouter;
         this.assetDefinitionService = assetDefinitionService;
         this.openseaService = openseaService;
+        this.tokensService = tokensService;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new AssetDisplayViewModel(fetchTokensInteract, genericWalletInteract, transferTicketRouter, redeemAssetSelectRouter, findDefaultNetworkInteract, myAddressRouter, assetDefinitionService, openseaService);
+        return (T) new AssetDisplayViewModel(fetchTokensInteract, genericWalletInteract, findDefaultNetworkInteract, myAddressRouter, assetDefinitionService, openseaService, tokensService);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -223,4 +223,9 @@ public class TokenFunctionViewModel extends BaseViewModel
     {
         keyService.failedAuthentication(signData);
     }
+
+    public void reloadScriptsIfRequired()
+    {
+        assetDefinitionService.reloadAssets();
+    }
 }


### PR DESCRIPTION
During lifecycle debugging it was flagged that debugging tokenscripts weren't re-loaded if they were OS scavenged.

This PR ensures that if the wallet is paged out (home pressed or application switched) while a tokenscript is showing in item-view or full view, on resume the script will display correctly.

The web view sizes for tokenscript views also persists across an app session now - so no need to recompute it each time it's displayed. This makes the app a bit more fluid, as the webview size for the complex scripts with backgrounds (eg tickets) has to be computed before a list can be displayed.

While refactoring also removed some redundant code.