### PR TITLE
Fix for initial native token load

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -283,7 +283,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
 
     private TokenTicker checkTicker(TokenTicker ticker, TokenTicker oldTicker)
     {
-        if (ticker.updateTime > 0) return ticker;
+        if (ticker != null && ticker.updateTime > 0) return ticker;
         else return oldTicker;
     }
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -254,21 +254,20 @@ public class TokensRealmSource implements TokenLocalSource {
     private void writeTickerToRealm(Realm realm, final Token token)
     {
         if (token.ticker == null) return;
-        long now = System.currentTimeMillis();
         String tickerName = databaseKey(token);
         RealmTokenTicker realmItem = realm.where(RealmTokenTicker.class)
                 .equalTo("contract", tickerName)
                 .findFirst();
         if (realmItem == null) {
             realmItem = realm.createObject(RealmTokenTicker.class, tickerName);
-            realmItem.setCreatedTime(now);
+            realmItem.setCreatedTime(token.ticker.updateTime);
         }
         realmItem.setPercentChange24h(token.ticker.percentChange24h);
         realmItem.setPrice(token.ticker.price);
         realmItem.setImage(TextUtils.isEmpty(token.ticker.image)
                            ? ""
                            : token.ticker.image);
-        realmItem.setUpdatedTime(now);
+        realmItem.setUpdatedTime(token.ticker.updateTime);
         realmItem.setCurrencySymbol(token.ticker.priceSymbol);
     }
 


### PR DESCRIPTION
Fix for offline token load where the wallet is setting up while offline.

When loading in the previous token data, if a ticker wasn't present for whatever reason then the token loading code would throw, leaving the app to create zero balance placeholder tokens.

This isn't normally visible because the values are pulled from internet very quickly on wallet start.
If you have no internet though you'll see the native currency cards with zero balance.
