### PR TITLE
Add Action local attributes

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -1089,7 +1089,7 @@ public class Token implements Parcelable, Comparable<Token>
 
         final StringBuilder attrs = assetService.getTokenAttrs(this, tokenId, range.tokenIds.size());
 
-        assetService.resolveAttrs(this, tokenId)
+        assetService.resolveAttrs(this, tokenId, null) //Can a view have local attributes?
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(attr -> onAttr(attr, attrs), throwable -> onError(throwable, ctx, assetService, attrs,

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -160,11 +160,16 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
             e.printStackTrace();
         }
 
-        viewModel.getAssetDefinitionService().resolveAttrs(token, tokenIds)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::onAttr, this::onError, () -> displayFunction(attrs.toString()))
-                .isDisposed();
+        // Fetch attributes local to this action and add them to the injected token properties
+        Map<String, TSAction> functions = viewModel.getAssetDefinitionService().getTokenFunctionMap(token.tokenInfo.chainId, token.getAddress());
+        TSAction action = functions.get(actionMethod);
+        List<AttributeType> localAttrs = (action != null && action.attributeTypes != null) ? new ArrayList<>(action.attributeTypes.values()) : null;
+
+        viewModel.getAssetDefinitionService().resolveAttrs(token, tokenIds, localAttrs)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(this::onAttr, this::onError, () -> displayFunction(attrs.toString()))
+                    .isDisposed();
     }
 
     private void addMultipleTokenIds(StringBuilder sb)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenscriptViewHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenscriptViewHolder.java
@@ -121,7 +121,7 @@ public class TokenscriptViewHolder extends BinderViewHolder<TicketRange> impleme
     {
         tokenId = data.tokenIds.get(0);
         attrs = assetDefinitionService.getTokenAttrs(token, tokenId, data.tokenIds.size());
-        assetDefinitionService.resolveAttrs(token, tokenId)
+        assetDefinitionService.resolveAttrs(token, tokenId, null) // Can a view have local attributes?
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onAttr, this::onError, () -> displayTicket(attrs.toString(), data))

--- a/dmz/src/main/java/com/alphawallet/token/web/Ethereum/TokenscriptFunction.java
+++ b/dmz/src/main/java/com/alphawallet/token/web/Ethereum/TokenscriptFunction.java
@@ -651,14 +651,13 @@ public abstract class TokenscriptFunction
     {
         if (definition != null && definition.attributeTypes.containsKey(arg.element.ref))
         {
-            arg.element.value = fetchAttrResult(walletAddress, arg.element.ref, tokenId, null, definition, attrIf).blockingSingle().text;
+            arg.element.value = fetchAttrResult(walletAddress, definition.attributeTypes.get(arg.element.ref), tokenId, null, definition, attrIf).blockingSingle().text;
         }
     }
 
 
-    public Observable<TokenScriptResult.Attribute> fetchAttrResult(String walletAddress, String attribute, BigInteger tokenId, ContractAddress cAddr, TokenDefinition td, AttributeInterface attrIf)
+    public Observable<TokenScriptResult.Attribute> fetchAttrResult(String walletAddress, AttributeType attr, BigInteger tokenId, ContractAddress cAddr, TokenDefinition td, AttributeInterface attrIf)
     {
-        AttributeType attr = td.attributeTypes.get(attribute);
         if (attr == null) return Observable.fromCallable(() -> null);
         if (attr.function == null)  // static attribute from tokenId (eg city mapping from tokenId)
         {
@@ -692,7 +691,7 @@ public abstract class TokenscriptFunction
         td.context.attrInterface = attrIf;
 
         return Observable.fromIterable(new ArrayList<>(td.attributeTypes.values()))
-                .flatMap(attr -> fetchAttrResult(walletAddress, attr.id, tokenId, cAddr, td, attrIf));
+                .flatMap(attr -> fetchAttrResult(walletAddress, attr, tokenId, cAddr, td, attrIf));
     }
 
     private Observable<TokenScriptResult.Attribute> staticAttribute(AttributeType attr, BigInteger tokenId)

--- a/util/src/main/java/com/alphawallet/scripttool/Entity/TokenscriptFunction.java
+++ b/util/src/main/java/com/alphawallet/scripttool/Entity/TokenscriptFunction.java
@@ -652,14 +652,12 @@ public abstract class TokenscriptFunction
     {
         if (definition != null && definition.attributeTypes.containsKey(arg.element.ref))
         {
-            arg.element.value = fetchAttrResult(walletAddress, arg.element.ref, tokenId, null, definition, attrIf).blockingSingle().text;
+            arg.element.value = fetchAttrResult(walletAddress, definition.attributeTypes.get(arg.element.ref), tokenId, null, definition, attrIf).blockingSingle().text;
         }
     }
 
-
-    public Observable<TokenScriptResult.Attribute> fetchAttrResult(String walletAddress, String attribute, BigInteger tokenId, ContractAddress cAddr, TokenDefinition td, AttributeInterface attrIf)
+    public Observable<TokenScriptResult.Attribute> fetchAttrResult(String walletAddress, AttributeType attr, BigInteger tokenId, ContractAddress cAddr, TokenDefinition td, AttributeInterface attrIf)
     {
-        AttributeType attr = td.attributeTypes.get(attribute);
         if (attr == null) return Observable.fromCallable(() -> null);
         if (attr.function == null)  // static attribute from tokenId (eg city mapping from tokenId)
         {
@@ -693,7 +691,7 @@ public abstract class TokenscriptFunction
         td.context.attrInterface = attrIf;
 
         return Observable.fromIterable(new ArrayList<>(td.attributeTypes.values()))
-                .flatMap(attr -> fetchAttrResult(walletAddress, attr.id, tokenId, cAddr, td, attrIf));
+                .flatMap(attr -> fetchAttrResult(walletAddress, attr, tokenId, cAddr, td, attrIf));
     }
 
     private Observable<TokenScriptResult.Attribute> staticAttribute(AttributeType attr, BigInteger tokenId)


### PR DESCRIPTION
Adds the local attributes for an ```<action>``` into the injected token properties.

Allows code like this to work (taken from ENS script):

```
<ts:action>
      <ts:name>
        <ts:string xml:lang="en">Renew</ts:string>
      </ts:name>

      <ts:attribute-type id="renewalPricePerYear" syntax="1.3.6.1.4.1.1466.115.121.1.36">
        <ts:name>
          <ts:string xml:lang="en">renewal price per year</ts:string>
        </ts:name>
        <ts:origins>
          <ts:ethereum function="rentPrice" contract="ETHRegistrarController" as="uint">
            <ts:data>
              <ts:string ref="ensName"/>
              <ts:uint256>31540000</ts:uint256>
            </ts:data>
          </ts:ethereum>
        </ts:origins>
      </ts:attribute-type>
```
...
```
<h3>Price of one year renewal: ${(this.props.renewalPricePerYear / 1e+18).toFixed(3)} ETH</h3>
```

The renewalPricePerYear attribute is only injected into the 'renew' action card view, not into any other actions or views.