### PR TITLE
Fix for builds without private API keys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
         def CoinmarketCapAPI = "CoinmarketCapAPI"
         def AmberdataAPI = "AmberdataAPI"
         def InfuraAPI = "InfuraAPI"
-        def COINMARKET_CAP_KEY = "\"obtain-api-key-from-coinmarketcap-com\""
+        def COINMARKET_CAP_KEY = "\"ea2d0a6b-7e77-4015-bccf-4877e5c5b882\""
         def AMBERDATA_API_KEY = "\"obtain-api-key-from-amberdata-io\"";
         def INFURA_API_KEY = "\"da3717f25f824cc1baa32d812386d93f\"";
         if (project.hasProperty("coinmarketcapAPI")) {

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -41,7 +41,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
        These hardcoded keys are fallbacks used by AlphaWallet forks.
      */
     public static final String BACKUP_INFURA_KEY = "da3717f25f824cc1baa32d812386d93f";
-    public static final String MAINNET_RPC_URL = "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI;
+    public static final String MAINNET_FALLBACK_RPC_URL = "https://ropsten.infura.io/v3/" + BuildConfig.InfuraAPI;
+    public static final String MAINNET_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI : MAINNET_FALLBACK_RPC_URL;
     public static final String CLASSIC_RPC_URL = "https://ethereumclassic.network";
     public static final String XDAI_RPC_URL = "https://dai.poa.network";
     public static final String POA_RPC_URL = "https://core.poa.network/";


### PR DESCRIPTION
Ensure wallet functions *almost* as normal without Amberdata API key.

- Tickers for main currencies work again.
- Main net node will now work falling back to Infura.
- Market discovery won't work (can be good-first-issue for open source contribution using free blockscout API). NB Market Discovery wouldn't work before this patch without Amberdata key. Market discovery is where we pick up any Market listed ERC20 tokens with value (eg DAI, cDAI etc) the account has.
- Tickers for ERC20 tokens won't work because these are sourced from Amberdata.

This PR allows contributing devs to see an almost normal baseline service straight from a clone/build.

Notice the CoinMarketCap key in build.gradle. This is deliberate and is a different key from the one we deploy for main AlphaWallet. With main AlphaWallet build we override this key with a secret one.