### PR TITLE
Fix tx to/from shown in transaction list and detail screens

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -627,7 +627,7 @@ public class Token implements Parcelable, Comparable<Token>
             }
             else
             {
-                if (transaction.from.equals(tokenWallet))
+                if (transaction.from.equalsIgnoreCase(tokenWallet))
                 {
                     name = ctx.getString(R.string.sent);
                 }

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -111,6 +111,9 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
         {
             findViewById(R.id.contract_name_title).setVisibility(View.GONE);
             findViewById(R.id.contract_name).setVisibility(View.GONE);
+
+            //no token, did we send? If from == our wallet then we sent this
+            if (transaction.from.equalsIgnoreCase(wallet.address)) operationName = getString(R.string.sent);
         }
 
         if (operationName != null)
@@ -166,7 +169,7 @@ public class TransactionDetailActivity extends BaseActivity implements View.OnCl
     }
 
     private void setupWalletDetails() {
-        boolean isSent = transaction.from.toLowerCase().equals(wallet.address);
+        boolean isSent = transaction.from.equalsIgnoreCase(wallet.address);
         String rawValue;
         String prefix = "";
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/ContractTransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/ContractTransactionHolder.java
@@ -87,7 +87,7 @@ public class ContractTransactionHolder extends BinderViewHolder<Transaction> imp
             String valueStr,
             long decimals,
             long timestamp) {
-        boolean isSent = from.toLowerCase().equals(defaultAddress);
+        boolean isSent = from.equalsIgnoreCase(defaultAddress);
         type.setText(isSent ? getString(R.string.sent) : getString(R.string.received));
         if (!TextUtils.isEmpty(error)) {
             typeIcon.setImageResource(R.drawable.ic_error_outline_black_24dp);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -266,7 +266,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
             long decimals,
             long timestamp)
     {
-        boolean isSent = from.toLowerCase().equals(defaultAddress);
+        boolean isSent = from.equalsIgnoreCase(defaultAddress);
         type.setText(isSent ? getString(R.string.sent) : getString(R.string.received));
         boolean self = false;
 
@@ -328,7 +328,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         String from = operation.from;
         String supplimentalTxt = "";
 
-        boolean isSent = from.toLowerCase().equals(defaultAddress.toLowerCase());
+        boolean isSent = from.equalsIgnoreCase(defaultAddress);
         String operationName = token != null ? token.getOperationName(transaction, getContext()) : null;
         if (operationName == null) operationName = isSent ? getString(R.string.sent) : getString(R.string.received);
         type.setText(operationName);

--- a/app/src/main/java/com/alphawallet/app/web3/entity/Address.java
+++ b/app/src/main/java/com/alphawallet/app/web3/entity/Address.java
@@ -41,7 +41,7 @@ public class Address implements Parcelable {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof Address && value.equals(((Address) other).value);
+        return other instanceof Address && value.equalsIgnoreCase(((Address) other).value);
 
     }
 


### PR DESCRIPTION
Fix inconsistent display of sent and received in Transaction view.

Reported in the AlphaWallet public forum.

Issue can be seen by watching this wallet:

```0xB9E289bC3beAFd15397Ae3D03054864f1c519B74```

Be sure to enable Rinkeby. Before patch you'll see all tx are green Received, after patch they will show up correctly. 