### PR TITLE
Update Web3j

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ project.ext {
     okhttpVersion = "4.0.0"
     picassoVersion = "2.71828"
     supportVersion = "28.0.0"
-    web3jVersion = "4.2.0-android"
+    web3jVersion = "4.2.1-android"
     gsonVersion = "2.8.5"
     rxJavaVersion = "2.2.10"
     rxAndroidVersion = "2.1.1"

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -41,7 +41,6 @@ public abstract class C {
     public static final String ARTIS_TAU1_SYMBOL = "ATS";
 
     public static final String BURN_ADDRESS = "0x0000000000000000000000000000000000000000";
-    public static final String ENSCONTRACT = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
     public static final String GWEI_UNIT = "Gwei";
 


### PR DESCRIPTION
Fixes ENS resolution for new registry contract.

Remove old ENSCONTRACT definition as a source of confusion where the ENS contract address lives (within web3j).