### PR TITLE
Add Event Listener and cache event results.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/ActionEventCallback.java
+++ b/app/src/main/java/com/alphawallet/app/entity/ActionEventCallback.java
@@ -1,0 +1,12 @@
+package com.alphawallet.app.entity;
+
+import io.reactivex.Single;
+
+/**
+ * Created by JB on 26/03/2020.
+ */
+public interface ActionEventCallback
+{
+    void receivedEvent(String selectedParamName, String selectedParamValue, long timeStamp, int chainId);
+    void eventsLoaded(Event[] events);
+}

--- a/app/src/main/java/com/alphawallet/app/entity/Event.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Event.java
@@ -1,0 +1,67 @@
+package com.alphawallet.app.entity;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Created by JB on 26/03/2020.
+ */
+public class Event implements Parcelable
+{
+    private final String eventText;
+    private final long timeStamp;
+    private final int chainId;
+
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
+
+    public Event(String eventTxt, long timeStamp, int chainId)
+    {
+        this.eventText = eventTxt;
+        this.timeStamp = timeStamp;
+        this.chainId = chainId;
+    }
+
+    protected Event(Parcel in)
+    {
+        eventText = in.readString();
+        timeStamp = in.readLong();
+        chainId = in.readInt();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
+        dest.writeString(eventText);
+        dest.writeLong(timeStamp);
+        dest.writeInt(chainId);
+    }
+
+    public static final Creator<Transaction> CREATOR = new Creator<Transaction>()
+    {
+        @Override
+        public Transaction createFromParcel(Parcel in) {
+            return new Transaction(in);
+        }
+
+        @Override
+        public Transaction[] newArray(int size) {
+            return new Transaction[size];
+        }
+    };
+
+    public String getEventText()
+    {
+        return eventText;
+    }
+    public long getTimeStamp() { return timeStamp; }
+    public String getHash()
+    {
+        String hash = eventText + "-" + timeStamp;
+        return String.valueOf(hash.hashCode());
+    }
+    public int getChainId() { return chainId; }
+}

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -316,6 +316,8 @@ public class ERC721Ticket extends Token implements Parcelable {
 
     @Override
     public boolean isERC721Ticket() { return true; }
+    @Override
+    public boolean isNonFungible() { return true; }
 
     @Override
     public boolean groupWithToken(TicketRange currentGroupingRange, TicketRangeElement newElement, long currentGroupTime)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -61,7 +61,6 @@ public class Token implements Parcelable, Comparable<Token>
     public boolean balanceChanged;
     public boolean walletUIUpdateRequired;
     public boolean hasTokenScript;
-    public boolean hasDebugTokenscript;
     public boolean refreshCheck;
     public long lastTxCheck;
     public long lastTxUpdate;
@@ -108,7 +107,6 @@ public class Token implements Parcelable, Comparable<Token>
             lastTxUpdate = oldToken.lastTxUpdate;
             balanceChanged = oldToken.balanceChanged;
             hasTokenScript = oldToken.hasTokenScript;
-            hasDebugTokenscript = oldToken.hasDebugTokenscript;
             lastTxTime = oldToken.lastTxTime;
         }
         refreshCheck = false;
@@ -127,7 +125,6 @@ public class Token implements Parcelable, Comparable<Token>
         lastTxUpdate = in.readLong();
         lastTxTime = in.readLong();
         hasTokenScript = in.readByte() == 1;
-        hasDebugTokenscript = in.readByte() == 1;
         nonIconifiedWebviewHeight = in.readInt();
         iconifiedWebviewHeight = in.readInt();
         nameWeight = in.readInt();
