### PR TITLE
Refactor ERC721 token select. 

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/ContractType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/ContractType.java
@@ -19,5 +19,6 @@ public enum ContractType
     DELETED_ACCOUNT,
     ERC721_LEGACY,
     ERC721_TICKET,
+    ERC721_UNDETERMINED, //when we receive an ERC721 we don't know what kind it is
     CREATION //Placeholder for generic, should be at end of list
 }

--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -66,11 +66,6 @@ public class EtherscanTransaction
             ContractType type = decoder.getContractType(input);
             ct.decimals = type.ordinal();
 
-            if (type != ContractType.OTHER)
-            {
-                TokensService.setInterfaceSpec(chainId, contractAddress, type);
-            }
-
             input = "Constructor"; //Placeholder - don't consume storage for the constructor
         }
         else

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
@@ -131,6 +131,7 @@ public class TokenFactory
                 break;
             case ERC721:
             case ERC721_LEGACY:
+            case ERC721_UNDETERMINED:
                 thisToken = new ERC721Token(tokenInfo, new ArrayList<Asset>(), currentTime, networkName, type);
                 break;
             case ETHEREUM:

--- a/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
+++ b/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
@@ -3,12 +3,10 @@ package com.alphawallet.app.service;
 import android.content.Context;
 import android.util.Log;
 
-import com.alphawallet.app.entity.tokens.ERC721Ticket;
 import com.alphawallet.app.entity.tokens.TokenFactory;
 import com.google.gson.Gson;
 import io.reactivex.Single;
 import com.alphawallet.app.entity.ContractType;
-import com.alphawallet.app.entity.tokens.ERC721Token;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenInfo;
 import com.alphawallet.app.entity.opensea.Asset;
@@ -18,10 +16,7 @@ import okhttp3.Request;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +77,7 @@ public class OpenseaService {
                     TokenInfo tInfo;
                     ContractType type;
                     Token checkToken = tokensService.getToken(networkId, asset.getAssetContract().getAddress());
-                    if (checkToken != null && checkToken.getInterfaceSpec() == ContractType.ERC721_TICKET)
+                    if (checkToken != null)
                     {
                         tInfo = checkToken.tokenInfo;
                         type = checkToken.getInterfaceSpec();
@@ -90,7 +85,7 @@ public class OpenseaService {
                     else
                     {
                         tInfo = new TokenInfo(asset.getAssetContract().getAddress(), asset.getAssetContract().getName(), asset.getAssetContract().getSymbol(), 0, true, networkId);
-                        type = ContractType.ERC721;
+						type = ContractType.ERC721_UNDETERMINED;
                     }
 
                     token = tf.createToken(tInfo, type, networkName);


### PR DESCRIPTION
NOTE: This PR goes in AFTER 'Direct-DB-Load' #1291 

General code improvements - when reading from OpenSea we don't know what type of ERC721 so mark as ERC721_UNDETERMINED when we first see it. 
This type acts as a flag for the resolution code to know the type hasn't been fully identified yet.

This way of resolving makes the code cleaner.