### PR TITLE
Refactor Token Type Correction

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/ContractType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/ContractType.java
@@ -19,5 +19,6 @@ public enum ContractType
     DELETED_ACCOUNT,
     ERC721_LEGACY,
     ERC721_TICKET,
+    ERC721_UNDETERMINED, //when we receive an ERC721 we don't know what kind it is
     CREATION //Placeholder for generic, should be at end of list
 }

--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -65,12 +65,6 @@ public class EtherscanTransaction
             isConstructor = true;
             ContractType type = decoder.getContractType(input);
             ct.decimals = type.ordinal();
-
-            if (type != ContractType.OTHER)
-            {
-                TokensService.setInterfaceSpec(chainId, contractAddress, type);
-            }
-
             input = "Constructor"; //Placeholder - don't consume storage for the constructor
         }
         else

--- a/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
@@ -33,5 +33,5 @@ public interface TokenLocalSource {
     Single<Token[]> saveERC20Tokens(Wallet wallet, Token[] tokens);
     void deleteRealmToken(int chainId, Wallet wallet, String address);
 
-    void updateTokenType(Token token, Wallet wallet, ContractType type);
+    Token updateTokenType(Token token, Wallet wallet, ContractType type);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -368,9 +368,9 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
-    public void updateTokenType(Token token, Wallet wallet, ContractType type)
+    public Token updateTokenType(Token token, Wallet wallet, ContractType type)
     {
-        localSource.updateTokenType(token, wallet, type);
+        return localSource.updateTokenType(token, wallet, type);
     }
 
     @Override
@@ -1303,6 +1303,7 @@ public class TokenRepository implements TokenRepositoryType {
             }
             catch (Exception e)
             {
+                e.printStackTrace();
                 //
             }
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -48,7 +48,7 @@ public interface TokenRepositoryType {
     Single<ContractType> determineCommonType(TokenInfo tokenInfo);
     Single<Token[]> addERC20(Wallet wallet, Token[] tokens);
 
-    void updateTokenType(Token token, Wallet wallet, ContractType type);
+    Token updateTokenType(Token token, Wallet wallet, ContractType type);
     Single<Token[]> storeTickers(Wallet wallet, Token[] tokens);
 
     Single<Boolean> fetchIsRedeemed(Token token, BigInteger tokenId);

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -109,7 +109,7 @@ public class TokensRealmSource implements TokenLocalSource {
     }
 
     @Override
-    public void updateTokenType(Token token, Wallet wallet, ContractType type)
+    public Token updateTokenType(Token token, Wallet wallet, ContractType type)
     {
         try (Realm realm = realmManager.getRealmInstance(wallet))
         {
@@ -128,6 +128,8 @@ public class TokensRealmSource implements TokenLocalSource {
                 realmToken.setInterfaceSpec(type.ordinal());
                 realm.commitTransaction();
             }
+
+            return fetchToken(token.tokenInfo.chainId, wallet, token.getAddress());
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
+++ b/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
@@ -3,12 +3,10 @@ package com.alphawallet.app.service;
 import android.content.Context;
 import android.util.Log;
 
-import com.alphawallet.app.entity.tokens.ERC721Ticket;
 import com.alphawallet.app.entity.tokens.TokenFactory;
 import com.google.gson.Gson;
 import io.reactivex.Single;
 import com.alphawallet.app.entity.ContractType;
-import com.alphawallet.app.entity.tokens.ERC721Token;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenInfo;
 import com.alphawallet.app.entity.opensea.Asset;
@@ -18,10 +16,7 @@ import okhttp3.Request;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +77,7 @@ public class OpenseaService {
                     TokenInfo tInfo;
                     ContractType type;
                     Token checkToken = tokensService.getToken(networkId, asset.getAssetContract().getAddress());
-                    if (checkToken != null && checkToken.getInterfaceSpec() == ContractType.ERC721_TICKET)
+                    if (checkToken != null)
                     {
                         tInfo = checkToken.tokenInfo;
                         type = checkToken.getInterfaceSpec();
@@ -90,7 +85,7 @@ public class OpenseaService {
                     else
                     {
                         tInfo = new TokenInfo(asset.getAssetContract().getAddress(), asset.getAssetContract().getName(), asset.getAssetContract().getSymbol(), 0, true, networkId);
-                        type = ContractType.ERC721;
+						type = ContractType.ERC721_UNDETERMINED;
                     }
 
                     token = tf.createToken(tInfo, type, networkName);

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -5,6 +5,7 @@ import android.util.SparseArray;
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.ContractResult;
 import com.alphawallet.app.entity.ContractType;
+import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenTicker;
 import com.alphawallet.app.interact.GenericWalletInteract;
@@ -93,8 +94,13 @@ public class TokensService
             tokenMap.put(t.getAddress(), tokenAddr);
         }
 
+        if (updatedSpec(t))
+        {
+            //store new spec in DB
+            t = tokenRepository.updateTokenType(t, new Wallet(currentAddress), t.getInterfaceSpec());
+        }
+
         tokenAddr.put(chainId, t);
-        updatedSpec(t);
     }
 
     public Token getToken(int chainId, String addr)


### PR DESCRIPTION
NOTE: Goes in after #1292 Refactor-ERC721-Select.

This PR goes over the code that updates token types if we discover the type is incorrect. When the token is updated (balance check etc) the TokensService will immediately update the Realm with the new type and change the base token type in the memory cache.

This stops any flicking between token types.

