### PR TITLE
Move decode of transaction to within constructor

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -3,17 +3,7 @@ package com.alphawallet.app.entity;
 
 import android.content.Context;
 
-import com.alphawallet.app.C;
-import com.alphawallet.app.repository.EthereumNetworkRepository;
-import com.alphawallet.app.service.TokensService;
-
 import com.alphawallet.token.tools.Numeric;
-import com.alphawallet.token.tools.ParseMagicLink;
-
-import org.web3j.crypto.Keys;
-import org.web3j.crypto.Sign;
-
-import java.math.BigInteger;
 
 /**
  * Created by James on 26/03/2018.
@@ -41,181 +31,19 @@ public class EtherscanTransaction
     int confirmations;
 
     private static TransactionDecoder decoder = null;
-    private static TransactionDecoder ensDecoder = null;
-    private static ParseMagicLink parser = null;
 
     public Transaction createTransaction(String walletAddress, Context ctx, int chainId)
     {
-        boolean isConstructor = false;
-        TransactionOperation[] o;
-        TransactionInput f = null;
-        if (decoder == null) decoder = new TransactionDecoder();
-        if (parser == null) parser = new ParseMagicLink(new CryptoFunctions(), EthereumNetworkRepository.extraChains());
-
-        if (contractAddress.length() > 0)
-        {
-            to = contractAddress;
-            //add a constructor here
-            o = generateERC875Op();
-            TransactionContract ct = o[0].contract;
-            ct.setOperation(TransactionType.CONSTRUCTOR);
-            ct.address = contractAddress;
-            ct.setType(-3);// indicate that we need to load the contract
-            o[0].value = "";
-            isConstructor = true;
-            ContractType type = decoder.getContractType(input);
-            ct.decimals = type.ordinal();
-            input = "Constructor"; //Placeholder - don't consume storage for the constructor
-        }
-        else
-        {
-            //Now perform as complete processing as we are able to here. This saves re-allocating and makes code far less brittle.
-            o = new TransactionOperation[0];
-
-            if (input != null && input.length() >= 10)
-            {
-                TransactionOperation op = null;
-                TransactionContract ct = null;
-
-                f = decoder.decodeInput(input);
-                //is this a trade?
-                if (f.functionData != null)
-                {
-                    //recover recipient
-                    switch (f.functionData.functionFullName)
-                    {
-                        case "trade(uint256,uint16[],uint8,bytes32,bytes32)":
-                        case "trade(uint256,uint256[],uint8,bytes32,bytes32)":
-                            o = processTrade(f);
-                            op = o[0];
-                            setName(o, TransactionType.MAGICLINK_TRANSFER);
-                            op.contract.address = to;
-                            op.value = String.valueOf(f.paramValues.size());
-                            break;
-                        case "transferFrom(address,address,uint16[])":
-                        case "transferFrom(address,address,uint256[])":
-                            o = generateERC875Op();
-                            op = o[0];
-                            op.contract.setIndicies(f.paramValues);
-                            if (f.containsAddress(C.BURN_ADDRESS))
-                            {
-                                setName(o, TransactionType.REDEEM);
-                            }
-                            else
-                            {
-                                setName(o, TransactionType.TRANSFER_FROM);
-                            }
-                            op.contract.setType(-1);
-                            op.contract.address = to;
-                            op.contract.setOtherParty(f.getFirstAddress());
-                            op.value = String.valueOf(f.paramValues.size());
-                            op.to = f.getAddress(1);
-                            break;
-                        case "transfer(address,uint16[])":
-                        case "transfer(address,uint256[])":
-                            o = generateERC875Op();
-                            op = o[0];
-                            op.contract.setOtherParty(f.getFirstAddress());
-                            op.contract.setIndicies(f.paramValues);
-                            setName(o, TransactionType.TRANSFER_TO);
-                            op.value = String.valueOf(f.paramValues.size());
-                            op.contract.address = to;
-                            break;
-                        case "transfer(address,uint256)":
-                            o = generateERC20Op();
-                            op = o[0];
-                            op.from = from;
-                            op.to = f.getFirstAddress();
-                            op.value = String.valueOf(f.getFirstValue(ctx));
-                            op.contract.address = to;
-                            setName(o, TransactionType.TRANSFER_TO);
-                            break;
-                        case "transferFrom(address,address,uint256)":
-                            o = generateERC20Op();
-                            op = o[0];
-                            op.from = f.getFirstAddress();
-                            op.to = f.getAddress(1);
-                            op.value = String.valueOf(f.getFirstValue(ctx));
-                            op.contract.address = to;
-                            setName(o, TransactionType.TRANSFER_FROM);
-                            op.contract.setType(1);
-                            break;
-                        case "allocateTo(address,uint256)":
-                            o = generateERC20Op();
-                            op = o[0];
-                            op.from = from;
-                            op.to = f.getFirstAddress();
-                            op.value = String.valueOf(f.getFirstValue(ctx));
-                            op.contract.address = to;
-                            setName(o, TransactionType.ALLOCATE_TO);
-                            break;
-                        case "approve(address,uint256)":
-                            o = generateERC20Op();
-                            op = o[0];
-                            op.from = from;
-                            op.to = f.getFirstAddress();
-                            op.value = String.valueOf(f.getFirstValue(ctx));
-                            op.contract.address = to;
-                            setName(o, TransactionType.APPROVE);
-                            break;
-                        case "loadNewTickets(bytes32[])":
-                        case "loadNewTickets(uint256[])":
-                            o = generateERC875Op();
-                            op = o[0];
-                            op.from = from;
-                            op.value = String.valueOf(f.paramValues.size());
-                            op.contract.address = to;
-                            setName(o, TransactionType.LOAD_NEW_TOKENS);
-                            op.contract.setType(1);
-                            break;
-                        case "passTo(uint256,uint16[],uint8,bytes32,bytes32,address)":
-                        case "passTo(uint256,uint256[],uint8,bytes32,bytes32,address)":
-                            o = processPassTo(f);
-                            op = o[0];
-                            op.from = from;
-                            op.to = f.getFirstAddress();
-                            op.value = String.valueOf(f.paramValues.size());
-                            op.contract.address = to;
-                            setName(o, TransactionType.PASS_TO);
-                            op.contract.setType(-1);
-                            break;
-                        case "endContract()":
-                        case "selfdestruct()":
-                        case "kill()":
-                            o = generateERC875Op();
-                            op = o[0];
-                            ct = op.contract;
-                            ct.setOperation(TransactionType.TERMINATE_CONTRACT);
-                            ct.name = to;
-                            ct.setType(-2);
-                            setName(o, TransactionType.TERMINATE_CONTRACT);
-                            op.value = "";
-                            ct.address = to;
-                            break;
-                        default:
-                            break;
-                    }
-
-                    if (op != null)
-                    {
-                        op.transactionId = hash;
-                    }
-                }
-            }
-        }
-
         Transaction tx = new Transaction(hash, isError, blockNumber, timeStamp, nonce, from, to, value, gas, gasPrice, input,
-            gasUsed, chainId, o);
+                                         gasUsed, chainId, contractAddress);
 
-        if (o.length > 0)
+        if (tx.operations.length > 0)
         {
-            TransactionOperation op = o[0];
+            TransactionOperation op = tx.operations[0];
             if (op.contract != null) op.contract.completeSetup(walletAddress, tx);
         }
 
-        tx.isConstructor = isConstructor;
-
-        if (walletAddress != null && !walletInvolvedInTransaction(tx, f, walletAddress))
+        if (walletAddress != null && !walletInvolvedInTransaction(tx, walletAddress))
         {
             tx = null; //this transaction is not relevant to the wallet we're scanning for
         }
@@ -223,91 +51,10 @@ public class EtherscanTransaction
         return tx;
     }
 
-    private TransactionOperation[] generateERC20Op()
+    private boolean walletInvolvedInTransaction(Transaction trans, String walletAddr)
     {
-        TransactionOperation[] o = new TransactionOperation[1];
-        TransactionOperation op = new TransactionOperation();
-        TransactionContract ct = new TransactionContract();
-        o[0] = op;
-        op.contract = ct;
-        return o;
-    }
-
-    private TransactionOperation[] generateERC875Op()
-    {
-        TransactionOperation[] o = new TransactionOperation[1];
-        TransactionOperation op = new TransactionOperation();
-        ERC875ContractTransaction ct = new ERC875ContractTransaction();
-        o[0] = op;
-        op.contract = ct;
-        return o;
-    }
-
-    private TransactionOperation[] processPassTo(TransactionInput f)
-    {
-        TransactionOperation[] o = processTrade(f);
-        if (o.length > 0)
-        {
-            o[0].contract.totalSupply = f.getFirstAddress(); //store destination address for this passTo. We don't use totalSupply for anything else in this case
-        }
-
-        return o;
-    }
-
-    private TransactionOperation[] processTrade(TransactionInput f)
-    {
-        TransactionOperation[] o;
-        try
-        {
-            Sign.SignatureData sig = decoder.getSignatureData(f);
-            //ecrecover the recipient of the ether
-            int[] ticketIndexArray = decoder.getIndices(f);
-            String expiryStr = f.miscData.get(0);
-            long expiry = Long.valueOf(expiryStr, 16);
-            BigInteger priceWei = new BigInteger(value);
-            contractAddress = to;
-            o = generateERC875Op();
-            TransactionOperation op = o[0];
-            TransactionContract ct = op.contract;
-            if (isError.equals("0")) //don't bother checking signature unless the transaction succeeded
-            {
-                byte[] tradeBytes = parser.getTradeBytes(ticketIndexArray, contractAddress, priceWei, expiry);
-                //attempt ecrecover
-                BigInteger key = Sign.signedMessageToKey(tradeBytes, sig);
-                ct.setOtherParty("0x" + Keys.getAddress(key));
-            }
-            ct.address = contractAddress;
-            ct.setIndicies(f.paramValues);
-            ct.name = contractAddress;
-        }
-        catch (Exception e)
-        {
-            o = generateERC875Op();
-            e.printStackTrace();
-        }
-
-        return o;
-    }
-
-    private void setName(TransactionOperation[] o, TransactionType name)
-    {
-        if (o.length > 0 && o[0] != null)
-        {
-            TransactionOperation op = o[0];
-            TransactionContract ct = op.contract;
-            if (ct instanceof ERC875ContractTransaction)
-            {
-                ((ERC875ContractTransaction) ct).operation = name;
-            }
-            else
-            {
-                op.contract.name = "*" + String.valueOf(name.ordinal());
-            }
-        }
-    }
-
-    private boolean walletInvolvedInTransaction(Transaction trans, TransactionInput data, String walletAddr)
-    {
+        if (decoder == null) decoder = new TransactionDecoder();
+        TransactionInput data = decoder.decodeInput(input);
         boolean involved = false;
         if ((data != null && data.functionData != null) && data.containsAddress(walletAddr)) return true;
         if (trans.from.equalsIgnoreCase(walletAddr)) return true;

--- a/app/src/main/java/com/alphawallet/app/entity/Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Transaction.java
@@ -2,9 +2,17 @@ package com.alphawallet.app.entity;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
 
+import com.alphawallet.app.C;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
+import com.alphawallet.token.tools.ParseMagicLink;
 import com.google.gson.annotations.SerializedName;
 
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.Sign;
+
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +47,9 @@ public class Transaction implements Parcelable {
 
     public boolean isConstructor = false;
 
+	private static TransactionDecoder decoder = null;
+	private static ParseMagicLink parser = null;
+
     public Transaction(
             String hash,
             String error,
@@ -68,6 +79,183 @@ public class Transaction implements Parcelable {
 		this.gasUsed = gasUsed;
 		this.chainId = chainId;
 		this.operations = operations;
+	}
+
+	public Transaction(String hash, String isError, String blockNumber, long timeStamp, int nonce, String from, String to,
+					   String value, String gas, String gasPrice, String input, String gasUsed, int chainId, String contractAddress)
+	{
+		//build transaction using input
+		TransactionInput f;
+
+		if (!TextUtils.isEmpty(contractAddress)) //must be a constructor
+		{
+			to = contractAddress;
+			//add a constructor here
+			operations = generateERC875Op();
+			TransactionContract ct = operations[0].contract;
+			ct.setOperation(TransactionType.CONSTRUCTOR);
+			ct.address = contractAddress;
+			ct.setType(-3);// indicate that we need to load the contract
+			operations[0].value = "";
+			isConstructor = true;
+			ContractType type = decoder.getContractType(input);
+			ct.decimals = type.ordinal();
+			input = "Constructor"; //Placeholder - don't consume storage for the constructor
+		}
+		else
+		{
+			//Now perform as complete processing as we are able to here. This saves re-allocating and makes code far less brittle.
+			TransactionOperation[] o = new TransactionOperation[0];
+
+			//TODO: Handle transaction with multiple operations
+			if (input != null && input.length() >= 10)
+			{
+				TransactionOperation op = null;
+				TransactionContract ct;
+
+				if (decoder == null) decoder = new TransactionDecoder(); //initialise decoder on demand
+
+				f = decoder.decodeInput(input);
+				//is this a trade?
+				if (f.functionData != null)
+				{
+					//recover recipient
+					switch (f.functionData.functionFullName)
+					{
+						case "trade(uint256,uint16[],uint8,bytes32,bytes32)":
+						case "trade(uint256,uint256[],uint8,bytes32,bytes32)":
+							o = processTrade(f, contractAddress);
+							op = o[0];
+							setName(o, TransactionType.MAGICLINK_TRANSFER);
+							op.contract.address = to;
+							op.value = String.valueOf(f.paramValues.size());
+							break;
+						case "transferFrom(address,address,uint16[])":
+						case "transferFrom(address,address,uint256[])":
+							o = generateERC875Op();
+							op = o[0];
+							op.contract.setIndicies(f.paramValues);
+							if (f.containsAddress(C.BURN_ADDRESS))
+							{
+								setName(o, TransactionType.REDEEM);
+							}
+							else
+							{
+								setName(o, TransactionType.TRANSFER_FROM);
+							}
+							op.contract.setType(-1);
+							op.contract.address = to;
+							op.contract.setOtherParty(f.getFirstAddress());
+							op.value = String.valueOf(f.paramValues.size());
+							op.to = f.getAddress(1);
+							break;
+						case "transfer(address,uint16[])":
+						case "transfer(address,uint256[])":
+							o = generateERC875Op();
+							op = o[0];
+							op.contract.setOtherParty(f.getFirstAddress());
+							op.contract.setIndicies(f.paramValues);
+							setName(o, TransactionType.TRANSFER_TO);
+							op.value = String.valueOf(f.paramValues.size());
+							op.contract.address = to;
+							break;
+						case "transfer(address,uint256)":
+							o = generateERC20Op();
+							op = o[0];
+							op.from = from;
+							op.to = f.getFirstAddress();
+							op.value = String.valueOf(f.getFirstValue());
+							op.contract.address = to;
+							setName(o, TransactionType.TRANSFER_TO);
+							break;
+						case "transferFrom(address,address,uint256)":
+							o = generateERC20Op();
+							op = o[0];
+							op.from = f.getFirstAddress();
+							op.to = f.getAddress(1);
+							op.value = String.valueOf(f.getFirstValue());
+							op.contract.address = to;
+							setName(o, TransactionType.TRANSFER_FROM);
+							op.contract.setType(1);
+							break;
+						case "allocateTo(address,uint256)":
+							o = generateERC20Op();
+							op = o[0];
+							op.from = from;
+							op.to = f.getFirstAddress();
+							op.value = String.valueOf(f.getFirstValue());
+							op.contract.address = to;
+							setName(o, TransactionType.ALLOCATE_TO);
+							break;
+						case "approve(address,uint256)":
+							o = generateERC20Op();
+							op = o[0];
+							op.from = from;
+							op.to = f.getFirstAddress();
+							op.value = String.valueOf(f.getFirstValue());
+							op.contract.address = to;
+							setName(o, TransactionType.APPROVE);
+							break;
+						case "loadNewTickets(bytes32[])":
+						case "loadNewTickets(uint256[])":
+							o = generateERC875Op();
+							op = o[0];
+							op.from = from;
+							op.value = String.valueOf(f.paramValues.size());
+							op.contract.address = to;
+							setName(o, TransactionType.LOAD_NEW_TOKENS);
+							op.contract.setType(1);
+							break;
+						case "passTo(uint256,uint16[],uint8,bytes32,bytes32,address)":
+						case "passTo(uint256,uint256[],uint8,bytes32,bytes32,address)":
+							o = processPassTo(f, contractAddress);
+							op = o[0];
+							op.from = from;
+							op.to = f.getFirstAddress();
+							op.value = String.valueOf(f.paramValues.size());
+							op.contract.address = to;
+							setName(o, TransactionType.PASS_TO);
+							op.contract.setType(-1);
+							break;
+						case "endContract()":
+						case "selfdestruct()":
+						case "kill()":
+							o = generateERC875Op();
+							op = o[0];
+							ct = op.contract;
+							ct.setOperation(TransactionType.TERMINATE_CONTRACT);
+							ct.name = to;
+							ct.setType(-2);
+							setName(o, TransactionType.TERMINATE_CONTRACT);
+							op.value = "";
+							ct.address = to;
+							break;
+						default:
+							break;
+					}
+
+					if (op != null)
+					{
+						op.transactionId = hash;
+					}
+				}
+			}
+			operations = o;
+		}
+
+		this.to = to;
+		this.hash = hash;
+		this.error = isError;
+		this.blockNumber = blockNumber;
+		this.timeStamp = timeStamp;
+		this.nonce = nonce;
+		this.from = from;
+		this.value = value;
+		this.gas = gas;
+		this.gasPrice = gasPrice;
+		this.input = input;
+		this.gasUsed = gasUsed;
+		this.chainId = chainId;
 	}
 
 	public String getTokenAddress(String walletAddress)
@@ -172,4 +360,89 @@ public class Transaction implements Parcelable {
 		return operations == null
 				|| operations.length == 0 ? null : operations[0].contract;
     }
+
+
+	private TransactionOperation[] generateERC20Op()
+	{
+		TransactionOperation[] o = new TransactionOperation[1];
+		TransactionOperation op = new TransactionOperation();
+		TransactionContract ct = new TransactionContract();
+		o[0] = op;
+		op.contract = ct;
+		return o;
+	}
+
+	private TransactionOperation[] generateERC875Op()
+	{
+		TransactionOperation[] o = new TransactionOperation[1];
+		TransactionOperation op = new TransactionOperation();
+		ERC875ContractTransaction ct = new ERC875ContractTransaction();
+		o[0] = op;
+		op.contract = ct;
+		return o;
+	}
+
+	private TransactionOperation[] processPassTo(TransactionInput f, String contractAddress)
+	{
+		TransactionOperation[] o = processTrade(f, contractAddress);
+		if (o.length > 0)
+		{
+			o[0].contract.totalSupply = f.getFirstAddress(); //store destination address for this passTo. We don't use totalSupply for anything else in this case
+		}
+
+		return o;
+	}
+
+	private TransactionOperation[] processTrade(TransactionInput f, String contractAddress)
+	{
+		TransactionOperation[] o;
+		try
+		{
+			Sign.SignatureData sig = decoder.getSignatureData(f);
+			//ecrecover the recipient of the ether
+			int[] ticketIndexArray = decoder.getIndices(f);
+			String expiryStr = f.miscData.get(0);
+			long expiry = Long.valueOf(expiryStr, 16);
+			BigInteger priceWei = new BigInteger(value);
+			contractAddress = to;
+			o = generateERC875Op();
+			TransactionOperation op = o[0];
+			TransactionContract ct = op.contract;
+			if (error.equals("0")) //don't bother checking signature unless the transaction succeeded
+			{
+				if (parser == null) parser = new ParseMagicLink(new CryptoFunctions(), EthereumNetworkRepository.extraChains()); //parser on demand
+				byte[] tradeBytes = parser.getTradeBytes(ticketIndexArray, contractAddress, priceWei, expiry);
+				//attempt ecrecover
+				BigInteger key = Sign.signedMessageToKey(tradeBytes, sig);
+				ct.setOtherParty("0x" + Keys.getAddress(key));
+			}
+			ct.address = contractAddress;
+			ct.setIndicies(f.paramValues);
+			ct.name = contractAddress;
+		}
+		catch (Exception e)
+		{
+			o = generateERC875Op();
+			e.printStackTrace();
+		}
+
+		return o;
+	}
+
+	private void setName(TransactionOperation[] o, TransactionType name)
+	{
+		if (o.length > 0 && o[0] != null)
+		{
+			TransactionOperation op = o[0];
+			TransactionContract ct = op.contract;
+			if (ct instanceof ERC875ContractTransaction)
+			{
+				((ERC875ContractTransaction) ct).operation = name;
+			}
+			else
+			{
+				op.contract.name = "*" + String.valueOf(name.ordinal());
+			}
+		}
+	}
 }

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionInput.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionInput.java
@@ -76,7 +76,8 @@ public class TransactionInput
         return address;
     }
 
-    public String getFirstValue(Context ctx)
+    //With static string as we don't have app context
+    String getFirstValue()
     {
         String value = "0";
         if (miscData.size() > 0)
@@ -84,7 +85,7 @@ public class TransactionInput
             String firstVal = miscData.get(0);
             if (firstVal.equals(ALL))
             {
-                value = ctx.getString(R.string.all);
+                value = "All"; //Can't localise here because no App context.
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionInput.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionInput.java
@@ -1,7 +1,5 @@
 package com.alphawallet.app.entity;
 
-import android.content.Context;
-import com.alphawallet.app.R;
 import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
@@ -28,7 +26,7 @@ public class TransactionInput
     public List<String> sigData;
     public List<String> miscData;
 
-    private final String ALL = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    private final String ERC20_APPROVE_ALL = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
     public TransactionInput()
     {
@@ -83,7 +81,7 @@ public class TransactionInput
         if (miscData.size() > 0)
         {
             String firstVal = miscData.get(0);
-            if (firstVal.equals(ALL))
+            if (firstVal.equals(ERC20_APPROVE_ALL))
             {
                 value = "All"; //Can't localise here because no App context.
             }


### PR DESCRIPTION
PR moves existing code from a helper method to within the Transaction constructor.

This is for a forthcoming PR which fixes an issue reported with pending transactions not displaying correctly.

The abstraction should work this way instead because it allows the code to decode and populate 
 transaction operation results whenever the transaction is created.

