### PR TITLE
Fixes  #1236

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -949,4 +949,17 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         sendBroadcast(new Intent(CHANGED_LOCALE));
         viewModel.updateLocale(newLocale, this);
     }
+
+    @Override
+    public void onBackPressed() {
+        //Check if current page is WALLET or not
+        if(viewPager.getCurrentItem() != WALLET)
+        {
+            showPage(WALLET);
+        }
+        else
+        {
+            super.onBackPressed();
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1236

- Check for current showing item on bottom navigation
- Once user press back button if not in WALLET page, it will navigate to WALLET fragment else close the app