### PR TITLE
Normalise Web3j usage

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
@@ -17,6 +17,8 @@ import com.alphawallet.app.service.KeyService;
 import com.alphawallet.app.service.TransactionsNetworkClientType;
 import okhttp3.OkHttpClient;
 
+import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
+
 public class WalletRepository implements WalletRepositoryType
 {
 	private final PreferenceRepositoryType preferenceRepositoryType;
@@ -143,7 +145,10 @@ public class WalletRepository implements WalletRepositoryType
 		return Single.fromCallable(() -> {
 			try
 			{
-				return new BigDecimal(Web3j.build(new HttpService(networkRepository.getDefaultNetwork().rpcServerUrl, httpClient, false)).ethGetBalance(wallet.address, DefaultBlockParameterName.PENDING).send().getBalance());
+				return new BigDecimal(getWeb3jService(networkRepository.getDefaultNetwork().chainId)
+											  .ethGetBalance(wallet.address, DefaultBlockParameterName.PENDING)
+											  .send()
+											  .getBalance());
 			}
 			catch (IOException e)
 			{

--- a/app/src/main/java/com/alphawallet/app/service/GasService.java
+++ b/app/src/main/java/com/alphawallet/app/service/GasService.java
@@ -21,6 +21,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
+import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
+
 /**
  * Created by James on 4/07/2019.
  * Stormbird in Sydney
@@ -69,7 +71,7 @@ public class GasService implements ContractGasProvider
                 return;
             }
 
-            web3j = Web3j.build(new HttpService(networkRepository.getNetworkByChain(currentChainId).rpcServerUrl));
+            web3j = getWeb3jService(currentChainId);
             setCurrentPrice(chainId);
             gasFetchDisposable = Observable.interval(0, FETCH_GAS_PRICE_INTERVAL, TimeUnit.SECONDS)
                     .doOnNext(l -> fetchCurrentGasPrice()).subscribe();

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletsViewModel.java
@@ -47,6 +47,7 @@ import io.reactivex.schedulers.Schedulers;
 import okhttp3.OkHttpClient;
 
 import static com.alphawallet.app.entity.tokenscript.TokenscriptFunction.ZERO_ADDRESS;
+import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
 
 public class WalletsViewModel extends BaseViewModel
 {
@@ -228,7 +229,7 @@ public class WalletsViewModel extends BaseViewModel
     private Observable<Wallet> resolveEns(Wallet wallet)
     {
         return Observable.fromCallable(() -> {
-            AWEnsResolver resolver = new AWEnsResolver(getService(EthereumNetworkRepository.MAINNET_ID), gasService);
+            AWEnsResolver resolver = new AWEnsResolver(getWeb3jService(EthereumNetworkRepository.MAINNET_ID), gasService);
             try
             {
                 wallet.ENSname = resolver.reverseResolve(wallet.address);
@@ -248,18 +249,6 @@ public class WalletsViewModel extends BaseViewModel
             }
             return wallet;
         }).subscribeOn(Schedulers.from(executorService));
-    }
-
-    private Web3j getService(int chainId)
-    {
-        OkHttpClient okClient = new OkHttpClient.Builder()
-                .connectTimeout(5, TimeUnit.SECONDS)
-                .readTimeout(5, TimeUnit.SECONDS)
-                .writeTimeout(5, TimeUnit.SECONDS)
-                .retryOnConnectionFailure(false)
-                .build();
-        NetworkInfo network = findDefaultNetworkInteract.getNetworkInfo(chainId);
-        return Web3j.build(new HttpService(network.rpcServerUrl, okClient, false));
     }
 
     public void fetchWallets()


### PR DESCRIPTION
Noticed that web3j is initialised differently in different places.

Standardise usage because if we needed to use a private chain with credentials this should only need to be added in one place to cover all usage.