### PR TITLE
Tidy up addr

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -95,17 +95,18 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         getPreviousMode();
     }
 
-    private void getPreviousMode() {
+    private void getPreviousMode()
+    {
         Intent intent = getIntent();
         if (token != null && token.isNonFungible())
         {
             showContract();
         }
-        else if (intent != null) {
+        else if (intent != null)
+        {
             int mode = intent.getIntExtra(KEY_MODE, MODE_ADDRESS);
-            if (mode == MODE_POS) {
-                overrideNetwork = intent.getIntExtra(OVERRIDE_DEFAULT, 1);
-                networkInfo = viewModel.getEthereumNetworkRepository().getNetworkByChain(overrideNetwork);
+            if (mode == MODE_POS)
+            {
                 showPointOfSaleMode();
             }
             else
@@ -219,7 +220,8 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         return super.onOptionsItemSelected(item);
     }
 
-    private void showPointOfSaleMode() {
+    private void showPointOfSaleMode()
+    {
         setContentView(R.layout.activity_eip681);
         initViews();
         getInfo();
@@ -230,6 +232,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         findViewById(R.id.toolbar_title).setVisibility(View.GONE);
         setTitle("");
         titleView.setVisibility(View.VISIBLE);
+        networkInfo = viewModel.getEthereumNetworkRepository().getNetworkByChain(overrideNetwork);
         if (token == null) token = viewModel.getEthereumNetworkRepository().getBlankOverrideToken(networkInfo);
         currentMode = MODE_POS;
         address.setVisibility(View.GONE);
@@ -242,9 +245,16 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
         amountInput.getValue();
         functionBar.setVisibility(View.GONE);
         selectNetworkLayout.setVisibility(View.VISIBLE);
+
+        if (networkInfo != null)
+        {
+            currentNetwork.setText(networkInfo.name);
+            Utils.setChainColour(networkIcon, networkInfo.chainId);
+        }
     }
 
-    private void showAddress() {
+    private void showAddress()
+    {
         getInfo();
         setContentView(R.layout.activity_my_address);
         initViews();
@@ -302,8 +312,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
                 int networkId = data.getIntExtra(C.EXTRA_CHAIN_ID, -1);
                 NetworkInfo info = viewModel.setNetwork(networkId);
 
-                // restart activity if required
-                if (info != null && (networkInfo == null || networkInfo.chainId != info.chainId))
+                if (info != null)
                 {
                     getInfo();
                     Intent intent = getIntent();
@@ -342,6 +351,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
     {
         wallet = getIntent().getParcelableExtra(C.Key.WALLET);
         token = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
+        overrideNetwork = getIntent().getIntExtra(OVERRIDE_DEFAULT, 1);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -51,8 +51,6 @@ import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
 
-import static com.alphawallet.app.C.Key.WALLET;
-
 public class MyAddressActivity extends BaseActivity implements View.OnClickListener, AmountUpdateCallback, StandardFunctionInterface
 {
     public static final String KEY_ADDRESS = "key_address";
@@ -307,8 +305,10 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
                 // restart activity if required
                 if (info != null && (networkInfo == null || networkInfo.chainId != info.chainId))
                 {
+                    getInfo();
                     Intent intent = getIntent();
                     intent.putExtra(KEY_MODE, MODE_POS);
+                    intent.putExtra(C.Key.WALLET, wallet);
                     intent.putExtra(OVERRIDE_DEFAULT, info.chainId);
                     finish();
                     startActivity(intent);
@@ -340,7 +340,7 @@ public class MyAddressActivity extends BaseActivity implements View.OnClickListe
 
     private void getInfo()
     {
-        wallet = getIntent().getParcelableExtra(WALLET);
+        wallet = getIntent().getParcelableExtra(C.Key.WALLET);
         token = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
     }
 

--- a/app/src/main/java/com/alphawallet/app/viewmodel/MyAddressViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/MyAddressViewModel.java
@@ -18,15 +18,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 
 public class MyAddressViewModel extends BaseViewModel {
-    private final String TAG = MyAddressViewModel.class.getSimpleName();
-    private static final long CHECK_ETHPRICE_INTERVAL = 60;
-
     private final FindDefaultNetworkInteract findDefaultNetworkInteract;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final TokenRepositoryType tokenRepository;
 
     private final MutableLiveData<NetworkInfo> defaultNetwork = new MutableLiveData<>();
-    private final MutableLiveData<TokenTicker> updateToken = new MutableLiveData<>();
 
     MyAddressViewModel(
             FindDefaultNetworkInteract findDefaultNetworkInteract,
@@ -59,13 +55,6 @@ public class MyAddressViewModel extends BaseViewModel {
     public LiveData<NetworkInfo> defaultNetwork() {
         return defaultNetwork;
     }
-    public LiveData<TokenTicker> updateToken() {
-        return updateToken;
-    }
-
-    public NetworkInfo[] getNetworkList() {
-        return ethereumNetworkRepository.getAvailableNetworkList();
-    }
 
     public NetworkInfo setNetwork(int chainId)
     {
@@ -78,17 +67,5 @@ public class MyAddressViewModel extends BaseViewModel {
         }
 
         return null;
-    }
-
-    public void startEthereumTicker(final Token token)
-    {
-        if (token.isEthereum())
-        {
-            disposable = Observable.interval(0, CHECK_ETHPRICE_INTERVAL, TimeUnit.SECONDS)
-                    .doOnNext(l -> Single.fromCallable(() -> ethereumNetworkRepository.getTokenTicker(token))
-                            .subscribeOn(Schedulers.io())
-                            .observeOn(AndroidSchedulers.mainThread())
-                            .subscribe(updateToken::postValue, this::onError)).subscribe();
-        }
     }
 }


### PR DESCRIPTION
Tidying up the address activity and resolving issue from life-cycle testing.

```
Caused by java.lang.NullPointerException: Attempt to read from field 'java.lang.String com.alphawallet.app.entity.Wallet.address' on a null object reference
       at com.alphawallet.app.ui.MyAddressActivity.showAddress + 257(MyAddressActivity.java:257)
       at com.alphawallet.app.ui.MyAddressActivity.getPreviousMode + 114(MyAddressActivity.java:114)
       at com.alphawallet.app.ui.MyAddressActivity.onCreate + 96(MyAddressActivity.java:96)
```

caused by: leaving the app in POS mode; swapping out the app, doing other stuff, re-entering the app, then changing the chain on POS mode.

Solution: re-populate the 'wallet' part of the intent when re-starting the activity with a new chain. 