### PR TITLE
Fix asset instance race condition

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -3,9 +3,6 @@ package com.alphawallet.app.di;
 import android.content.Context;
 
 import com.alphawallet.app.repository.EthereumNetworkRepository;
-import com.alphawallet.app.service.TickerServiceInterface;
-import com.google.gson.Gson;
-
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.repository.SharedPreferenceRepository;
@@ -23,7 +20,6 @@ import com.alphawallet.app.repository.WalletRepositoryType;
 import com.alphawallet.app.service.AccountKeystoreService;
 import com.alphawallet.app.service.AlphaWalletService;
 import com.alphawallet.app.service.AssetDefinitionService;
-import com.alphawallet.app.service.TickerService;
 import com.alphawallet.app.service.GasService;
 import com.alphawallet.app.service.KeyService;
 import com.alphawallet.app.service.KeystoreAccountService;
@@ -31,9 +27,12 @@ import com.alphawallet.app.service.MarketQueueService;
 import com.alphawallet.app.service.NotificationService;
 import com.alphawallet.app.service.OpenseaService;
 import com.alphawallet.app.service.RealmManager;
+import com.alphawallet.app.service.TickerService;
+import com.alphawallet.app.service.TickerServiceInterface;
 import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.service.TransactionsNetworkClient;
 import com.alphawallet.app.service.TransactionsNetworkClientType;
+import com.google.gson.Gson;
 
 import java.io.File;
 
