### PR TITLE
Add obsoletion notification for users running on <= Android 6.0 (Marshmallow)

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -3,10 +3,10 @@ package com.alphawallet.app.ui;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,13 +26,13 @@ import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.viewmodel.NewSettingsViewModel;
 import com.alphawallet.app.viewmodel.NewSettingsViewModelFactory;
+import com.alphawallet.app.widget.NotificationView;
 import com.alphawallet.app.widget.SettingsItemView;
 
 import javax.inject.Inject;
 
 import dagger.android.support.AndroidSupportInjection;
 
-import static com.alphawallet.app.C.EXTRA_ADDRESS;
 import static com.alphawallet.app.C.Key.WALLET;
 import static com.alphawallet.token.tools.TokenDefinition.TOKENSCRIPT_CURRENT_SCHEMA;
 
@@ -62,6 +62,7 @@ public class NewSettingsFragment extends BaseFragment {
     private TextView backupDetail;
     private ImageView backupMenuButton;
     private View backupPopupAnchor;
+    private NotificationView notificationView;
 
     private Wallet wallet;
 
@@ -87,7 +88,20 @@ public class NewSettingsFragment extends BaseFragment {
 
         initBackupWarningViews(view);
 
+        initNotificationView(view);
+
         return view;
+    }
+
+    private void initNotificationView(View view) {
+        notificationView = view.findViewById(R.id.notification);
+        if (android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+            notificationView.setNotificationBackgroundColor(R.color.indigo);
+            notificationView.setTitle(getContext().getString(R.string.title_version_support_warning));
+            notificationView.setMessage(getContext().getString(R.string.message_version_support_warning));
+        } else {
+            notificationView.setVisibility(View.GONE);
+        }
     }
 
     private void initBackupWarningViews(View view) {

--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -2,11 +2,14 @@ package com.alphawallet.app.ui;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Canvas;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
@@ -43,6 +46,7 @@ import com.alphawallet.app.ui.widget.holder.WarningHolder;
 import com.alphawallet.app.util.TabUtils;
 import com.alphawallet.app.viewmodel.WalletViewModel;
 import com.alphawallet.app.viewmodel.WalletViewModelFactory;
+import com.alphawallet.app.widget.NotificationView;
 import com.alphawallet.app.widget.ProgressView;
 import com.alphawallet.app.widget.SystemView;
 
@@ -118,6 +122,8 @@ public class WalletFragment extends BaseFragment implements
         initTabLayout(view);
 
         viewModel.clearProcess();
+
+        initNotificationView(view);
 
         return view;
     }
@@ -598,5 +604,25 @@ public class WalletFragment extends BaseFragment implements
             viewModel.showAddToken(getContext());
         }
         return super.onMenuItemClick(menuItem);
