### PR TITLE
Resolve reference for 'value' in tokenscript

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -12,6 +12,7 @@ import android.os.FileObserver;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
 import android.util.SparseArray;
 
 import com.alphawallet.app.C;
@@ -41,7 +42,6 @@ import com.alphawallet.token.entity.ContractInfo;
 import com.alphawallet.token.entity.EventDefinition;
 import com.alphawallet.token.entity.FunctionDefinition;
 import com.alphawallet.token.entity.MethodArg;
-import com.alphawallet.token.entity.NonFungibleToken;
 import com.alphawallet.token.entity.ParseResult;
 import com.alphawallet.token.entity.SigReturnType;
 import com.alphawallet.token.entity.TSAction;
@@ -53,6 +53,7 @@ import com.alphawallet.token.entity.XMLDsigDescriptor;
 import com.alphawallet.token.tools.Numeric;
 import com.alphawallet.token.tools.TokenDefinition;
 
+import org.jetbrains.annotations.NotNull;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.crypto.WalletUtils;
@@ -60,7 +61,6 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthLog;
-import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.protocol.core.methods.response.Log;
 import org.xml.sax.SAXException;
 
@@ -76,7 +76,6 @@ import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -85,7 +84,6 @@ import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -1833,6 +1831,18 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         {
             requireEventSend = false;
             generateAndSendEvents();
+        }
+    }
+
+    public void resolveReference(@NotNull Token token, TSAction action, TokenscriptElement arg, BigInteger tokenId)
+    {
+        TokenDefinition td = getAssetDefinition(token.tokenInfo.chainId, token.getAddress());
+        if (td == null || TextUtils.isEmpty(arg.ref)) return;
+        AttributeType attributeType = (action != null && action.attributeTypes != null) ? action.attributeTypes.get(arg.ref) : null; // try locals first
+        if (attributeType == null) attributeType = td.attributeTypes.get(arg.ref); // now try globals
+        if (attributeType != null)
+        {
+            arg.value = tokenscriptUtility.fetchAttrResult(tokensService.getCurrentAddress(), attributeType, tokenId, null, td, this, 0).blockingSingle().text;
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -135,6 +136,7 @@ public class ConfirmationActivity extends BaseActivity implements SignAuthentica
         String tokenList = getIntent().getStringExtra(C.EXTRA_TOKENID_LIST);
         token = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
         chainId = token != null ? token.tokenInfo.chainId : getIntent().getIntExtra(C.EXTRA_NETWORKID, 1);
+        String functionDetails = getIntent().getStringExtra(C.EXTRA_FUNCTION_NAME);
 
         String amountString;
 
@@ -191,6 +193,7 @@ public class ConfirmationActivity extends BaseActivity implements SignAuthentica
                 contractAddrLabel.setVisibility(View.VISIBLE);
                 contractAddrText.setText(contractAddress);
                 amountString = getIntent().getStringExtra(C.EXTRA_ACTION_NAME);
+                if (!TextUtils.isEmpty(functionDetails)) amountString = functionDetails;
                 symbolText.setVisibility(View.GONE);
 
                 transactionHex = getIntent().getStringExtra(C.EXTRA_TRANSACTION_DATA);


### PR DESCRIPTION
Fixes #1266 

The 'value' for transactions wasn't being resolved for a reference if the attribute was local.

@hboon you may face the same issue - when the 'value' param comes from a view local attribute like this:

```
<ts:action>
      <ts:name>
        <ts:string xml:lang="en">Renew</ts:string>
      </ts:name>
<ts:attribute-type id="renewalPricePerYear" syntax="1.3.6.1.4.1.1466.115.121.1.36">
        <ts:name>
          <ts:string xml:lang="en">renewal price per year</ts:string>
        </ts:name>
        <ts:origins>
          <ts:ethereum function="rentPrice" contract="ETHRegistrarController" as="uint">
            <ts:data>
              <ts:string ref="ensName"/>
              <ts:uint256>31540000</ts:uint256>
            </ts:data>
          </ts:ethereum>
        </ts:origins>
      </ts:attribute-type>

      <ts:transaction>
        <ts:ethereum function="renew" contract="registrar" as="uint">
          <ts:value ref="renewalPricePerYear"/>    //<--- value is result from attribute function call
          <ts:data>
            <ts:string ref="ensName"/>
            <ts:uint256>31540000</ts:uint256>
          </ts:data>
        </ts:ethereum>
      </ts:transaction>
...
```