### PR TITLE
Clean out redundant DApp Signing code

### DIFF
--- a/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
@@ -44,24 +44,6 @@ public class CreateTransactionInteract
                                              .observeOn(AndroidSchedulers.mainThread());
     }
 
-    /**
-     *
-     * For constructors
-     *
-     * @param from
-     * @param gasPrice
-     * @param gasLimit
-     * @param data
-     * @param chainId
-     * @return
-     */
-    public Single<String> create(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, int chainId)
-    {
-        return transactionRepository.createTransaction(from, gasPrice, gasLimit, data, chainId)
-                                         .subscribeOn(Schedulers.computation())
-                                         .observeOn(AndroidSchedulers.mainThread());
-    }
-
     public Single<TransactionData> createWithSig(Wallet from, String to, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, int chainId)
     {
         return transactionRepository.createTransactionWithSig(from, to, subunitAmount, gasPrice, gasLimit, data, chainId)

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
@@ -19,7 +19,6 @@ public interface TransactionRepositoryType {
 	Observable<Transaction[]> fetchCachedTransactions(Wallet wallet, int maxTransactions, List<Integer> networkFilters);
 	Observable<Transaction[]> fetchNetworkTransaction(NetworkInfo network, String tokenAddress, long lastBlock, String userAddress);
 	Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, int chainId);
-	Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, int chainId);
 	Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, int chainId);
 	Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, int chainId);
 	Single<SignatureFromKey> getSignature(Wallet wallet, byte[] message, int chainId);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -170,37 +170,6 @@ public class DappBrowserViewModel extends BaseViewModel  {
                            error -> dAppFunction.DAppError(error, message));
     }
 
-    public void signTransaction(Web3Transaction transaction, DAppFunction dAppFunction, String url)
-    {
-        Message errorMsg = new Message<>("Error executing transaction", url, 0);
-
-        BigInteger addr = Numeric.toBigInt(transaction.recipient.toString());
-
-        if (addr.equals(BigInteger.ZERO)) //constructor
-        {
-            disposable = createTransactionInteract
-                    .create(defaultWallet.getValue(), transaction.gasPrice, transaction.gasLimit, transaction.payload, defaultNetwork.getValue().chainId)
-                    .subscribe(hash -> onCreateTransaction(hash, dAppFunction, url),
-                               error -> dAppFunction.DAppError(error, errorMsg));
-
-        }
-        else
-        {
-            byte[] data = Numeric.hexStringToByteArray(transaction.payload);
-            disposable = createTransactionInteract
-                    .create(defaultWallet.getValue(), transaction.recipient.toString(), transaction.value, transaction.gasPrice, transaction.gasLimit, data, defaultNetwork.getValue().chainId)
-                    .subscribe(hash -> onCreateTransaction(hash, dAppFunction, url),
-                               error -> dAppFunction.DAppError(error, errorMsg));
-        }
-    }
-
-    private void onCreateTransaction(String s, DAppFunction dAppFunction, String url)
-    {
-        //pushed transaction
-        Message<String> msg = new Message<>(s, url, 0);
-        dAppFunction.DAppReturn(s.getBytes(), msg);
-    }
-
     public void openConfirmation(Activity context, Web3Transaction transaction, String requesterURL, NetworkInfo networkInfo) throws TransactionTooLargeException
     {
         if (System.currentTimeMillis() > (debounceTime + DEBOUNCE_LIMIT)) //debounce transaction click

--- a/app/src/test/java/com/alphawallet/app/MarketOrderTest.java
+++ b/app/src/test/java/com/alphawallet/app/MarketOrderTest.java
@@ -99,12 +99,6 @@ public class MarketOrderTest
             }
 
             @Override
-            public Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, int chainId)
-            {
-                return null;
-            }
-
-            @Override
             public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, int chainId)
             {
                 return null;

--- a/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
+++ b/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
@@ -84,12 +84,6 @@ public class QRSelectionTest
             }
 
             @Override
-            public Single<String> createTransaction(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, int chainId)
-            {
-                return null;
-            }
-
-            @Override
             public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, int chainId)
             {
                 return null;


### PR DESCRIPTION
Cleaning out some old dapp transaction test code from the early days of DappBrowser implementation, before it confuses any more devs working on the project.

It looks very dangerous too - pushing unchecked transactions directly without confirmation! It was never part of released code and should be removed.