+    }
+
+    private void initNotificationView(View view) {
+        final String key = "marshmallow_version_support_warning_shown";
+        NotificationView notificationView = view.findViewById(R.id.notification);
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getContext());
+        boolean hasShownWarning = pref.getBoolean(key, false);
+
+        if (!hasShownWarning && android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+            notificationView.setNotificationBackgroundColor(R.color.indigo);
+            notificationView.setTitle(getContext().getString(R.string.title_version_support_warning));
+            notificationView.setMessage(getContext().getString(R.string.message_version_support_warning));
+            notificationView.setPrimaryButtonText(getContext().getString(R.string.hide_notification));
+            notificationView.setPrimaryButtonListener(() -> {
+                notificationView.setVisibility(View.GONE);
+                pref.edit().putBoolean(key, true).apply();
+            });
+        } else {
+            notificationView.setVisibility(View.GONE);
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/widget/NotificationView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/NotificationView.java
@@ -1,0 +1,213 @@
+package com.alphawallet.app.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import com.alphawallet.app.R;
+import com.alphawallet.app.util.Utils;
+
+public class NotificationView extends LinearLayout {
+    private RelativeLayout layout;
+    private TextView title;
+    private TextView message;
+    private Button primaryButton;
+    private Button secondaryButton;
+    private int backgroundColorRes;
+    private int textColorRes;
+
+    public static class Builder {
+        private Context context;
+        private int backgroundColorRes = -1;
+        private int textColorRes = -1;
+        private int titleRes = -1;
+        private int messageRes = -1;
+        private int primaryButtonTextRes = -1;
+        private int secondaryButtonTextRes = -1;
+        private OnPrimaryButtonClickListener primaryButtonClickListener;
+        private OnSecondaryButtonClickListener secondaryButtonClickListener;
+
+        public Builder(Context context) {
+            this.context = context;
+        }
+
+        public Builder setTitle(int titleRes) {
+            this.titleRes = titleRes;
+            return this;
+        }
+
+        public Builder setMessage(int messageRes) {
+            this.messageRes = messageRes;
+            return this;
+        }
+
+        public Builder setBackgroundColor(int backgroundColorRes) {
+            this.backgroundColorRes = backgroundColorRes;
+            return this;
+        }
+
+        public Builder setTextColor(int textColorRes) {
+            this.textColorRes = textColorRes;
+            return this;
+        }
+
+        public Builder setPrimaryButtonText(int primaryButtonTextRes) {
+            this.primaryButtonTextRes = primaryButtonTextRes;
+            return this;
+        }
+
+        public Builder setSecondaryButtonText(int secondaryButtonTextRes) {
+            this.secondaryButtonTextRes = secondaryButtonTextRes;
+            return this;
+        }
+
+        public Builder setPrimaryButtonClickListener(OnPrimaryButtonClickListener listener) {
+            this.primaryButtonClickListener = listener;
+            return this;
+        }
+
+        public Builder setSecondaryButtonClickListener(OnSecondaryButtonClickListener listener) {
+            this.secondaryButtonClickListener = listener;
+            return this;
+        }
+
+        public NotificationView build() {
+            NotificationView view = new NotificationView(context);
+            view.setTitle(context.getString(titleRes));
+            view.setMessage(context.getString(messageRes));
+            view.setNotificationBackgroundColor(backgroundColorRes);
+            view.setNotificationTextColor(textColorRes);
+            if (primaryButtonTextRes != -1) {
+                view.setPrimaryButtonText(context.getString(primaryButtonTextRes));
+                view.setPrimaryButtonListener(primaryButtonClickListener);
+            }
+
+            if (secondaryButtonTextRes != -1) {
+                view.setSecondaryButtonText(context.getString(secondaryButtonTextRes));
+                view.setSecondaryButtonListener(secondaryButtonClickListener);
+            }
+            return view;
+        }
+    }
+
+    public interface OnPrimaryButtonClickListener {
+        void onPrimaryButtonClicked();
+    }
+
+    public interface OnSecondaryButtonClickListener {
+        void onSecondaryButtonClicked();
+    }
+
+    public NotificationView(Context context) {
+        this(context, null);
+    }
+
+    public NotificationView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        inflate(context, R.layout.layout_notification_view, this);
+
+        setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+
+        initializeViews();
+
+        processAttrs(context, attrs);
+    }
+
+    private void processAttrs(Context context, AttributeSet attrs) {
+        if (attrs != null) {
+            getAttrs(context, attrs);
+            if (backgroundColorRes != -1) {
+                setNotificationBackgroundColor(backgroundColorRes);
+            }
+
+            if (textColorRes != -1) {
+                setNotificationTextColor(textColorRes);
+            }
+        }
+    }
+
+    private void initializeViews() {
+        layout = findViewById(R.id.layout);
+        title = findViewById(R.id.title);
+        message = findViewById(R.id.message);
+        primaryButton = findViewById(R.id.btn_primary);
+        secondaryButton = findViewById(R.id.btn_secondary);
+    }
+
+    private void getAttrs(Context context, AttributeSet attrs) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attrs,
+                R.styleable.NotificationView,
+                0, 0
+        );
+
+        try {
+            backgroundColorRes = a.getResourceId(R.styleable.NotificationView_backgroundColor, -1);
+            textColorRes = a.getResourceId(R.styleable.NotificationView_textColor, -1);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    public void setPrimaryButtonListener(OnPrimaryButtonClickListener listener) {
+        if (listener != null) {
+            primaryButton.setOnClickListener(v -> {
+                listener.onPrimaryButtonClicked();
+            });
+        }
+    }
+
+    public void setSecondaryButtonListener(OnSecondaryButtonClickListener listener) {
+        if (listener != null) {
+            secondaryButton.setOnClickListener(v -> {
+                listener.onSecondaryButtonClicked();
+            });
+        }
+    }
+
+    public void setTitle(String titleText) {
+        title.setText(titleText);
+    }
+
+    public void setMessage(String messageText) {
+        message.setText(messageText);
+    }
+
+    public void setPrimaryButtonText(String primaryButtonText) {
+        if (!primaryButtonText.isEmpty()) {
+            primaryButton.setVisibility(View.VISIBLE);
+            primaryButton.setText(primaryButtonText);
+        } else {
+            primaryButton.setVisibility(View.GONE);
+        }
+    }
+
+    public void setSecondaryButtonText(String secondaryButtonText) {
+        if (!secondaryButtonText.isEmpty()) {
+            secondaryButton.setVisibility(View.VISIBLE);
+            secondaryButton.setText(secondaryButtonText);
+        } else {
+            secondaryButton.setVisibility(View.GONE);
+        }
+    }
+
+    public void setNotificationBackgroundColor(int backgroundColorRes) {
+        layout.setBackgroundTintList(ContextCompat.getColorStateList(getContext(), backgroundColorRes));
+    }
+
+    public void setNotificationTextColor(int textColorRes) {
+        title.setTextColor(textColorRes);
+        message.setTextColor(textColorRes);
+        primaryButton.setTextColor(textColorRes);
+        secondaryButton.setTextColor(textColorRes);
+    }
+}
+

