### PR TITLE
Check wallet for TS enabled tokens

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenInterface.java
@@ -1,9 +1,13 @@
 package com.alphawallet.app.entity.tokens;
 
+import com.alphawallet.app.entity.ContractLocator;
+
+import java.util.List;
+
 public interface TokenInterface
 {
     void resetTokens();
     void changedLocale();
-    void addedToken(int[] chainIds, String[] addrs);
+    void addedToken(List<ContractLocator> tokenContracts);
     default void refreshTokens() { };
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokensReceiver.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokensReceiver.java
@@ -33,9 +33,7 @@ public class TokensReceiver extends BroadcastReceiver
                     tokenInterface.resetTokens();
                     break;
                 case C.ADDED_TOKEN:
-                    String[] addrs = intent.getStringArrayExtra(C.EXTRA_TOKENID_LIST);
-                    int[] chainIds = intent.getIntArrayExtra(C.EXTRA_CHAIN_ID);
-                    tokenInterface.addedToken(chainIds, addrs);
+                    tokenInterface.addedToken(intent.getParcelableArrayListExtra(C.EXTRA_TOKENID_LIST));
                     break;
                 case C.CHANGED_LOCALE:
                     tokenInterface.changedLocale();

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -1220,8 +1220,7 @@ public class TokenRepository implements TokenRepositoryType {
                     responseValue, function.getOutputParameters());
             if (response.size() == 1)
             {
-                contractLocator.name = (String) response.get(0).getValue();
-                return contractLocator;
+                return new ContractLocator((String) response.get(0).getValue(), chainId);
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
@@ -16,6 +16,9 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.alphawallet.app.C;
+import com.alphawallet.app.R;
+import com.alphawallet.app.entity.ContractLocator;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.CryptoFunctions;
 import com.alphawallet.app.entity.ErrorEnvelope;
@@ -28,21 +31,22 @@ import com.alphawallet.app.ui.zxing.FullScannerFragment;
 import com.alphawallet.app.ui.zxing.QRScanningActivity;
 import com.alphawallet.app.util.QRURLParser;
 import com.alphawallet.app.util.Utils;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.inject.Inject;
-import dagger.android.AndroidInjection;
-import com.alphawallet.token.entity.SalesOrderMalformed;
-import com.alphawallet.token.tools.ParseMagicLink;
-import com.alphawallet.app.C;
-import com.alphawallet.app.R;
-
 import com.alphawallet.app.viewmodel.AddTokenViewModel;
 import com.alphawallet.app.viewmodel.AddTokenViewModelFactory;
 import com.alphawallet.app.widget.AWalletAlertDialog;
 import com.alphawallet.app.widget.InputAddressView;
 import com.alphawallet.app.widget.InputView;
+import com.alphawallet.token.entity.SalesOrderMalformed;
+import com.alphawallet.token.tools.ParseMagicLink;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import dagger.android.AndroidInjection;
 
 import static com.alphawallet.app.C.ADDED_TOKEN;
 import static com.alphawallet.app.widget.AWalletAlertDialog.ERROR;
@@ -249,11 +253,9 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
     {
         if (result != null)
         {
-            String[] addrs = { result.getAddress() };
-            int[] chainIds = { result.tokenInfo.chainId };
+            ContractLocator cr = new ContractLocator(result.getAddress(), result.tokenInfo.chainId);
             Intent intent = new Intent(ADDED_TOKEN);
-            intent.putExtra(C.EXTRA_TOKENID_LIST, addrs);
-            intent.putExtra(C.EXTRA_CHAIN_ID, chainIds);
+            intent.putParcelableArrayListExtra(C.EXTRA_TOKENID_LIST, new ArrayList<>(Collections.singletonList(cr)));
             sendBroadcast(intent);
             finish();
         }

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionsFragment.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.alphawallet.app.R;
+import com.alphawallet.app.entity.ContractLocator;
 import com.alphawallet.app.entity.ErrorEnvelope;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.Wallet;
@@ -26,11 +27,11 @@ import com.alphawallet.app.viewmodel.TransactionsViewModelFactory;
 import com.alphawallet.app.widget.EmptyTransactionsView;
 import com.alphawallet.app.widget.SystemView;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import dagger.android.support.AndroidSupportInjection;
-
-import static com.alphawallet.app.C.ErrorCode.EMPTY_COLLECTION;
 
 public class TransactionsFragment extends Fragment implements View.OnClickListener, TokenInterface
 {
@@ -179,7 +180,7 @@ public class TransactionsFragment extends Fragment implements View.OnClickListen
     }
 
     @Override
-    public void addedToken(int[] chainIds, String[] addrs)
+    public void addedToken(List<ContractLocator> tokenContracts)
     {
 
     }

--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -404,18 +404,15 @@ public class WalletFragment extends Fragment implements OnTokenClickListener, Vi
     }
 
     @Override
-    public void addedToken(int[] chainIds, String[] addrs)
+    public void addedToken(List<ContractLocator> tokenContracts)
     {
-        //token was added
-        if (chainIds.length != addrs.length)
-        {
-            System.out.println("Receiver data mismatch");
-            return;
-        }
+        //new tokens found
+        viewModel.newTokensFound(tokenContracts);
 
-        for (int i = 0; i < chainIds.length; i++)
+        //see if these are currently known, if so update them in adapter
+        for (ContractLocator cResult : tokenContracts)
         {
-            Token t = viewModel.getTokenFromService(chainIds[i], addrs[i]);
+            Token t = viewModel.getTokenFromService(cResult.chainId, cResult.name);
             if (t != null) adapter.updateToken(t, false);
         }
     }


### PR DESCRIPTION
Ensure TokenScript enabled tokens are checked for all wallets - shouldn't have to manually add them.

Previously we didn't automatically check the wallet for TokenScript enabled tokens.

This PR builds on #1311 to ensure that once populated, all the TokenScript origin tokens are checked in the walletview.