### PR TITLE
Fix cached tickers

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/TickerService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TickerService.java
@@ -218,8 +218,20 @@ public class TickerService implements TickerServiceInterface
     public TokenTicker getTokenTicker(Token token)
     {
         if (token == null) return null;
-        if (token.isEthereum()) return ethTickers.get(token.tokenInfo.chainId);
-        else return erc20Tickers.get(token.getAddress().toLowerCase());
+        TokenTicker serviceTicker;
+        if (token.isEthereum()) serviceTicker = ethTickers.get(token.tokenInfo.chainId);
+        else serviceTicker = erc20Tickers.get(token.getAddress().toLowerCase());
+
+        //Only update the ticker if service ticker is more recent than stored ticker
+        if (serviceTicker != null &&
+                (token.ticker == null || (serviceTicker.updateTime > token.ticker.updateTime)))
+        {
+            return serviceTicker;
+        }
+        else
+        {
+            return token.ticker;
+        }
     }
 
     @Override


### PR DESCRIPTION
Small refactor of tickers - ensure that tickers are only updated if the new ticker is fresher than the stored one, and simplify ticker loading.

This fixes the issue of null tickers when network connection is intermittent, or when using airplane mode. It has a good side effect of making the initial wallet list build at startup a little smoother too (if there's no ticker at startup as the service is a little slow then simply use the cached ticker).