### PR TITLE
Standardise Token and Card Display

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -570,6 +570,5 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
     public void hideTabBar(View view)
     {
         view.findViewById(R.id.tab_layout).setVisibility(View.GONE);
-        view.findViewById(R.id.view_tab_space).setVisibility(View.VISIBLE);
     }
 }

--- a/app/src/main/res/layout/activity_asset_display.xml
+++ b/app/src/main/res/layout/activity_asset_display.xml
@@ -17,7 +17,6 @@
         android:background="@drawable/background_card">
 
         <com.alphawallet.app.web3.Web3TokenView
-            android:layout_marginTop="10dp"
             android:id="@+id/test_web3"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
@@ -37,15 +36,12 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/greyffive"
-                android:layout_marginTop="10dp"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/listTickets"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:divider="@android:color/white"
-                android:dividerHeight="10.0sp" />
+                android:layout_height="match_parent"/>
             </android.support.v4.widget.SwipeRefreshLayout>
 
         </RelativeLayout>

--- a/app/src/main/res/layout/activity_redeem_asset.xml
+++ b/app/src/main/res/layout/activity_redeem_asset.xml
@@ -25,16 +25,12 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="?actionBarSize"
-            android:paddingLeft="15dp"
-            android:paddingRight="15dp">
+            android:layout_marginBottom="?actionBarSize">
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/listTickets"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:divider="@android:color/transparent"
-                android:dividerHeight="10.0sp" />
+                android:layout_height="wrap_content" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_script_view.xml
+++ b/app/src/main/res/layout/activity_script_view.xml
@@ -28,9 +28,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
+            android:background="@color/greyffive"
             android:layout_above="@id/layoutButtons"
-            android:orientation="vertical"
-            android:layout_marginTop="10dp">
+            android:orientation="vertical">
 
             <include layout="@layout/item_ticket" />
 

--- a/app/src/main/res/layout/activity_set_price.xml
+++ b/app/src/main/res/layout/activity_set_price.xml
@@ -68,9 +68,7 @@
                     <android.support.v7.widget.RecyclerView
                         android:id="@+id/listTickets"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:divider="@android:color/transparent"
-                        android:dividerHeight="10.0sp" />
+                        android:layout_height="wrap_content" />
 
                     <LinearLayout
                         android:id="@+id/layout_set_quantity"

--- a/app/src/main/res/layout/activity_transfer_detail.xml
+++ b/app/src/main/res/layout/activity_transfer_detail.xml
@@ -49,12 +49,7 @@
                 <android.support.v7.widget.RecyclerView
                     android:id="@+id/listTickets"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="2dp"
-                    android:paddingRight="2dp"
-                    android:divider="@android:color/transparent"
-                    android:dividerHeight="10.0sp" />
-
+                    android:layout_height="wrap_content"/>
 
                 <LinearLayout
                     android:id="@+id/layout_ticket_quantity"

--- a/app/src/main/res/layout/activity_transfer_ticket_select.xml
+++ b/app/src/main/res/layout/activity_transfer_ticket_select.xml
@@ -24,16 +24,12 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="?actionBarSize"
-            android:paddingLeft="15dp"
-            android:paddingRight="15dp">
+            android:layout_marginBottom="?actionBarSize">
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/listTickets"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:divider="@android:color/transparent"
-                android:dividerHeight="10.0sp" />
+                android:layout_height="wrap_content"/>
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/fragment_wallet.xml
+++ b/app/src/main/res/layout/fragment_wallet.xml
@@ -33,28 +33,12 @@
         android:layout_height="1dp"
         android:background="@color/greydd"/>
 
-    <LinearLayout
-        android:id="@+id/layout_spacer"
-        android:layout_below="@id/spacer_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <View
-            android:id="@+id/view_tab_space"
-            android:layout_width="match_parent"
-            android:layout_height="6dp"
-            android:visibility="gone"
-            android:background="@color/greyffive"/>
-
-    </LinearLayout>
-
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/greyffive"
-        android:layout_below="@id/layout_spacer"
+        android:layout_below="@id/spacer_view"
         android:paddingBottom="3dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -76,7 +76,7 @@
         android:elevation="1dp"
         android:minHeight="100dp"
         android:orientation="horizontal"
-        android:visibility="visible"
+        android:visibility="gone"
         android:paddingBottom="20dp"
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:fontFamily="@font/font_bold"
-                android:text="x3"
+                android:text=""
                 android:textColor="@color/green"
                 android:textSize="21sp" />
 

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -1,10 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_holding_view"
+    android:orientation="vertical"
+    android:layout_height="wrap_content"
+    android:background="@color/greyffive"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp"
+    android:layout_width="match_parent">
+
+<RelativeLayout
     android:id="@+id/layout_select_ticket"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingStart="6dp"
+    android:paddingEnd="6dp"
+    android:background="@color/white"
     android:minHeight="100dp"
     android:animateLayoutChanges="false">
 
@@ -49,6 +61,7 @@
             <com.alphawallet.app.web3.Web3TokenView
                 android:id="@+id/web3_tokenview"
                 android:layout_width="wrap_content"
+                android:minHeight="200dp"
                 android:layout_height="wrap_content">
 
             </com.alphawallet.app.web3.Web3TokenView>
@@ -59,14 +72,11 @@
         android:id="@+id/layout_legacy"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/background_card_shadow"
+        android:background="@color/white"
         android:elevation="1dp"
-        android:layout_marginBottom="6dp"
-        android:layout_marginLeft="5dp"
-        android:layout_marginRight="5dp"
         android:minHeight="100dp"
         android:orientation="horizontal"
-        android:visibility="gone"
+        android:visibility="visible"
         android:paddingBottom="20dp"
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
@@ -78,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:fontFamily="@font/font_bold"
-                android:text=""
+                android:text="x3"
                 android:textColor="@color/green"
                 android:textSize="21sp" />
 
@@ -110,3 +120,4 @@
     </LinearLayout>
 
 </RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_token.xml
+++ b/app/src/main/res/layout/item_token.xml
@@ -8,7 +8,7 @@
     android:focusable="true"
     android:paddingBottom="3dp"
     android:background="@drawable/background_token_border"
-    android:layout_marginBottom="6dp"
+    android:layout_marginTop="6dp"
     android:layout_marginLeft="1dp"
     android:layout_marginRight="1dp">
 


### PR DESCRIPTION
Small UI tweak that improves and normalises the look of tokens and cards (Tokenscript views).

Previously they appeared slightly differently across the various views as a hangover from the previously hard coded 2018 style tickets.

Now all the margins from the holding views are removed and instead these are in the token / script holding view. Therefore they appear consistent anywhere they're displayed.