### PR TITLE
Use Realm as fallback for token loading

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -123,13 +123,11 @@ public class RepositoriesModule {
     TokenRepositoryType provideTokenRepository(
             EthereumNetworkRepositoryType ethereumNetworkRepository,
             TokenLocalSource tokenLocalSource,
-			GasService gasService,
-			TokensService tokensService) {
+			GasService gasService) {
 	    return new TokenRepository(
 	            ethereumNetworkRepository,
                 tokenLocalSource,
-				gasService,
-				tokensService);
+				gasService);
     }
 
     @Singleton
@@ -146,8 +144,8 @@ public class RepositoriesModule {
 
 	@Singleton
 	@Provides
-	TokensService provideTokensService(EthereumNetworkRepositoryType ethereumNetworkRepository, RealmManager realmManager, OkHttpClient okHttpClient, PreferenceRepositoryType preferenceRepository) {
-		return new TokensService(ethereumNetworkRepository, realmManager, okHttpClient, preferenceRepository);
+	TokensService provideTokensService(EthereumNetworkRepositoryType ethereumNetworkRepository, TokenRepositoryType tokenRepository, OkHttpClient okHttpClient, PreferenceRepositoryType preferenceRepository) {
+		return new TokensService(ethereumNetworkRepository, tokenRepository, okHttpClient, preferenceRepository);
 	}
 
 	@Singleton

--- a/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
@@ -33,7 +33,7 @@ public class FetchTokensInteract {
 
     public Observable<Token> fetchStoredToken(NetworkInfo network, Wallet wallet, String tokenAddress) {
         if (TextUtils.isEmpty(tokenAddress)) tokenAddress = wallet.address.toLowerCase();
-        return tokenRepository.fetchCachedSingleToken(network, wallet.address, tokenAddress)
+        return tokenRepository.fetchCachedSingleToken(network.chainId, wallet.address, tokenAddress)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread());
     }

--- a/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
@@ -18,10 +18,11 @@ public interface TokenLocalSource {
     Single<Token[]> saveTokens(Wallet wallet, Token[] items);
     void updateTokenBalance(NetworkInfo network, Wallet wallet, Token token);
     Token getTokenBalance(NetworkInfo network, Wallet wallet, String address);
+    Token fetchToken(int chainId, Wallet wallet, String address);
     Map<Integer, Token> getTokenBalances(Wallet wallet, String address);
     void setEnable(NetworkInfo network, Wallet wallet, Token token, boolean isEnabled);
 
-    Single<Token> fetchEnabledToken(NetworkInfo networkInfo, Wallet wallet, String address);
+    Single<Token> fetchEnabledToken(int chainId, Wallet wallet, String address);
     Single<Token[]> fetchTokensWithBalance(Wallet wallet);
     Single<Token> saveTicker(Wallet wallet, Token token);
     Single<Token[]> saveTickers(Wallet wallet, Token[] tokens);

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -77,7 +77,6 @@ public class TokenRepository implements TokenRepositoryType {
     private final TokenLocalSource localSource;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final GasService gasService;
-    private final TokensService tokensService;
 
     public static final String INVALID_CONTRACT = "<invalid>";
 
@@ -96,13 +95,11 @@ public class TokenRepository implements TokenRepositoryType {
     public TokenRepository(
             EthereumNetworkRepositoryType ethereumNetworkRepository,
             TokenLocalSource localSource,
-            GasService gasService,
-            TokensService tokensService) {
+            GasService gasService) {
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.localSource = localSource;
         this.ethereumNetworkRepository.addOnChangeDefaultNetwork(this::buildWeb3jClient);
         this.gasService = gasService;
-        this.tokensService = tokensService;
 
         web3jNodeServers = new ConcurrentHashMap<>();
         okClient = new OkHttpClient.Builder()
@@ -249,17 +246,24 @@ public class TokenRepository implements TokenRepositoryType {
         NetworkInfo network = ethereumNetworkRepository.getNetworkByChain(token.tokenInfo.chainId);
         Wallet wallet = new Wallet(walletAddress);
         return Single.merge(
-                fetchCachedToken(network, wallet, token.getAddress()),
+                fetchCachedToken(network.chainId, wallet, token.getAddress()),
                 updateBalance(network, wallet, token)) // Looking for new tokens
                 .toObservable();
     }
 
     @Override
-    public Observable<Token> fetchCachedSingleToken(NetworkInfo network, String walletAddress, String tokenAddress)
+    public Observable<Token> fetchCachedSingleToken(int chainId, String walletAddress, String tokenAddress)
     {
         Wallet wallet = new Wallet(walletAddress);
-        return fetchCachedToken(network, wallet, tokenAddress)
+        return fetchCachedToken(chainId, wallet, tokenAddress)
                 .toObservable();
+    }
+
+    @Override
+    public Token fetchToken(int chainId, String walletAddress, String address)
+    {
+        Wallet wallet = new Wallet(walletAddress);
+        return localSource.fetchToken(chainId, wallet, address);
     }
 
     /**
@@ -582,7 +586,7 @@ public class TokenRepository implements TokenRepositoryType {
     private void updateInService(Token t)
     {
         t.walletUIUpdateRequired = true;
-        tokensService.addToken(t);
+        TokensService.setInterfaceSpec(t.tokenInfo.chainId, t.getAddress(), t.getInterfaceSpec());
     }
 
     /**
@@ -638,15 +642,15 @@ public class TokenRepository implements TokenRepositoryType {
                 .fetchTokensWithBalance(wallet);
     }
 
-    private Single<Token> fetchCachedToken(NetworkInfo network, Wallet wallet, String address)
+    private Single<Token> fetchCachedToken(int chainId, Wallet wallet, String address)
     {
         return localSource
-                .fetchEnabledToken(network, wallet, address);
+                .fetchEnabledToken(chainId, wallet, address);
     }
 
     private BigDecimal updatePending(Token oldToken, BigDecimal pendingBalance)
     {
-        if (!tokensService.getCurrentAddress().equals(oldToken.getWallet()))
+        if (!TokensService.getCurrentWalletAddress().equals(oldToken.getWallet()))
         {
             oldToken.pendingBalance = oldToken.balance;
         }

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -23,7 +23,7 @@ public interface TokenRepositoryType {
     Observable<Token[]> fetchStored(String walletAddress);
     Observable<Token[]> fetchActiveStoredPlusEth(String walletAddress);
     Observable<Token> fetchActiveSingle(String walletAddress, Token token);
-    Observable<Token> fetchCachedSingleToken(NetworkInfo network, String walletAddress, String tokenAddress);
+    Observable<Token> fetchCachedSingleToken(int chainId, String walletAddress, String tokenAddress);
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
     Single<ContractResult> getTokenResponse(String address, int chainId, String method);
     Completable setEnable(Wallet wallet, Token token, boolean isEnabled);
@@ -36,6 +36,7 @@ public interface TokenRepositoryType {
     Single<TokenTicker> getTokenTicker(Token token);
     Single<Token> getEthBalance(NetworkInfo network, Wallet wallet);
     Single<BigInteger> fetchLatestBlockNumber(int chainId);
+    Token fetchToken(int chainId, String walletAddress, String address);
 
     Disposable terminateToken(Token token, Wallet wallet, NetworkInfo network);
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -167,18 +167,22 @@ public class TokensRealmSource implements TokenLocalSource {
     }
 
     @Override
-    public Single<Token> fetchEnabledToken(NetworkInfo networkInfo, Wallet wallet, String address) {
-        return Single.fromCallable(() -> {
-            try (Realm realm = realmManager.getRealmInstance(wallet))
-            {
-                RealmToken realmItem = realm.where(RealmToken.class)
-                        .equalTo("address", databaseKey(networkInfo.chainId, address))
-                        .equalTo("chainId", networkInfo.chainId)
-                        .findFirst();
+    public Single<Token> fetchEnabledToken(int chainId, Wallet wallet, String address) {
+        return Single.fromCallable(() -> fetchToken(chainId, wallet, address));
+    }
 
-                return convertSingle(realmItem, realm, null, wallet);
-            }
-        });
+    @Override
+    public Token fetchToken(int chainId, Wallet wallet, String address)
+    {
+        try (Realm realm = realmManager.getRealmInstance(wallet))
+        {
+            RealmToken realmItem = realm.where(RealmToken.class)
+                    .equalTo("address", databaseKey(chainId, address))
+                    .equalTo("chainId", chainId)
+                    .findFirst();
+
+            return convertSingle(realmItem, realm, null, wallet);
+        }
     }
 
     @Override


### PR DESCRIPTION
If token not found in the memory cache then try loading from Realm. Also allows retrieval of tokens before initialisation which fixes #1281 

Remove tokensService from backbone TokenRepositories service & allow retrieval of tokens (and update) direct from realm.

This PR is first in the series of decoupling Token display in the wallet similar to the Transactions view. This is beneficial for handling wallets with large numbers of tokens and also for encapsulating for testing etc.