@@ -147,8 +146,8 @@ public class RepositoriesModule {
 
 	@Singleton
 	@Provides
-	TokensService provideTokensService(EthereumNetworkRepositoryType ethereumNetworkRepository, RealmManager realmManager, OkHttpClient okHttpClient) {
-		return new TokensService(ethereumNetworkRepository, realmManager, okHttpClient);
+	TokensService provideTokensService(EthereumNetworkRepositoryType ethereumNetworkRepository, RealmManager realmManager, OkHttpClient okHttpClient, PreferenceRepositoryType preferenceRepository) {
+		return new TokensService(ethereumNetworkRepository, realmManager, okHttpClient, preferenceRepository);
 	}
 
 	@Singleton

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -3,10 +3,7 @@ package com.alphawallet.app.entity.tokens;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.util.Base64;
 import android.view.View;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.ContractType;
@@ -20,25 +17,17 @@ import com.alphawallet.app.repository.entity.RealmToken;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.ui.widget.holder.TokenHolder;
 import com.alphawallet.app.viewmodel.BaseViewModel;
-import com.alphawallet.app.web3.Web3TokenView;
 import com.alphawallet.token.entity.TicketRange;
-import com.alphawallet.token.entity.TokenScriptResult;
-import com.alphawallet.token.tools.TokenDefinition;
 
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.generated.Uint256;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
-
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
 
 public class ERC721Ticket extends Token implements Parcelable {
 
@@ -181,45 +170,6 @@ public class ERC721Ticket extends Token implements Parcelable {
         tokenHolder.balanceEth.setText(composite);
 
         tokenHolder.layoutValueDetails.setVisibility(View.GONE);
-    }
-
-    /*************************************
-     *
-     * Conversion functions used for manipulating indices
-     *
-     */
-
-    /**
-     * This is a single method that populates any instance of graphic ticket anywhere
-     *
-     * @param range
-     * @param activity
-     * @param assetService
-     * @param ctx needed to create date/time format objects
-     */
-    @Override
-    public void displayTicketHolder(TicketRange range, View activity, AssetDefinitionService assetService, Context ctx, boolean iconified)
-    {
-        TokenDefinition td = assetService.getAssetDefinition(tokenInfo.chainId, tokenInfo.address);
-        if (td != null)
-        {
-            //use webview
-            displayTokenscriptView(range, assetService, activity, ctx, iconified);
-        }
-        else
-        {
-            activity.findViewById(R.id.layout_legacy).setVisibility(View.VISIBLE);
-            activity.findViewById(R.id.layout_webwrapper).setVisibility(View.GONE);
-
-            TextView amount = activity.findViewById(R.id.amount);
-            TextView name = activity.findViewById(R.id.name);
-
-            String nameStr = getTokenTitle();
-            String seatCount = String.format(Locale.getDefault(), "x%d", range.tokenIds.size());
-
-            name.setText(nameStr);
-            amount.setText(seatCount);
-        }
     }
 
     public void checkIsMatchedInXML(AssetDefinitionService assetService)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -3,13 +3,9 @@ package com.alphawallet.app.entity.tokens;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.util.Base64;
-import android.util.Log;
 import android.view.View;
-import android.widget.LinearLayout;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
+import com.alphawallet.app.R;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.ERC875ContractTransaction;
 import com.alphawallet.app.entity.TicketRangeElement;
@@ -17,10 +13,9 @@ import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionOperation;
 import com.alphawallet.app.repository.entity.RealmToken;
 import com.alphawallet.app.service.AssetDefinitionService;
-import com.alphawallet.app.ui.BaseActivity;
 import com.alphawallet.app.ui.widget.holder.TokenHolder;
 import com.alphawallet.app.viewmodel.BaseViewModel;
-import com.alphawallet.app.web3.Web3TokenView;
+import com.alphawallet.token.entity.TicketRange;
 
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.Function;
@@ -28,20 +23,11 @@ import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
-
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
-import com.alphawallet.token.entity.TicketRange;
-import com.alphawallet.token.entity.TokenScriptResult;
-import com.alphawallet.token.tools.TokenDefinition;
-import com.alphawallet.app.R;
 
 /**
  * Created by James on 27/01/2018.  It might seem counter intuitive
@@ -307,44 +293,6 @@ public class Ticket extends Token implements Parcelable
         }
 
         return indexList;
-    }
-
-    public void displayTicketHolder(TicketRange range, View activity, AssetDefinitionService assetService, Context ctx)
-    {
-        displayTicketHolder(range, activity, assetService, ctx, false);
-    }
-
-    /**
-     * This is a single method that populates any instance of graphic ticket anywhere
-     *
-     * @param range
-     * @param activity
-     * @param assetService
-     * @param ctx needed to create date/time format objects
-     */
-    @Override
-    public void displayTicketHolder(TicketRange range, View activity, AssetDefinitionService assetService, Context ctx, boolean iconified)
-    {
-        TokenDefinition td = assetService.getAssetDefinition(tokenInfo.chainId, tokenInfo.address);
-        if (td != null)
-        {
-            //use webview
-            displayTokenscriptView(range, assetService, activity, ctx, iconified);
-        }
-        else
-        {
-            activity.findViewById(R.id.layout_legacy).setVisibility(View.VISIBLE);
-            activity.findViewById(R.id.layout_webwrapper).setVisibility(View.GONE);
-
-            TextView amount = activity.findViewById(R.id.amount);
-            TextView name = activity.findViewById(R.id.name);
-
-            String nameStr = getTokenTitle();
-            String seatCount = String.format(Locale.getDefault(), "x%d", range.tokenIds.size());
-
-            name.setText(nameStr);
-            amount.setText(seatCount);
-        }
     }
 
     public void checkIsMatchedInXML(AssetDefinitionService assetService)

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -137,7 +137,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     {
         try
         {
-            assetLoadingLock.acquire();
+            assetLoadingLock.acquire(); // wonder when is this released? Read comments 9 lines down
         }
         catch (InterruptedException e)
         {
@@ -146,6 +146,14 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
         assetDefinitions = new SparseArray<>();
 
+        /* the following Observable<File> has a subscription with loadInternalAssets() at completion or error
+           which in turn has checkAndroidExternal() at completion or error
+           which in turn has checkLegacyDirectory() at completion or error
+           which in turn has finishLoading() at completion or error
+           which releases the Semaphore.
+           One might argue that getting a full list of files to check and do away with only one subscription
+           might not be bad.   -- Weiwu, code review.
+         */
         loadContracts(context.getFilesDir())
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -7,7 +7,9 @@ import com.alphawallet.app.entity.ContractResult;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenTicker;
+import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
+import com.alphawallet.app.repository.PreferenceRepositoryType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +32,10 @@ public class TokensService
     private final OkHttpClient okHttpClient;
     private int currencyCheckCount;
 
-    public TokensService(EthereumNetworkRepositoryType ethereumNetworkRepository, RealmManager realmManager, OkHttpClient client) {
+    public TokensService(EthereumNetworkRepositoryType ethereumNetworkRepository,
+                         RealmManager realmManager,
+                         OkHttpClient client,
+                         PreferenceRepositoryType preferenceRepository) {
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.realmManager = realmManager;
         loaded = false;
@@ -39,6 +44,7 @@ public class TokensService
         focusToken = null;
         okHttpClient = client;
         currencyCheckCount = 0;
+        setCurrentAddress(preferenceRepository.getCurrentWalletAddress()); //set current wallet address at service startup
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -223,8 +223,6 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             showPage(WALLET);
         }
 
-        viewModel.loadExternalXMLContracts();
-
         if (VisibilityFilter.hideDappBrowser())
         {
             removeDappBrowser();
@@ -768,7 +766,6 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             case RC_DOWNLOAD_EXTERNAL_WRITE_PERM:
                 if (hasPermission(permissions, grantResults))
                 {
-                    viewModel.loadExternalXMLContracts();
                     ((NewSettingsFragment)settingsFragment).refresh();
                 }
                 break;

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -174,10 +174,6 @@ public class HomeViewModel extends BaseViewModel {
         LocaleUtils.setLocale(activity, currentLocale);
     }
 
-    public void loadExternalXMLContracts() {
-        assetDefinitionService.checkExternalDirectoryAndLoad();
-    }
-
     public void downloadAndInstall(String build, Context ctx) {
         createDirectory();
         downloadAPK(build, ctx);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/ImportTokenViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/ImportTokenViewModel.java
@@ -697,7 +697,7 @@ public class ImportTokenViewModel extends BaseViewModel
 
     public void checkTokenScriptSignature(final int chainId, final String address)
     {
-        disposable = assetDefinitionService.getAssetdefinitionASync(chainId, address)
+        disposable = assetDefinitionService.getAssetDefinitionASync(chainId, address)
                 .flatMap(def -> assetDefinitionService.getSignatureData(chainId, address))
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())


### PR DESCRIPTION
Fixes a race condition only seen when restarting the app while a Token Card is visible.

After the wallet's local memory is reclaimed by the OS and the wallet is restarted the asset service re-loads the scripts.

At the same time if the wallet was viewing a token card, the view will check if the token has an asset.

This PR introduces a semaphore to ensure the token card query holds until loading is complete.

A subsequent PR will store the token -> contract mappings into a database for rapid reload.