@@ -161,6 +158,23 @@ public class Token implements Parcelable, Comparable<Token>
 
     public Asset getAssetForToken(String tokenId) {
         return null;
+    }
+    public List<BigInteger> getUniqueTokenIds()
+    {
+        List<BigInteger> uniqueIds = new ArrayList<>();
+        if (isNonFungible())
+        {
+            for (BigInteger id : getArrayBalance())
+            {
+                if (!uniqueIds.contains(id)) uniqueIds.add(id);
+            }
+        }
+        else
+        {
+            uniqueIds.add(BigInteger.ZERO);
+        }
+
+        return uniqueIds;
     }
 
     public void addAssetToTokenBalanceAssets(Asset asset) {
@@ -198,7 +212,6 @@ public class Token implements Parcelable, Comparable<Token>
         dest.writeLong(lastTxUpdate);
         dest.writeLong(lastTxTime);
         dest.writeByte(hasTokenScript?(byte)1:(byte)0);
-        dest.writeByte(hasDebugTokenscript?(byte)1:(byte)0);
         dest.writeInt(nonIconifiedWebviewHeight);
         dest.writeInt(iconifiedWebviewHeight);
         dest.writeInt(nameWeight);

--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/EventUtils.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/EventUtils.java
@@ -1,0 +1,661 @@
+package com.alphawallet.app.entity.tokenscript;
+
+import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.token.entity.EventDefinition;
+import com.alphawallet.token.entity.Module;
+
+import org.web3j.abi.EventEncoder;
+import org.web3j.abi.EventValues;
+import org.web3j.abi.TypeEncoder;
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.BytesType;
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.Int;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.Uint;
+import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.generated.Bytes1;
+import org.web3j.abi.datatypes.generated.Bytes10;
+import org.web3j.abi.datatypes.generated.Bytes11;
+import org.web3j.abi.datatypes.generated.Bytes12;
+import org.web3j.abi.datatypes.generated.Bytes13;
+import org.web3j.abi.datatypes.generated.Bytes14;
+import org.web3j.abi.datatypes.generated.Bytes15;
+import org.web3j.abi.datatypes.generated.Bytes16;
+import org.web3j.abi.datatypes.generated.Bytes17;
+import org.web3j.abi.datatypes.generated.Bytes18;
+import org.web3j.abi.datatypes.generated.Bytes19;
+import org.web3j.abi.datatypes.generated.Bytes2;
+import org.web3j.abi.datatypes.generated.Bytes20;
+import org.web3j.abi.datatypes.generated.Bytes21;
+import org.web3j.abi.datatypes.generated.Bytes22;
+import org.web3j.abi.datatypes.generated.Bytes23;
+import org.web3j.abi.datatypes.generated.Bytes24;
+import org.web3j.abi.datatypes.generated.Bytes25;
+import org.web3j.abi.datatypes.generated.Bytes26;
+import org.web3j.abi.datatypes.generated.Bytes27;
+import org.web3j.abi.datatypes.generated.Bytes28;
+import org.web3j.abi.datatypes.generated.Bytes29;
+import org.web3j.abi.datatypes.generated.Bytes3;
+import org.web3j.abi.datatypes.generated.Bytes30;
+import org.web3j.abi.datatypes.generated.Bytes31;
+import org.web3j.abi.datatypes.generated.Bytes32;
+import org.web3j.abi.datatypes.generated.Bytes4;
+import org.web3j.abi.datatypes.generated.Bytes5;
+import org.web3j.abi.datatypes.generated.Bytes6;
+import org.web3j.abi.datatypes.generated.Bytes7;
+import org.web3j.abi.datatypes.generated.Bytes8;
+import org.web3j.abi.datatypes.generated.Bytes9;
+import org.web3j.abi.datatypes.generated.Int104;
+import org.web3j.abi.datatypes.generated.Int112;
+import org.web3j.abi.datatypes.generated.Int120;
+import org.web3j.abi.datatypes.generated.Int128;
+import org.web3j.abi.datatypes.generated.Int136;
+import org.web3j.abi.datatypes.generated.Int144;
+import org.web3j.abi.datatypes.generated.Int152;
+import org.web3j.abi.datatypes.generated.Int16;
+import org.web3j.abi.datatypes.generated.Int160;
+import org.web3j.abi.datatypes.generated.Int168;
+import org.web3j.abi.datatypes.generated.Int176;
+import org.web3j.abi.datatypes.generated.Int184;
+import org.web3j.abi.datatypes.generated.Int192;
+import org.web3j.abi.datatypes.generated.Int200;
+import org.web3j.abi.datatypes.generated.Int208;
+import org.web3j.abi.datatypes.generated.Int216;
+import org.web3j.abi.datatypes.generated.Int224;
+import org.web3j.abi.datatypes.generated.Int232;
+import org.web3j.abi.datatypes.generated.Int24;
+import org.web3j.abi.datatypes.generated.Int240;
+import org.web3j.abi.datatypes.generated.Int248;
+import org.web3j.abi.datatypes.generated.Int256;
+import org.web3j.abi.datatypes.generated.Int32;
+import org.web3j.abi.datatypes.generated.Int40;
+import org.web3j.abi.datatypes.generated.Int48;
+import org.web3j.abi.datatypes.generated.Int56;
+import org.web3j.abi.datatypes.generated.Int64;
+import org.web3j.abi.datatypes.generated.Int72;
+import org.web3j.abi.datatypes.generated.Int8;
+import org.web3j.abi.datatypes.generated.Int80;
+import org.web3j.abi.datatypes.generated.Int88;
+import org.web3j.abi.datatypes.generated.Int96;
+import org.web3j.abi.datatypes.generated.Uint104;
+import org.web3j.abi.datatypes.generated.Uint112;
+import org.web3j.abi.datatypes.generated.Uint120;
+import org.web3j.abi.datatypes.generated.Uint128;
+import org.web3j.abi.datatypes.generated.Uint136;
+import org.web3j.abi.datatypes.generated.Uint144;
+import org.web3j.abi.datatypes.generated.Uint152;
+import org.web3j.abi.datatypes.generated.Uint16;
+import org.web3j.abi.datatypes.generated.Uint160;
+import org.web3j.abi.datatypes.generated.Uint168;
+import org.web3j.abi.datatypes.generated.Uint176;
+import org.web3j.abi.datatypes.generated.Uint184;
+import org.web3j.abi.datatypes.generated.Uint192;
+import org.web3j.abi.datatypes.generated.Uint200;
+import org.web3j.abi.datatypes.generated.Uint208;
+import org.web3j.abi.datatypes.generated.Uint216;
+import org.web3j.abi.datatypes.generated.Uint224;
+import org.web3j.abi.datatypes.generated.Uint232;
+import org.web3j.abi.datatypes.generated.Uint24;
+import org.web3j.abi.datatypes.generated.Uint240;
+import org.web3j.abi.datatypes.generated.Uint248;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.abi.datatypes.generated.Uint32;
+import org.web3j.abi.datatypes.generated.Uint40;
+import org.web3j.abi.datatypes.generated.Uint48;
+import org.web3j.abi.datatypes.generated.Uint56;
+import org.web3j.abi.datatypes.generated.Uint64;
+import org.web3j.abi.datatypes.generated.Uint72;
+import org.web3j.abi.datatypes.generated.Uint8;
+import org.web3j.abi.datatypes.generated.Uint80;
+import org.web3j.abi.datatypes.generated.Uint88;
+import org.web3j.abi.datatypes.generated.Uint96;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.utils.Numeric;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.Single;
+
+import static org.web3j.tx.Contract.staticExtractEventParameters;
+
+/**
+ * Created by JB on 23/03/2020.
+ *
+ * Class to contain event filter creation functions
+ *
+ * This class would be better placed entirely in the common library. However because the app uses web3j-Android and DMZ uses web3j
+ * the function signatures are incompatible.
+ *
+ * The cleanest solution is to link the main web3j into the library. Web3j-Android and web3j currently have
+ * incompatibilities. Web3j labs would like to eliminate Web3j-Android, which would clear things up very well
+ * but this can only be done after we drop API23, even then it may not be possible immediately.
+ *
+ * Recommend: see if web3j base is compatible with Android API24+. If so, phase out API23 by warning users support will discontinue,
+ * then do refactor and move these functions into the EventDefinition class in the library.
+ *
+ */
+public abstract class EventUtils
+{
+    public EthFilter generateLogFilter(EventDefinition ev, Token originToken)
+    {
+        String eventContractAddr = ev.eventModule.contractInfo.addresses.get(originToken.tokenInfo.chainId).get(0);
+        final Event resolverEvent = generateEventFunction(ev);
+        //work out which topics to filter on
+        String filterTopic = ev.getFilterTopicIndex();
+        String filterTopicValue = ev.getFilterTopicValue();
+
+        //find the topic index - at this stage we only handle single topics
+        int topicIndex = ev.getTopicIndex(filterTopic);
+
+        //isolate which indexed param it is
+        List<String> indexedParams = ev.eventModule.getArgNames(true);
+
+        DefaultBlockParameter startBlock = DefaultBlockParameterName.EARLIEST;
+
+        if (ev.readBlock != null && ev.readBlock.compareTo(BigInteger.ZERO) > 0)
+        {
+            startBlock = DefaultBlockParameter.valueOf(ev.readBlock);
+        }
+
+        final org.web3j.protocol.core.methods.request.EthFilter filter =
+                new org.web3j.protocol.core.methods.request.EthFilter(
+                        startBlock,
+                        DefaultBlockParameterName.LATEST,
+                        eventContractAddr)                            // contract address
+                        .addSingleTopic(EventEncoder.encode(resolverEvent)); // event name
+
+        for (int i = 0; i < indexedParams.size(); i++)
+        {
+            if (i == topicIndex)
+            {
+                addTopicFilter(filter, filterTopicValue, originToken); //add the required log filter - allowing for multiple tokenIds
+                break;
+            }
+            else
+            {
+                filter.addSingleTopic(null);
+            }
+        }
+
+        return filter;
+    }
+
+    public String getSelectVal(EventDefinition ev, EthLog.LogResult ethLog)
+    {
+        String selectVal = "";
+        final Event resolverEvent = generateEventFunction(ev);
+        final EventValues eventValues = staticExtractEventParameters(resolverEvent, (Log)ethLog.get());
+        int selectIndexInNonIndexed = ev.getSelectIndex(false);
+        int selectIndexInIndexed = ev.getSelectIndex(true);
+
+        if (selectIndexInNonIndexed >= 0)
+        {
+            selectVal = getValueFromParams(eventValues.getNonIndexedValues(), selectIndexInNonIndexed);
+        }
+        else if (selectIndexInIndexed >= 0)
+        {
+            selectVal = getValueFromParams(eventValues.getIndexedValues(), selectIndexInIndexed);
+        }
+
+        Log log = (Log)ethLog;
+        ev.readBlock = log.getBlockNumber().add(BigInteger.ONE);
+
+        return selectVal;
+    }
+
+    public String getTopicVal(EventDefinition ev, EthLog.LogResult ethLog)
+    {
+        String topicVal = "";
+        final Event resolverEvent = generateEventFunction(ev);
+        final EventValues eventValues = staticExtractEventParameters(resolverEvent, (Log)ethLog.get());
+        String filterTopic = ev.getFilterTopicIndex();
+        int topicIndex = ev.getTopicIndex(filterTopic);
+
+        topicVal = getValueFromParams(eventValues.getIndexedValues(), topicIndex);
+
+        return topicVal;
+    }
+
+    public Single<EthBlock> getTransactionDetails(String blockHash, Web3j web3j)
+    {
+        return Single.fromCallable(() -> {
+            EthBlock txResult;
+            try
+            {
+                txResult = web3j.ethGetBlockByHash(blockHash.trim(), false).send();
+                System.out.println(txResult.getResult());
+            }
+            catch (IOException | NullPointerException e)
+            {
+                e.printStackTrace();
+                txResult = new EthBlock();
+            }
+
+            return txResult;
+        });
+    }
+
+    private String getValueFromParams(List<Type> responseParams, int selectIndex)
+    {
+        Type t = responseParams.get(selectIndex);
+        String typeName = t.getTypeAsString();
+        //strip numbers
+        int i = typeName.length() - 1;
+        while (Character.isDigit(typeName.charAt(i))) { i--; }; //strip
+        typeName = typeName.substring(0, i+1);
+        byte[] val;
+
+        String selectVal;
+
+        // Note this param gets interpreted according to the script 'syntax'
+        // by the attribute value conversion function getSyntaxVal(String ...) in class AttributeType
+        switch (typeName.toLowerCase())
+        {
+            case "string":
+            case "address":
+            case "uint":
+            case "int":
+            case "bool":
+            case "fixed":
+                selectVal = t.getValue().toString();
+                break;
+            case "bytes":
+                val = (byte[])(t.getValue());
+                selectVal = Numeric.toHexString(val);
+                break;
+
+            default:
+                selectVal = "Unexpected type: " + t.getTypeAsString();
+                break;
+        }
+
+        return selectVal;
+    }
+
+    /**
+     * This function generates an input definition given an arg sequence, including if the arg is indexed
+     * Could be used to generate any input function spec to pass to Web3j
+     * @param args
+     * @return
+     */
+    private static List<TypeReference<?>> generateFunctionDefinition(List<Module.SequenceElement> args)
+    {
+        List<TypeReference<?>> paramList = new ArrayList<>();
+        for (Module.SequenceElement element : args)
+        {
+            switch (element.type)
+            {
+                case "int":
+                    paramList.add(new TypeReference<Int>(element.indexed) { });
+                    break;
+                case "int8":
+                    paramList.add(new TypeReference<Int8>(element.indexed) { });
+                    break;
+                case "int16":
+                    paramList.add(new TypeReference<Int16>(element.indexed) { });
+                    break;
+                case "int24":
+                    paramList.add(new TypeReference<Int24>(element.indexed) { });
+                    break;
+                case "int32":
+                    paramList.add(new TypeReference<Int32>(element.indexed) { });
+                    break;
+                case "int40":
+                    paramList.add(new TypeReference<Int40>(element.indexed) { });
+                    break;
+                case "int48":
+                    paramList.add(new TypeReference<Int48>(element.indexed) { });
+                    break;
+                case "int56":
+                    paramList.add(new TypeReference<Int56>(element.indexed) { });
+                    break;
+                case "int64":
+                    paramList.add(new TypeReference<Int64>(element.indexed) { });
+                    break;
+                case "int72":
+                    paramList.add(new TypeReference<Int72>(element.indexed) { });
+                    break;
+                case "int80":
+                    paramList.add(new TypeReference<Int80>(element.indexed) { });
+                    break;
+                case "int88":
+                    paramList.add(new TypeReference<Int88>(element.indexed) { });
+                    break;
+                case "int96":
+                    paramList.add(new TypeReference<Int96>(element.indexed) { });
+                    break;
+                case "int104":
+                    paramList.add(new TypeReference<Int104>(element.indexed) { });
+                    break;
+                case "int112":
+                    paramList.add(new TypeReference<Int112>(element.indexed) { });
+                    break;
+                case "int120":
+                    paramList.add(new TypeReference<Int120>(element.indexed) { });
+                    break;
+                case "int128":
+                    paramList.add(new TypeReference<Int128>(element.indexed) { });
+                    break;
+                case "int136":
+                    paramList.add(new TypeReference<Int136>(element.indexed) { });
+                    break;
+                case "int144":
+                    paramList.add(new TypeReference<Int144>(element.indexed) { });
+                    break;
+                case "int152":
+                    paramList.add(new TypeReference<Int152>(element.indexed) { });
+                    break;
+                case "int160":
+                    paramList.add(new TypeReference<Int160>(element.indexed) { });
+                    break;
+                case "int168":
+                    paramList.add(new TypeReference<Int168>(element.indexed) { });
+                    break;
+                case "int176":
+                    paramList.add(new TypeReference<Int176>(element.indexed) { });
+                    break;
+                case "int184":
+                    paramList.add(new TypeReference<Int184>(element.indexed) { });
+                    break;
+                case "int192":
+                    paramList.add(new TypeReference<Int192>(element.indexed) { });
+                    break;
+                case "int200":
+                    paramList.add(new TypeReference<Int200>(element.indexed) { });
+                    break;
+                case "int208":
+                    paramList.add(new TypeReference<Int208>(element.indexed) { });
+                    break;
+                case "int216":
+                    paramList.add(new TypeReference<Int216>(element.indexed) { });
+                    break;
+                case "int224":
+                    paramList.add(new TypeReference<Int224>(element.indexed) { });
+                    break;
+                case "int232":
+                    paramList.add(new TypeReference<Int232>(element.indexed) { });
+                    break;
+                case "int240":
+                    paramList.add(new TypeReference<Int240>(element.indexed) { });
+                    break;
+                case "int248":
+                    paramList.add(new TypeReference<Int248>(element.indexed) { });
+                    break;
+                case "int256":
+                    paramList.add(new TypeReference<Int256>(element.indexed) { });
+                    break;
+                case "uint":
+                    paramList.add(new TypeReference<Uint>(element.indexed) { });
+                    break;
+
+                case "uint8":
+                    paramList.add(new TypeReference<Uint8>(element.indexed) { });
+                    break;
+                case "uint16":
+                    paramList.add(new TypeReference<Uint16>(element.indexed) { });
+                    break;
+                case "uint24":
+                    paramList.add(new TypeReference<Uint24>(element.indexed) { });
+                    break;
+                case "uint32":
+                    paramList.add(new TypeReference<Uint32>(element.indexed) { });
+                    break;
+                case "uint40":
+                    paramList.add(new TypeReference<Uint40>(element.indexed) { });
+                    break;
+                case "uint48":
+                    paramList.add(new TypeReference<Uint48>(element.indexed) { });
+                    break;
+                case "uint56":
+                    paramList.add(new TypeReference<Uint56>(element.indexed) { });
+                    break;
+                case "uint64":
+                    paramList.add(new TypeReference<Uint64>(element.indexed) { });
+                    break;
+                case "uint72":
+                    paramList.add(new TypeReference<Uint72>(element.indexed) { });
+                    break;
+                case "uint80":
+                    paramList.add(new TypeReference<Uint80>(element.indexed) { });
+                    break;
+                case "uint88":
+                    paramList.add(new TypeReference<Uint88>(element.indexed) { });
+                    break;
+                case "uint96":
+                    paramList.add(new TypeReference<Uint96>(element.indexed) { });
+                    break;
+                case "uint104":
+                    paramList.add(new TypeReference<Uint104>(element.indexed) { });
+                    break;
+                case "uint112":
+                    paramList.add(new TypeReference<Uint112>(element.indexed) { });
+                    break;
+                case "uint120":
+                    paramList.add(new TypeReference<Uint120>(element.indexed) { });
+                    break;
+                case "uint128":
+                    paramList.add(new TypeReference<Uint128>(element.indexed) { });
+                    break;
+                case "uint136":
+                    paramList.add(new TypeReference<Uint136>(element.indexed) { });
+                    break;
+                case "uint144":
+                    paramList.add(new TypeReference<Uint144>(element.indexed) { });
+                    break;
+                case "uint152":
+                    paramList.add(new TypeReference<Uint152>(element.indexed) { });
+                    break;
+                case "uint160":
+                    paramList.add(new TypeReference<Uint160>(element.indexed) { });
+                    break;
+                case "uint168":
+                    paramList.add(new TypeReference<Uint168>(element.indexed) { });
+                    break;
+                case "uint176":
+                    paramList.add(new TypeReference<Uint176>(element.indexed) { });
+                    break;
+                case "uint184":
+                    paramList.add(new TypeReference<Uint184>(element.indexed) { });
+                    break;
+                case "uint192":
+                    paramList.add(new TypeReference<Uint192>(element.indexed) { });
+                    break;
+                case "uint200":
+                    paramList.add(new TypeReference<Uint200>(element.indexed) { });
+                    break;
+                case "uint208":
+                    paramList.add(new TypeReference<Uint208>(element.indexed) { });
+                    break;
+                case "uint216":
+                    paramList.add(new TypeReference<Uint216>(element.indexed) { });
+                    break;
+                case "uint224":
+                    paramList.add(new TypeReference<Uint224>(element.indexed) { });
+                    break;
+                case "uint232":
+                    paramList.add(new TypeReference<Uint232>(element.indexed) { });
+                    break;
+                case "uint240":
+                    paramList.add(new TypeReference<Uint240>(element.indexed) { });
+                    break;
+                case "uint248":
+                    paramList.add(new TypeReference<Uint248>(element.indexed) { });
+                    break;
+                case "uint256":
+                    paramList.add(new TypeReference<Uint256>(element.indexed) { });
+                    break;
+                case "address":
+                    paramList.add(new TypeReference<Address>(element.indexed) { });
+                    break;
+                case "string":
+                    paramList.add(new TypeReference<Utf8String>(element.indexed) { });
+                    break;
+                case "bytes":
+                    paramList.add(new TypeReference<BytesType>(element.indexed) { });
+                    break;
+                case "bytes1":
+                    paramList.add(new TypeReference<Bytes1>(element.indexed) { });
+                    break;
+                case "bytes2":
+                    paramList.add(new TypeReference<Bytes2>(element.indexed) { });
+                    break;
+                case "bytes3":
+                    paramList.add(new TypeReference<Bytes3>(element.indexed) { });
+                    break;
+                case "bytes4":
+                    paramList.add(new TypeReference<Bytes4>(element.indexed) { });
+                    break;
+                case "bytes5":
+                    paramList.add(new TypeReference<Bytes5>(element.indexed) { });
+                    break;
+                case "bytes6":
+                    paramList.add(new TypeReference<Bytes6>(element.indexed) { });
+                    break;
+                case "bytes7":
+                    paramList.add(new TypeReference<Bytes7>(element.indexed) { });
+                    break;
+                case "bytes8":
+                    paramList.add(new TypeReference<Bytes8>(element.indexed) { });
+                    break;
+                case "bytes9":
+                    paramList.add(new TypeReference<Bytes9>(element.indexed) { });
+                    break;
+                case "bytes10":
+                    paramList.add(new TypeReference<Bytes10>(element.indexed) { });
+                    break;
+                case "bytes11":
+                    paramList.add(new TypeReference<Bytes11>(element.indexed) { });
+                    break;
+                case "bytes12":
+                    paramList.add(new TypeReference<Bytes12>(element.indexed) { });
+                    break;
+                case "bytes13":
+                    paramList.add(new TypeReference<Bytes13>(element.indexed) { });
+                    break;
+                case "bytes14":
+                    paramList.add(new TypeReference<Bytes14>(element.indexed) { });
+                    break;
+                case "bytes15":
+                    paramList.add(new TypeReference<Bytes15>(element.indexed) { });
+                    break;
+                case "bytes16":
+                    paramList.add(new TypeReference<Bytes16>(element.indexed) { });
+                    break;
+                case "bytes17":
+                    paramList.add(new TypeReference<Bytes17>(element.indexed) { });
+                    break;
+                case "bytes18":
+                    paramList.add(new TypeReference<Bytes18>(element.indexed) { });
+                    break;
+                case "bytes19":
+                    paramList.add(new TypeReference<Bytes19>(element.indexed) { });
+                    break;
+                case "bytes20":
+                    paramList.add(new TypeReference<Bytes20>(element.indexed) { });
+                    break;
+                case "bytes21":
+                    paramList.add(new TypeReference<Bytes21>(element.indexed) { });
+                    break;
+                case "bytes22":
+                    paramList.add(new TypeReference<Bytes22>(element.indexed) { });
+                    break;
+                case "bytes23":
+                    paramList.add(new TypeReference<Bytes23>(element.indexed) { });
+                    break;
+                case "bytes24":
+                    paramList.add(new TypeReference<Bytes24>(element.indexed) { });
+                    break;
+                case "bytes25":
+                    paramList.add(new TypeReference<Bytes25>(element.indexed) { });
+                    break;
+                case "bytes26":
+                    paramList.add(new TypeReference<Bytes26>(element.indexed) { });
+                    break;
+                case "bytes27":
+                    paramList.add(new TypeReference<Bytes27>(element.indexed) { });
+                    break;
+                case "bytes28":
+                    paramList.add(new TypeReference<Bytes28>(element.indexed) { });
+                    break;
+                case "bytes29":
+                    paramList.add(new TypeReference<Bytes29>(element.indexed) { });
+                    break;
+                case "bytes30":
+                    paramList.add(new TypeReference<Bytes30>(element.indexed) { });
+                    break;
+                case "bytes31":
+                    paramList.add(new TypeReference<Bytes31>(element.indexed) { });
+                    break;
+                case "bytes32":
+                    paramList.add(new TypeReference<Bytes32>(element.indexed) { });
+                    break;
+                default:
+                    System.out.println("NOT IMPLEMENTED: " + element.type);
+                    break;
+            }
+        }
+
+        return paramList;
+    }
+
+    private Event generateEventFunction(EventDefinition ev)
+    {
+        List<TypeReference<?>> eventArgSpec = EventUtils.generateFunctionDefinition(ev.eventModule.getSequenceArgs());
+        return new Event(ev.eventName, eventArgSpec);
+    }
+
+    private void addTopicFilter(EthFilter filter, String filterTopicValue, Token originToken)
+    {
+        //find the topic value
+        switch (filterTopicValue)
+        {
+            case "tokenId":
+                if (originToken.isNonFungible())
+                {
+                    //get unique tokenId balance
+                    List<BigInteger> uniqueTokenIds = originToken.getUniqueTokenIds();
+                    if (uniqueTokenIds.size() == 1)
+                    {
+                        filter.addSingleTopic("0x" + TypeEncoder.encode(new Uint256(uniqueTokenIds.get(0))));
+                    }
+                    else
+                    {
+                        //listen for multiple tokenIds
+                        List<String> optionals = new ArrayList<>();
+                        for (BigInteger uid : uniqueTokenIds)
+                        {
+                            String entry = "0x" + TypeEncoder.encode(new Uint256(uid));
+                            optionals.add(entry);
+                        }
+                        filter.addOptionalTopics(optionals.toArray(new String[0]));
+                    }
+                }
+                else
+                {
+                    //TODO: report error in tokenscript management page
+                    System.out.println("ERROR: using 'tokenId' with Fungible token");
+                }
+                break;
+            case "value":
+                //TODO: Fulfilled from user entry - work out a way of doing this
+                filter.addSingleTopic(null);
+                break;
+            case "ownerAddress":
+                filter.addSingleTopic("0x" + TypeEncoder.encode(new Address(originToken.getWallet())));
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
@@ -2,17 +2,24 @@ package com.alphawallet.app.entity.tokenscript;
 
 import io.reactivex.Observable;
 
-import com.alphawallet.app.repository.EthereumNetworkRepository;
+import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.repository.TokenRepository;
 import com.alphawallet.app.util.BalanceUtils;
+import com.alphawallet.app.util.Utils;
 import com.alphawallet.token.entity.*;
 import com.alphawallet.token.tools.TokenDefinition;
-import okhttp3.OkHttpClient;
+
+import io.reactivex.Single;
+
+import org.web3j.abi.EventEncoder;
+import org.web3j.abi.EventValues;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.FunctionReturnDecoder;
+import org.web3j.abi.TypeEncoder;
 import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.BytesType;
+import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Int;
 import org.web3j.abi.datatypes.Type;
@@ -20,9 +27,13 @@ import org.web3j.abi.datatypes.Uint;
 import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.*;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCall;
-import org.web3j.protocol.http.HttpService;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.utils.Numeric;
 
 import java.io.IOException;
@@ -31,9 +42,11 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.web3j.protocol.core.methods.request.Transaction.createEthCallTransaction;
+import static org.web3j.tx.Contract.staticExtractEventParameters;
 
 /**
  * Created by James on 13/06/2019.
@@ -54,203 +67,206 @@ public abstract class TokenscriptFunction
         for (MethodArg arg : function.parameters)
         {
             resolveReference(walletAddress, arg, tokenId, definition, attrIf);
+            //get arg.element.value in the form of BigInteger if appropriate
+            byte[] argValueBytes = convertArgToBytes(arg.element.value);
+            BigInteger argValueBI = new BigInteger(1, argValueBytes);
+
             switch (arg.parameterType)
             {
-
                 case "int":
-                    params.add(new Int(new BigInteger(arg.element.value)));
+                    params.add(new Int(argValueBI));
                     break;
                 case "int8":
-                    params.add(new Int8(new BigInteger(arg.element.value)));
+                    params.add(new Int8(argValueBI));
                     break;
                 case "int16":
-                    params.add(new Int16(new BigInteger(arg.element.value)));
+                    params.add(new Int16(argValueBI));
                     break;
                 case "int24":
-                    params.add(new Int24(new BigInteger(arg.element.value)));
+                    params.add(new Int24(argValueBI));
                     break;
                 case "int32":
-                    params.add(new Int32(new BigInteger(arg.element.value)));
+                    params.add(new Int32(argValueBI));
                     break;
                 case "int40":
-                    params.add(new Int40(new BigInteger(arg.element.value)));
+                    params.add(new Int40(argValueBI));
                     break;
                 case "int48":
-                    params.add(new Int48(new BigInteger(arg.element.value)));
+                    params.add(new Int48(argValueBI));
                     break;
                 case "int56":
-                    params.add(new Int56(new BigInteger(arg.element.value)));
+                    params.add(new Int56(argValueBI));
                     break;
                 case "int64":
-                    params.add(new Int64(new BigInteger(arg.element.value)));
+                    params.add(new Int64(argValueBI));
                     break;
                 case "int72":
-                    params.add(new Int72(new BigInteger(arg.element.value)));
+                    params.add(new Int72(argValueBI));
                     break;
                 case "int80":
-                    params.add(new Int80(new BigInteger(arg.element.value)));
+                    params.add(new Int80(argValueBI));
                     break;
                 case "int88":
-                    params.add(new Int88(new BigInteger(arg.element.value)));
+                    params.add(new Int88(argValueBI));
                     break;
                 case "int96":
-                    params.add(new Int96(new BigInteger(arg.element.value)));
+                    params.add(new Int96(argValueBI));
                     break;
                 case "int104":
-                    params.add(new Int104(new BigInteger(arg.element.value)));
+                    params.add(new Int104(argValueBI));
                     break;
                 case "int112":
-                    params.add(new Int112(new BigInteger(arg.element.value)));
+                    params.add(new Int112(argValueBI));
                     break;
                 case "int120":
-                    params.add(new Int120(new BigInteger(arg.element.value)));
+                    params.add(new Int120(argValueBI));
                     break;
                 case "int128":
-                    params.add(new Int128(new BigInteger(arg.element.value)));
+                    params.add(new Int128(argValueBI));
                     break;
                 case "int136":
-                    params.add(new Int136(new BigInteger(arg.element.value)));
+                    params.add(new Int136(argValueBI));
                     break;
                 case "int144":
-                    params.add(new Int144(new BigInteger(arg.element.value)));
+                    params.add(new Int144(argValueBI));
                     break;
                 case "int152":
-                    params.add(new Int152(new BigInteger(arg.element.value)));
+                    params.add(new Int152(argValueBI));
                     break;
                 case "int160":
-                    params.add(new Int160(new BigInteger(arg.element.value)));
+                    params.add(new Int160(argValueBI));
                     break;
                 case "int168":
-                    params.add(new Int168(new BigInteger(arg.element.value)));
+                    params.add(new Int168(argValueBI));
                     break;
                 case "int176":
-                    params.add(new Int176(new BigInteger(arg.element.value)));
+                    params.add(new Int176(argValueBI));
                     break;
                 case "int184":
-                    params.add(new Int184(new BigInteger(arg.element.value)));
+                    params.add(new Int184(argValueBI));
                     break;
                 case "int192":
-                    params.add(new Int192(new BigInteger(arg.element.value)));
+                    params.add(new Int192(argValueBI));
                     break;
                 case "int200":
-                    params.add(new Int200(new BigInteger(arg.element.value)));
+                    params.add(new Int200(argValueBI));
                     break;
                 case "int208":
-                    params.add(new Int208(new BigInteger(arg.element.value)));
+                    params.add(new Int208(argValueBI));
                     break;
                 case "int216":
-                    params.add(new Int216(new BigInteger(arg.element.value)));
+                    params.add(new Int216(argValueBI));
                     break;
                 case "int224":
-                    params.add(new Int224(new BigInteger(arg.element.value)));
+                    params.add(new Int224(argValueBI));
                     break;
                 case "int232":
-                    params.add(new Int232(new BigInteger(arg.element.value)));
+                    params.add(new Int232(argValueBI));
                     break;
                 case "int240":
-                    params.add(new Int240(new BigInteger(arg.element.value)));
+                    params.add(new Int240(argValueBI));
                     break;
                 case "int248":
-                    params.add(new Int248(new BigInteger(arg.element.value)));
+                    params.add(new Int248(argValueBI));
                     break;
                 case "int256":
-                    params.add(new Int256(new BigInteger(arg.element.value)));
+                    params.add(new Int256(argValueBI));
                     break;
                 case "uint":
-                    params.add(new Uint(new BigInteger(arg.element.value)));
+                    params.add(new Uint(argValueBI));
                     break;
                 case "uint8":
-                    params.add(new Uint8(new BigInteger(arg.element.value)));
+                    params.add(new Uint8(argValueBI));
                     break;
                 case "uint16":
-                    params.add(new Uint16(new BigInteger(arg.element.value)));
+                    params.add(new Uint16(argValueBI));
                     break;
                 case "uint24":
-                    params.add(new Uint24(new BigInteger(arg.element.value)));
+                    params.add(new Uint24(argValueBI));
                     break;
                 case "uint32":
-                    params.add(new Uint32(new BigInteger(arg.element.value)));
+                    params.add(new Uint32(argValueBI));
                     break;
                 case "uint40":
-                    params.add(new Uint40(new BigInteger(arg.element.value)));
+                    params.add(new Uint40(argValueBI));
                     break;
                 case "uint48":
-                    params.add(new Uint48(new BigInteger(arg.element.value)));
+                    params.add(new Uint48(argValueBI));
                     break;
                 case "uint56":
-                    params.add(new Uint56(new BigInteger(arg.element.value)));
+                    params.add(new Uint56(argValueBI));
                     break;
                 case "uint64":
-                    params.add(new Uint64(new BigInteger(arg.element.value)));
+                    params.add(new Uint64(argValueBI));
                     break;
                 case "uint72":
-                    params.add(new Uint72(new BigInteger(arg.element.value)));
+                    params.add(new Uint72(argValueBI));
                     break;
                 case "uint80":
-                    params.add(new Uint80(new BigInteger(arg.element.value)));
+                    params.add(new Uint80(argValueBI));
                     break;
                 case "uint88":
-                    params.add(new Uint88(new BigInteger(arg.element.value)));
+                    params.add(new Uint88(argValueBI));
                     break;
                 case "uint96":
-                    params.add(new Uint96(new BigInteger(arg.element.value)));
+                    params.add(new Uint96(argValueBI));
                     break;
                 case "uint104":
-                    params.add(new Uint104(new BigInteger(arg.element.value)));
+                    params.add(new Uint104(argValueBI));
                     break;
                 case "uint112":
-                    params.add(new Uint112(new BigInteger(arg.element.value)));
+                    params.add(new Uint112(argValueBI));
                     break;
                 case "uint120":
-                    params.add(new Uint120(new BigInteger(arg.element.value)));
+                    params.add(new Uint120(argValueBI));
                     break;
                 case "uint128":
-                    params.add(new Uint128(new BigInteger(arg.element.value)));
+                    params.add(new Uint128(argValueBI));
                     break;
                 case "uint136":
-                    params.add(new Uint136(new BigInteger(arg.element.value)));
+                    params.add(new Uint136(argValueBI));
                     break;
                 case "uint144":
-                    params.add(new Uint144(new BigInteger(arg.element.value)));
+                    params.add(new Uint144(argValueBI));
                     break;
                 case "uint152":
-                    params.add(new Uint152(new BigInteger(arg.element.value)));
+                    params.add(new Uint152(argValueBI));
                     break;
                 case "uint160":
-                    params.add(new Uint160(new BigInteger(arg.element.value)));
+                    params.add(new Uint160(argValueBI));
                     break;
                 case "uint168":
-                    params.add(new Uint168(new BigInteger(arg.element.value)));
+                    params.add(new Uint168(argValueBI));
                     break;
                 case "uint176":
-                    params.add(new Uint176(new BigInteger(arg.element.value)));
+                    params.add(new Uint176(argValueBI));
                     break;
                 case "uint184":
-                    params.add(new Uint184(new BigInteger(arg.element.value)));
+                    params.add(new Uint184(argValueBI));
                     break;
                 case "uint192":
-                    params.add(new Uint192(new BigInteger(arg.element.value)));
+                    params.add(new Uint192(argValueBI));
                     break;
                 case "uint200":
-                    params.add(new Uint200(new BigInteger(arg.element.value)));
+                    params.add(new Uint200(argValueBI));
                     break;
                 case "uint208":
-                    params.add(new Uint208(new BigInteger(arg.element.value)));
+                    params.add(new Uint208(argValueBI));
                     break;
                 case "uint216":
-                    params.add(new Uint216(new BigInteger(arg.element.value)));
+                    params.add(new Uint216(argValueBI));
                     break;
                 case "uint224":
-                    params.add(new Uint224(new BigInteger(arg.element.value)));
+                    params.add(new Uint224(argValueBI));
                     break;
                 case "uint232":
-                    params.add(new Uint232(new BigInteger(arg.element.value)));
+                    params.add(new Uint232(argValueBI));
                     break;
                 case "uint240":
-                    params.add(new Uint240(new BigInteger(arg.element.value)));
+                    params.add(new Uint240(argValueBI));
                     break;
                 case "uint248":
-                    params.add(new Uint248(new BigInteger(arg.element.value)));
+                    params.add(new Uint248(argValueBI));
                     break;
                 case "uint256":
                     switch (arg.element.ref)
@@ -260,7 +276,7 @@ public abstract class TokenscriptFunction
                             break;
                         case "value":
                         default:
-                            params.add(new Uint256(new BigInteger(arg.element.value)));
+                            params.add(new Uint256(argValueBI));
                             break;
                     }
                     break;
@@ -272,7 +288,7 @@ public abstract class TokenscriptFunction
                             break;
                         case "value":
                         default:
-                            params.add(new Address(arg.element.value));
+                            params.add(new Address(Numeric.toHexString(argValueBytes)));
                             break;
                     }
                     break;
@@ -280,103 +296,112 @@ public abstract class TokenscriptFunction
                     params.add(new Utf8String(arg.element.value));
                     break;
                 case "bytes":
-                    params.add(new BytesType(Numeric.hexStringToByteArray(arg.element.value), "bytes"));
+                    params.add(new BytesType(argValueBytes, "bytes"));
                     break;
                 case "bytes1":
-                    params.add(new Bytes1(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes1(argValueBytes));
                     break;
                 case "bytes2":
-                    params.add(new Bytes2(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes2(argValueBytes));
                     break;
                 case "bytes3":
-                    params.add(new Bytes3(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes3(argValueBytes));
                     break;
                 case "bytes4":
-                    params.add(new Bytes4(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes4(argValueBytes));
                     break;
                 case "bytes5":
-                    params.add(new Bytes5(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes5(argValueBytes));
                     break;
                 case "bytes6":
-                    params.add(new Bytes6(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes6(argValueBytes));
                     break;
                 case "bytes7":
-                    params.add(new Bytes7(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes7(argValueBytes));
                     break;
                 case "bytes8":
-                    params.add(new Bytes8(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes8(argValueBytes));
                     break;
                 case "bytes9":
-                    params.add(new Bytes9(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes9(argValueBytes));
                     break;
                 case "bytes10":
-                    params.add(new Bytes10(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes10(argValueBytes));
                     break;
                 case "bytes11":
-                    params.add(new Bytes11(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes11(argValueBytes));
                     break;
                 case "bytes12":
-                    params.add(new Bytes12(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes12(argValueBytes));
                     break;
                 case "bytes13":
-                    params.add(new Bytes13(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes13(argValueBytes));
                     break;
                 case "bytes14":
-                    params.add(new Bytes14(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes14(argValueBytes));
                     break;
                 case "bytes15":
-                    params.add(new Bytes15(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes15(argValueBytes));
                     break;
                 case "bytes16":
-                    params.add(new Bytes16(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes16(argValueBytes));
                     break;
                 case "bytes17":
-                    params.add(new Bytes17(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes17(argValueBytes));
                     break;
                 case "bytes18":
-                    params.add(new Bytes18(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes18(argValueBytes));
                     break;
                 case "bytes19":
-                    params.add(new Bytes19(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes19(argValueBytes));
                     break;
                 case "bytes20":
-                    params.add(new Bytes20(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes20(argValueBytes));
                     break;
                 case "bytes21":
-                    params.add(new Bytes21(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes21(argValueBytes));
                     break;
                 case "bytes22":
-                    params.add(new Bytes22(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes22(argValueBytes));
                     break;
                 case "bytes23":
-                    params.add(new Bytes23(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes23(argValueBytes));
                     break;
                 case "bytes24":
-                    params.add(new Bytes24(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes24(argValueBytes));
                     break;
                 case "bytes25":
-                    params.add(new Bytes25(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes25(argValueBytes));
                     break;
                 case "bytes26":
-                    params.add(new Bytes26(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes26(argValueBytes));
                     break;
                 case "bytes27":
-                    params.add(new Bytes27(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes27(argValueBytes));
                     break;
                 case "bytes28":
-                    params.add(new Bytes28(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes28(argValueBytes));
                     break;
                 case "bytes29":
-                    params.add(new Bytes29(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes29(argValueBytes));
                     break;
                 case "bytes30":
-                    params.add(new Bytes30(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes30(argValueBytes));
                     break;
                 case "bytes31":
-                    params.add(new Bytes31(Numeric.hexStringToByteArray(arg.element.value)));
+                    params.add(new Bytes31(argValueBytes));
                     break;
-                case "bytes32":
-                    params.add(new Bytes32(Numeric.hexStringToByteArray(arg.element.value)));
+                case "bytes32": //sometimes tokenId can be passed as bytes32
+                    switch (arg.element.ref)
+                    {
+                        case "tokenId":
+                            params.add(new Bytes32(Numeric.toBytesPadded(tokenId, 32)));
+                            break;
+                        case "value":
+                        default:
+                            params.add(new Bytes32(argValueBytes));
+                            break;
+                    }
                     break;
                 default:
                     System.out.println("NOT IMPLEMENTED: " + arg.parameterType);
@@ -629,7 +654,15 @@ public abstract class TokenscriptFunction
     public Observable<TokenScriptResult.Attribute> fetchAttrResult(String walletAddress, AttributeType attr, BigInteger tokenId, ContractAddress cAddr, TokenDefinition td, AttributeInterface attrIf, long transactionUpdate)
     {
         if (attr == null) return Observable.fromCallable(() -> new TokenScriptResult.Attribute("bd", "bd", BigInteger.ZERO, ""));
-        if (attr.function == null)  // static attribute from tokenId (eg city mapping from tokenId)
+        else if (attr.event != null)
+        {
+            //retrieve events from DB
+            ContractAddress useAddress = new ContractAddress(attr.event.eventModule.contractInfo.addresses.keySet().iterator().next(),
+                                                             attr.event.eventModule.contractInfo.addresses.values().iterator().next().get(0));
+            TransactionResult cachedResult = attrIf.getFunctionResult(useAddress, attr, tokenId); //Needs to allow for multiple tokenIds
+            return resultFromDatabase(cachedResult, attr);
+        }
+        else if (attr.function == null)  // static attribute from tokenId (eg city mapping from tokenId)
         {
             return staticAttribute(attr, tokenId);
         }
@@ -703,7 +736,7 @@ public abstract class TokenscriptFunction
                 case Unsigned:
                 case Signed:
                 case UnsignedInput:
-                    inputBytes = TokenscriptFunction.convertArgToBytes(valueFromInput);
+                    inputBytes = TokenscriptFunction.convertArgToBytes(Utils.isolateNumeric(valueFromInput)); //convert cleaned user input
                     BigInteger unsignedValue = new BigInteger(inputBytes);
                     convertedValue = unsignedValue.toString();
                     e.value = unsignedValue.toString();

--- a/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
@@ -41,7 +41,7 @@ public class FetchTokensInteract {
                 .observeOn(AndroidSchedulers.mainThread());
     }
 
-    public Observable<Token> fetchSingle(Wallet wallet, Token token) {
+    public Single<Token> fetchSingle(Wallet wallet, Token token) {
         return tokenRepository.fetchActiveSingle(wallet.address, token)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -42,8 +42,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
        These hardcoded keys are fallbacks used by AlphaWallet forks.
      */
     public static final String BACKUP_INFURA_KEY = "da3717f25f824cc1baa32d812386d93f";
-    public static final String MAINNET_FALLBACK_RPC_URL = "https://ropsten.infura.io/v3/" + BuildConfig.InfuraAPI;
-    public static final String MAINNET_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI : MAINNET_FALLBACK_RPC_URL;
+    public static final String MAINNET_FALLBACK_RPC_URL = "https://mainnet.infura.io/v3/" + BuildConfig.InfuraAPI;
+    public static final String MAINNET_RPC_URL = MAINNET_FALLBACK_RPC_URL;//!BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI : MAINNET_FALLBACK_RPC_URL;
     public static final String CLASSIC_RPC_URL = "https://ethereumclassic.network";
     public static final String XDAI_RPC_URL = "https://dai.poa.network";
     public static final String POA_RPC_URL = "https://core.poa.network/";

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -244,14 +244,12 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
-    public Observable<Token> fetchActiveSingle(String walletAddress, Token token)
+    public Single<Token> fetchActiveSingle(String walletAddress, Token token)
     {
         NetworkInfo network = ethereumNetworkRepository.getNetworkByChain(token.tokenInfo.chainId);
         Wallet wallet = new Wallet(walletAddress);
-        return Single.merge(
-                fetchCachedToken(network, wallet, token.getAddress()),
-                updateBalance(network, wallet, token)) // Looking for new tokens
-                .toObservable();
+        return fetchCachedToken(network, wallet, token.getAddress())
+               .flatMap(t -> updateBalance(network, wallet, t)); // Looking for new tokens
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -22,7 +22,7 @@ public interface TokenRepositoryType {
 
     Observable<Token[]> fetchStored(String walletAddress);
     Observable<Token[]> fetchActiveStoredPlusEth(String walletAddress);
-    Observable<Token> fetchActiveSingle(String walletAddress, Token token);
+    Single<Token> fetchActiveSingle(String walletAddress, Token token);
     Observable<Token> fetchCachedSingleToken(NetworkInfo network, String walletAddress, String tokenAddress);
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
     Single<ContractResult> getTokenResponse(String address, int chainId, String method);

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -5,6 +5,7 @@ import android.util.SparseArray;
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.ContractResult;
 import com.alphawallet.app.entity.ContractType;
+import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenTicker;
 import com.alphawallet.app.interact.GenericWalletInteract;
@@ -471,5 +472,12 @@ public class TokensService
     public TokenTicker getTokenTicker(Token token)
     {
         return ethereumNetworkRepository.getTokenTicker(token);
+    }
+
+    public String getShortNetworkName(int chainId)
+    {
+        NetworkInfo info = ethereumNetworkRepository.getNetworkByChain(chainId);
+        if (info != null) return info.getShortName();
+        else return "";
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.ErrorEnvelope;
+import com.alphawallet.app.entity.Event;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.TokenInterface;
@@ -80,6 +81,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         viewModel.clearAdapter().observe(this, this::clearAdapter);
         viewModel.refreshAdapter().observe(this, this::refreshAdapter);
         viewModel.newTransactions().observe(this, this::onNewTransactions);
+        viewModel.event().observe(this, this::onNewEvents);
         refreshLayout.setOnRefreshListener(() -> viewModel.prepare());
 
         adapter.clear();
@@ -141,6 +143,11 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         if (transactions.length > 0) showEmptyTx(false);
     }
 
+    private void onNewEvents(Event[] events)
+    {
+        adapter.addEvents(events);
+    }
+
     @Override
     public void onDestroy()
     {
@@ -169,6 +176,9 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         }
     }
 
+    /**
+     * Called only after user changes the wallet
+     */
     @Override
     public void resetTokens()
     {
@@ -176,6 +186,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
         adapter.clear();
         list.setAdapter(adapter);
         viewModel.clearProcesses();
+        viewModel.restartEventListener();
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TransactionsAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TransactionsAdapter.java
@@ -6,6 +6,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
 import com.alphawallet.app.R;
 
+import com.alphawallet.app.entity.Event;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionMeta;
 import com.alphawallet.app.entity.Wallet;
@@ -184,6 +185,12 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
         }
         items.endBatchedUpdates();
         notifyDataSetChanged();
+    }
+
+    //TODO: Display events in Actions list
+    public void addEvents(Event[] events)
+    {
+
     }
 
     public int updateRecentTransactions(Transaction[] transactions)

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -29,6 +29,8 @@ import org.web3j.crypto.WalletUtils;
 
 public class Utils {
 
+    private static final String ISOLATE_NUMERIC = "(0?x?[0-9a-fA-F]+)";
+
     public static int dp2px(Context context, int dp) {
         Resources r = context.getResources();
         return (int) TypedValue.applyDimension(
@@ -259,5 +261,26 @@ public class Utils {
         }
 
         return false;
+    }
+
+    public static String isolateNumeric(String valueFromInput)
+    {
+        try
+        {
+            Matcher regexResult = Pattern.compile(ISOLATE_NUMERIC).matcher(valueFromInput);
+            if (regexResult.find())
+            {
+                if (regexResult.groupCount() >= 1)
+                {
+                    valueFromInput = regexResult.group(0);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            // Silent fail - no action; just return input; this function is only to clean junk from a number
+        }
+
+        return valueFromInput;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -148,7 +148,7 @@ public class TokenFunctionViewModel extends BaseViewModel
 
     private void onToken(Token t)
     {
-        if (token.checkBalanceChange(t))
+        if (assetDefinitionService.checkTokenForNewEvent(t) || token.checkBalanceChange(t))
         {
             t.transferPreviousData(token);
             token = t;

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -46,6 +46,7 @@ public class Web3TokenView extends WebView
     private static final String JS_PROTOCOL_CANCELLED = "cancelled";
     private static final String JS_PROTOCOL_ON_SUCCESSFUL = "executeCallback(%1$s, null, \"%2$s\")";
     private static final String JS_PROTOCOL_ON_FAILURE = "executeCallback(%1$s, \"%2$s\", null)";
+    private static final String REFRESH_ERROR = "refresh is not defined";
 
     private JsInjectorClient jsInjectorClient;
     private TokenScriptClient tokenScriptClient;
@@ -114,6 +115,7 @@ public class Web3TokenView extends WebView
             {
                 if (!showingError && msg.messageLevel() == ConsoleMessage.MessageLevel.ERROR)
                 {
+                    if (msg.message().contains(REFRESH_ERROR)) return true; //don't stop for refresh error
                     String errorMessage = RENDERING_ERROR.replace("${ERR1}", msg.message());
                     showError(errorMessage);
                 }

--- a/lib/src/main/java/com/alphawallet/token/entity/EventDefinition.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/EventDefinition.java
@@ -1,6 +1,7 @@
 package com.alphawallet.token.entity;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,16 +21,16 @@ public class EventDefinition
 
     public String getFilterTopicValue()
     {
-        // (\+\d{4}|\-\d{4})
+        // This regex splits up the "filterArgName=${filterValue}" directive and gets the 'filterValue'
         Matcher m = Pattern.compile("\\$\\{([^}]+)\\}").matcher(filter);
-        String item = m.find() ? m.group(1) : null;
-        return item;
+        return (m.find() && m.groupCount() >= 1) ? m.group(1) : null;
     }
 
     public String getFilterTopicIndex()
     {
+        // Get the filter name from the directive and strip whitespace
         String[] item = filter.split("=");
-        return item[0];
+        return item[0].replaceAll("\\s+", "");
     }
 
     public int getTopicIndex(String filterTopic)

--- a/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/TransactionResult.java
@@ -21,7 +21,9 @@ public class TransactionResult
         this.contractAddress = address;
         this.contractChainId = chainId;
         this.tokenId = tokenId;
-        this.method = attr.function.method;
+        if (attr.function != null) this.method = attr.function.method;
+        else if (attr.event != null) this.method = attr.id; //for event store attribute name
+        else this.method = attr.name;
         this.attrId = attr.id;
         result = null;
         resultTime = 0;


### PR DESCRIPTION
Completes the basic implementation for event support.

This PR starts the event listener for reading events and repeats on a 15 second cycle (matching how web3j polls logs behind the scenes for flowable listeners).

Also cache individual events pending schema design while we solidify the requirements.

TODO: 
- Display events in Activity display.
- Develop schema for storing individual events.

closes #1194 