--- a/app/src/main/res/drawable/background_bottom_border.xml
+++ b/app/src/main/res/drawable/background_bottom_border.xml
@@ -4,7 +4,7 @@
         <shape android:shape="rectangle">
             <stroke
                 android:width="1dp"
-                android:color="@color/onboarding_indicator_unselected" />
+                android:color="@color/mercury" />
             <padding
                 android:bottom="0dip"
                 android:left="0dip"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -18,6 +18,12 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
+            <com.alphawallet.app.widget.NotificationView
+                android:id="@+id/notification"
+                android:layout_width="match_parent"
+                android:background="@drawable/background_bottom_border"
+                android:layout_height="wrap_content" />
+
             <include layout="@layout/item_warning" />
 
             <View

--- a/app/src/main/res/layout/fragment_wallet.xml
+++ b/app/src/main/res/layout/fragment_wallet.xml
@@ -40,6 +40,12 @@
             app:tabTextAppearance="@style/WalletTabTextAppearance"
             app:tabTextColor="@color/dove" />
 
+        <com.alphawallet.app.widget.NotificationView
+            android:id="@+id/notification"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/background_bottom_border" />
+
     </android.support.design.widget.AppBarLayout>
 
     <android.support.v4.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/layout_notification_view.xml
+++ b/app/src/main/res/layout/layout_notification_view.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:layout_weight="0.9"
+    android:animateLayoutChanges="true"
+    android:background="@drawable/background_round_nofill_8dp"
+    android:clickable="true"
+    android:elevation="2dp"
+    android:focusable="true"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingTop="23dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="25dp">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="16dp"
+        android:fontFamily="@font/font_regular"
+        android:text="Notification"
+        android:textColor="@color/white"
+        android:textSize="24sp" />
+
+    <TextView
+        android:id="@+id/message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/title"
+        android:layout_marginEnd="70dp"
+        android:fontFamily="@font/font_regular"
+        android:text="This is a notification"
+        android:textColor="@color/white"
+        android:textSize="17sp" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/message"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/btn_primary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginRight="15dp"
+            android:background="@drawable/background_white_4dp"
+            android:fontFamily="@font/font_semibold"
+            android:paddingLeft="17dp"
+            android:paddingRight="17dp"
+            android:text="Primary"
+            android:textAllCaps="false"
+            android:textColor="@color/white"
+            android:textSize="17sp"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/btn_secondary"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:fontFamily="@font/font_semibold"
+            android:paddingLeft="17dp"
+            android:paddingRight="17dp"
+            android:text="Secondary"
+            android:textAllCaps="false"
+            android:textColor="@color/white"
+            android:textSize="17sp"
+            android:visibility="gone" />
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -578,4 +578,7 @@
     <string name="settings_locale_currency">Change Currency</string>
     <string name="dialog_title_select_currency">Select FIAT Currency</string>
     <string name="your_wallets">Your Wallets</string>
+    <string name="title_version_support_warning">Important Update</string>
+    <string name="message_version_support_warning">Starting Version 2.3, AlphaWallet will no longer support devices running on Android 6.0 and below.</string>
+    <string name="hide_notification">Hide Notification</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -567,4 +567,7 @@
     <string name="settings_locale_currency">Change Currency</string>
     <string name="dialog_title_select_currency">Select FIAT Currency</string>
     <string name="your_wallets">Your Wallets</string>
+    <string name="title_version_support_warning">Important Update</string>
+    <string name="message_version_support_warning">Starting Version 2.3, AlphaWallet will no longer support devices running on Android 6.0 and below.</string>
+    <string name="hide_notification">Hide Notification</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -6,6 +6,10 @@
         <attr name="settingSubtitle" format="integer" />
         <attr name="settingType" format="string" />
     </declare-styleable>
+    <declare-styleable name="NotificationView">
+        <attr name="backgroundColor" format="integer" />
+        <attr name="textColor" format="integer" />
+    </declare-styleable>
     <declare-styleable name="InputAddressView" />
     <declare-styleable name="InputView">
         <attr name="label" format="integer" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,4 +580,7 @@
     <string name="toast_browser_cache_cleared">Browser cache cleared</string>
     <string name="your_wallets">Your Wallets</string>
     <string name="action_copy">Copy</string>
+    <string name="title_version_support_warning">Important Update</string>
+    <string name="message_version_support_warning">Starting Version 2.3, AlphaWallet will no longer support devices running on Android 6.0 and below.</string>
+    <string name="hide_notification">Hide Notification</string>
 </resources>


### PR DESCRIPTION
Closes #1264 

- Created a customizable Notification View (with optional Primary and Secondary buttons)
- Adds a check if a user is running Android 6 (API 23) or below. A notification will be displayed in the Wallet Screen until a user taps on "Hide Notification". A similar and permanent (no Hide button) message will be displayed in the Settings page as per requirement.