### PR TITLE
Log and display full pending transactions

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
@@ -5,6 +5,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 
+import com.alphawallet.app.C;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.cryptokeys.SignatureFromKey;
@@ -128,7 +129,7 @@ public class TransactionRepository implements TransactionRepositoryType {
 					txData.txHash = raw.getTransactionHash();
 					return txData;
 				}))
-				.flatMap(tx -> storeUnconfirmedTransaction(from, tx, toAddress, subunitAmount, useGasPrice, chainId, data != null ? Numeric.toHexString(data) : "0x"))
+				.flatMap(tx -> storeUnconfirmedTransaction(from, tx, toAddress, subunitAmount, useGasPrice, chainId, data != null ? Numeric.toHexString(data) : "0x", ""))
 				.subscribeOn(Schedulers.io());
 	}
 
@@ -154,7 +155,7 @@ public class TransactionRepository implements TransactionRepositoryType {
 					txData.txHash = raw.getTransactionHash();
 					return txData;
 				}))
-				.flatMap(tx -> storeUnconfirmedTransaction(from, tx, "", BigInteger.ZERO, useGasPrice, chainId, data))
+				.flatMap(tx -> storeUnconfirmedTransaction(from, tx, "", BigInteger.ZERO, useGasPrice, chainId, data, C.BURN_ADDRESS))
 				.subscribeOn(Schedulers.io());
 	}
 
@@ -164,11 +165,11 @@ public class TransactionRepository implements TransactionRepositoryType {
 		else return gasPrice;
 	}
 
-	private Single<TransactionData> storeUnconfirmedTransaction(Wallet from, TransactionData txData, String toAddress, BigInteger value, BigInteger gasPrice, int chainId, String data)
+	private Single<TransactionData> storeUnconfirmedTransaction(Wallet from, TransactionData txData, String toAddress, BigInteger value, BigInteger gasPrice, int chainId, String data, String contractAddr)
 	{
 		return Single.fromCallable(() -> {
 			Transaction newTx = new Transaction(txData.txHash, "0", "0", System.currentTimeMillis()/1000, 0, from.address, toAddress, value.toString(10), "0", gasPrice.toString(10), data,
-					"0", chainId, new TransactionOperation[0]);
+					"0", chainId, contractAddr);
 			inDiskCache.putTransaction(from, newTx);
 
 			return txData;
@@ -180,7 +181,7 @@ public class TransactionRepository implements TransactionRepositoryType {
 		return Single.fromCallable(() -> {
 
 			Transaction newTx = new Transaction(txHash, "0", "0", System.currentTimeMillis()/1000, 0, from.address, toAddress, value.toString(10), "0", gasPrice.toString(10), data,
-					"0", chainId, new TransactionOperation[0]);
+					"0", chainId, "");
 			inDiskCache.putTransaction(from, newTx);
 
 			return txHash;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -119,9 +119,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
 
         if (date != null) setDate();
 
-        if (transaction.blockNumber != null && transaction.blockNumber.equals("0")) { fillPending(); return; }
-        if (transactionBackground != null) transactionBackground.setBackgroundResource(R.color.white);
-
         boolean txSuccess = (transaction.error != null && transaction.error.equals("0"));
         // If operations include token transfer, display token transfer instead
         TransactionOperation operation = transaction.operations == null
@@ -145,6 +142,20 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         {
             fillERC20(txSuccess, transaction);
         }
+
+        //Handle displaying the transaction item as pending or completed
+        if (transaction.blockNumber != null && transaction.blockNumber.equals("0"))
+        {
+            type.setText(R.string.pending_transaction);
+            transactionBackground.setBackgroundResource(R.drawable.background_pending_transaction);
+            pendingSpinner.setVisibility(View.VISIBLE);
+            typeIcon.setVisibility(View.GONE);
+        }
+        else if (transactionBackground != null)
+        {
+            if (pendingSpinner != null) pendingSpinner.setVisibility(View.GONE);
+            transactionBackground.setBackgroundResource(R.color.white);
+        }
     }
 
     private void setDate()
@@ -154,31 +165,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         calendar.setTime(txDate);
         date.setText(DateFormat.format("dd MMM yyyy", calendar));
-    }
-
-    private void fillPending()
-    {
-        transactionBackground.setBackgroundResource(R.drawable.background_pending_transaction);
-        pendingSpinner.setVisibility(View.VISIBLE);
-        typeIcon.setVisibility(View.GONE);
-        type.setText(R.string.pending_transaction);
-        String symbol = getString(R.string.eth);
-        Token t = tokensService.getToken(transaction.chainId, tokensService.getCurrentAddress());
-        if (t != null) symbol = t.getSymbol();
-
-        String valueStr = getValueStr(transaction.value, true, symbol, 18, transaction.to.equalsIgnoreCase(transaction.from));
-        value.setText(valueStr);
-        value.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
-        value.setVisibility(View.VISIBLE);
-
-        if (transaction.to.length() == 0)
-        {
-            address.setText(R.string.ticket_contract_constructor);
-        }
-        else
-        {
-            address.setText(transaction.to);
-        }
     }
 
     private void fillERC875(boolean txSuccess, Transaction trans, ERC875ContractTransaction ct)


### PR DESCRIPTION
Fixes an issue reported in one of our forks:

Pending transactions for ERC20 (and any other non-native tx) show up as blank transactions.

This is because when the pending transaction data is created, the transaction is not decoded, only stored without looking at the data. Most Contract transactions don't have any 'value' attached so would be stored simply as a native transaction with no value.

Building on the 'Decode-Tx-In-Constructor' PR this decodes and populates the transaction type within the constructor so it can be displayed correctly as a pending transaction.