### PR TITLE
Fix database name case issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/KeystoreAccountService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeystoreAccountService.java
@@ -163,7 +163,8 @@ public class KeystoreAccountService implements AccountKeystoreService
             {
                 for (File f : contents)
                 {
-                    if (f.getName().contains(cleanedAddr))
+                    String fileName = f.getName().toLowerCase();
+                    if (fileName.contains(cleanedAddr.toLowerCase()))
                     {
                         deleteRecursive(f);
                     }

--- a/app/src/main/java/com/alphawallet/app/service/RealmManager.java
+++ b/app/src/main/java/com/alphawallet/app/service/RealmManager.java
@@ -16,7 +16,7 @@ public class RealmManager {
     private final Map<String, RealmConfiguration> realmConfigurations = new HashMap<>();
 
     public String getRealmInstanceName(Wallet wallet) {
-        return wallet.address + "-db.realm";
+        return wallet.address.toLowerCase() + "-db.realm";
     }
 
     public Realm getRealmInstance(Wallet wallet) {
@@ -63,7 +63,7 @@ public class RealmManager {
 
     public Realm getAuxRealmInstance(String walletAddress)
     {
-        String name = "AuxData-" + walletAddress + "-db.realm";
+        String name = "AuxData-" + walletAddress.toLowerCase() + "-db.realm";
         return getRealmInstance(name);
     }
 }


### PR DESCRIPTION
NOTE: Goes in after #1293 Refator token type selection.

Ensure Realm files in the protected area have normalised names (all lower case).
When removing an account, delete all matching files (upper and lower case).

Can lead to multiple databases and false-negatives otherwise.

The wallet will self-correct once this PR goes through, and it resolves some update issues seen previously.