### PR TITLE
Fix up Wallets currency label

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsAdapter.java
@@ -39,14 +39,9 @@ public class WalletsAdapter extends RecyclerView.Adapter<BinderViewHolder> imple
     @Override
     public BinderViewHolder onCreateViewHolder(@NotNull ViewGroup parent, int viewType) {
         BinderViewHolder binderViewHolder = null;
-        WalletHolder h;
         switch (viewType) {
             case WalletHolder.VIEW_TYPE:
-                h = new WalletHolder(R.layout.item_wallet_manage, parent, this);
-                if (network != null) {
-                    h.setCurrencySymbol(network.symbol);
-                }
-                binderViewHolder = h;
+                binderViewHolder = new WalletHolder(R.layout.item_wallet_manage, parent, this);
             break;
             case TextHolder.VIEW_TYPE:
                 binderViewHolder = new TextHolder(R.layout.item_text_view, parent);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletHolder.java
@@ -140,15 +140,10 @@ public class WalletHolder extends BinderViewHolder<Wallet> implements View.OnCli
 			case R.id.btn_more:
 				Intent intent = new Intent(getContext(), WalletActionsActivity.class);
 				intent.putExtra("wallet", wallet);
-				intent.putExtra("currency", currencySymbol);
+				intent.putExtra("currency", wallet.balanceSymbol);
 				intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 				getContext().startActivity(intent);
 				break;
 		}
 	}
-
-    public void setCurrencySymbol(String symbol)
-    {
-		currencySymbol = symbol;
-    }
 }


### PR DESCRIPTION
Tidying up some old code.

Fix up inefficient code for updating wallet currency symbol. This could trip up forked wallets if they happen to have a different currency symbol for their base currency.