### PR TITLE
Update Collectibles Tab to match iOS

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -16,6 +16,7 @@ import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SimpleItemAnimator;
@@ -24,7 +25,6 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.alphawallet.app.C;
@@ -42,6 +42,7 @@ import com.alphawallet.app.ui.widget.OnTokenClickListener;
 import com.alphawallet.app.ui.widget.adapter.TokensAdapter;
 import com.alphawallet.app.ui.widget.entity.WarningData;
 import com.alphawallet.app.ui.widget.holder.ManageTokensHolder;
+import com.alphawallet.app.ui.widget.holder.TokenGridHolder;
 import com.alphawallet.app.ui.widget.holder.TokenHolder;
 import com.alphawallet.app.ui.widget.holder.WarningHolder;
 import com.alphawallet.app.util.TabUtils;
@@ -51,7 +52,6 @@ import com.alphawallet.app.widget.NotificationView;
 import com.alphawallet.app.widget.ProgressView;
 import com.alphawallet.app.widget.SystemView;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +60,6 @@ import javax.inject.Inject;
 
 import dagger.android.support.AndroidSupportInjection;
 
-import static com.alphawallet.app.C.EXTRA_ADDRESS;
 import static com.alphawallet.app.C.ErrorCode.EMPTY_COLLECTION;
 import static com.alphawallet.app.C.Key.WALLET;
 
@@ -91,6 +90,8 @@ public class WalletFragment extends BaseFragment implements
     private String importFileName;
     private RecyclerView recyclerView;
     private SwipeRefreshLayout refreshLayout;
+    private GridLayoutManager gridLayoutManager;
+    private LinearLayoutManager linearLayoutManager;
 
     private boolean isVisible;
 
@@ -130,9 +131,10 @@ public class WalletFragment extends BaseFragment implements
     }
 
     private void initList() {
+        initLayoutManagers();
         adapter = new TokensAdapter(this, viewModel.getAssetDefinitionService(), viewModel.getTokensService(), getContext());
         adapter.setHasStableIds(true);
-        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView.setLayoutManager(linearLayoutManager);
         recyclerView.setAdapter(adapter);
         if (recyclerView.getItemAnimator() != null)
             ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
@@ -230,14 +232,17 @@ public class WalletFragment extends BaseFragment implements
                 switch (tab.getPosition())
                 {
                     case 0:
+                        recyclerView.setLayoutManager(linearLayoutManager);
                         adapter.setFilterType(TokensAdapter.FILTER_ALL);
                         viewModel.fetchTokens();
                         break;
                     case 1:
+                        recyclerView.setLayoutManager(linearLayoutManager);
                         adapter.setFilterType(TokensAdapter.FILTER_CURRENCY);
                         viewModel.fetchTokens();
                         break;
                     case 2:
+                        recyclerView.setLayoutManager(gridLayoutManager);
                         adapter.setFilterType(TokensAdapter.FILTER_COLLECTIBLES);
                         viewModel.fetchTokens();
                         break;
@@ -260,6 +265,21 @@ public class WalletFragment extends BaseFragment implements
         });
 
         TabUtils.decorateTabLayout(getContext(), tabLayout);
+    }
+
+    private void initLayoutManagers() {
+        linearLayoutManager = new LinearLayoutManager(getContext());
+
+        gridLayoutManager = new GridLayoutManager(getContext(), 2);
+        gridLayoutManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
+            @Override
+            public int getSpanSize(int position) {
+                if (adapter.getItemViewType(position) == TokenGridHolder.VIEW_TYPE) {
+                    return 1;
+                }
+                return 2;
+            }
+        });
     }
 
     @Override
@@ -558,7 +578,8 @@ public class WalletFragment extends BaseFragment implements
                 Token t = ((TokenHolder)viewHolder).token;
                 if (t.isEthereum()) return 0;
             }
-            else if (viewHolder.getItemViewType() == ManageTokensHolder.VIEW_TYPE)
+            else if (viewHolder.getItemViewType() == ManageTokensHolder.VIEW_TYPE ||
+                    viewHolder.getItemViewType() == TokenGridHolder.VIEW_TYPE)
             {
                 return 0;
             }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
@@ -22,6 +22,7 @@ import com.alphawallet.app.ui.widget.entity.WarningSortedItem;
 import com.alphawallet.app.ui.widget.holder.AssetInstanceScriptHolder;
 import com.alphawallet.app.ui.widget.holder.BinderViewHolder;
 import com.alphawallet.app.ui.widget.holder.ManageTokensHolder;
+import com.alphawallet.app.ui.widget.holder.TokenGridHolder;
 import com.alphawallet.app.ui.widget.holder.TokenHolder;
 import com.alphawallet.app.ui.widget.holder.TotalBalanceHolder;
 import com.alphawallet.app.ui.widget.holder.WarningHolder;
@@ -44,8 +45,9 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     private ContractResult scrollToken; // designates a token that should be scrolled to
 
     private Context context;
-
     private String walletAddress;
+
+    private boolean gridFlag;
 
     protected final OnTokenClickListener onTokenClickListener;
     protected final SortedList<SortedItem> items = new SortedList<>(SortedItem.class, new SortedList.Callback<SortedItem>() {
@@ -123,8 +125,14 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
                 TokenHolder tokenHolder = new TokenHolder(R.layout.item_token, parent, assetService);
                 tokenHolder.setOnTokenClickListener(onTokenClickListener);
                 holder = tokenHolder;
+                break;
             }
-            break;
+            case TokenGridHolder.VIEW_TYPE: {
+                TokenGridHolder tokenGridHolder = new TokenGridHolder(R.layout.item_token_grid, parent, assetService);
+                tokenGridHolder.setOnTokenClickListener(onTokenClickListener);
+                holder = tokenGridHolder;
+                break;
+            }
             case ManageTokensHolder.VIEW_TYPE:
                 holder = new ManageTokensHolder(R.layout.layout_manage_tokens, parent);
                 break;
@@ -204,7 +212,11 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
         if (tokensService != null) tokensService.markTokenUpdated(token);
         if (canDisplayToken(token))
         {
-            items.add(new TokenSortedItem(token, token.getNameWeight()));
+            if (gridFlag) {
+                items.add(new TokenSortedItem(TokenGridHolder.VIEW_TYPE, token, token.getNameWeight()));
+            } else {
+                items.add(new TokenSortedItem(TokenHolder.VIEW_TYPE,token, token.getNameWeight()));
+            }
         }
         else
         {
@@ -337,6 +349,11 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder> {
     public void setFilterType(int filterType)
     {
         this.filterType = filterType;
+        if (filterType == FILTER_COLLECTIBLES) {
+            gridFlag = true;
+        } else {
+            gridFlag = false;
+        }
         filterAdapterItems();
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
@@ -10,6 +10,10 @@ public class TokenSortedItem extends SortedItem<Token> {
         super(TokenHolder.VIEW_TYPE, value, weight);
     }
 
+    public TokenSortedItem(int viewType, Token value, int weight) {
+        super(viewType, value, weight);
+    }
+
     @Override
     public int compare(SortedItem other) {
         return weight - other.weight;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenGridHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenGridHolder.java
@@ -1,0 +1,97 @@
+package com.alphawallet.app.ui.widget.holder;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.alphawallet.app.R;
+import com.alphawallet.app.entity.opensea.Asset;
+import com.alphawallet.app.entity.tokens.ERC721Ticket;
+import com.alphawallet.app.entity.tokens.ERC721Token;
+import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.ui.widget.OnTokenClickListener;
+import com.alphawallet.app.util.Utils;
+import com.bumptech.glide.Glide;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class TokenGridHolder extends BinderViewHolder<Token> {
+
+    public static final int VIEW_TYPE = 2005;
+
+    private final LinearLayout layout;
+    private final TextView name;
+    private final ImageView imageIcon;
+    private final TextView textIcon;
+    private final AssetDefinitionService assetDefinition;
+
+    private OnTokenClickListener onTokenClickListener;
+
+    public TokenGridHolder(int resId, ViewGroup parent, AssetDefinitionService assetService) {
+        super(resId, parent);
+
+        layout = findViewById(R.id.token_layout);
+        imageIcon = findViewById(R.id.token_icon);
+        name = findViewById(R.id.token_name);
+        textIcon = findViewById(R.id.text_icon);
+
+        assetDefinition = assetService;
+    }
+
+    @Override
+    public void bind(@Nullable Token token, @NonNull Bundle addition) {
+        if (token != null) {
+            if (token.isERC721()) {
+                ERC721Token tkn = (ERC721Token) token;
+                List<Asset> assets = tkn.getTokenAssets();
+                if (assets != null) {
+                    Asset firstAsset = assets.get(0);
+                    if (firstAsset != null) {
+                        Glide.with(getContext())
+                                .load(firstAsset.getImagePreviewUrl())
+                                .into(imageIcon);
+                        name.setText(token.tokenInfo.name);
+                        textIcon.setVisibility(View.GONE);
+                        imageIcon.setVisibility(View.VISIBLE);
+                    } else {
+                        setupIcon(token);
+                    }
+                }
+            } else if (token.isERC721Ticket()) {
+                ERC721Ticket tkn = (ERC721Ticket) token;
+                String tokenName = tkn.getTokenName(assetDefinition, 0);
+                name.setText(tokenName);
+                setupIcon(token);
+            } else {
+                name.setText(token.tokenInfo.name);
+                setupIcon(token);
+            }
+
+            layout.setOnClickListener(v -> {
+                if (onTokenClickListener != null) {
+                    onTokenClickListener.onTokenClick(v, token, null, true);
+                }
+            });
+        }
+    }
+
+    private void setupIcon(@NotNull Token token) {
+        imageIcon.setVisibility(View.GONE);
+        textIcon.setVisibility(View.VISIBLE);
+        textIcon.setBackgroundTintList(ContextCompat.getColorStateList(getContext(), Utils.getChainColour(token.tokenInfo.chainId)));
+        textIcon.setText(Utils.getIconisedText(token.tokenInfo.name));
+    }
+
+    public void setOnTokenClickListener(OnTokenClickListener onTokenClickListener) {
+        this.onTokenClickListener = onTokenClickListener;
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -7,6 +7,12 @@ import android.util.TypedValue;
 import android.view.View;
 import android.webkit.URLUtil;
 
+import com.alphawallet.app.C;
+import com.alphawallet.app.R;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
+
+import org.web3j.crypto.WalletUtils;
+
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -16,16 +22,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.alphawallet.app.C;
-import com.alphawallet.app.R;
-import com.alphawallet.app.repository.EthereumNetworkRepository;
-
-import org.web3j.crypto.WalletUtils;
 
 public class Utils {
 
@@ -74,6 +73,60 @@ public class Utils {
         }
 
         return result;
+    }
+
+    private static String getFirstWord(String text) {
+        int index = text.indexOf(' ');
+        if (index > -1) {
+            return text.substring(0, index).trim();
+        } else {
+            return text;
+        }
+    }
+
+    public static String getIconisedText(String text)
+    {
+        String firstWord = getFirstWord(text);
+        switch (firstWord.length()) {
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                return firstWord.toUpperCase();
+            default:
+                return firstWord.substring(0, 4).toUpperCase();
+        }
+    }
+
+    public static int getChainColour(int chainId)
+    {
+        switch (chainId)
+        {
+            case EthereumNetworkRepository.MAINNET_ID:
+                return R.color.mainnet;
+            case EthereumNetworkRepository.CLASSIC_ID:
+                return R.color.classic;
+            case EthereumNetworkRepository.POA_ID:
+                return R.color.poa;
+            case EthereumNetworkRepository.KOVAN_ID:
+                return R.color.kovan;
+            case EthereumNetworkRepository.ROPSTEN_ID:
+                return R.color.ropsten;
+            case EthereumNetworkRepository.SOKOL_ID:
+                return R.color.sokol;
+            case EthereumNetworkRepository.RINKEBY_ID:
+                return R.color.rinkeby;
+            case EthereumNetworkRepository.GOERLI_ID:
+                return R.color.goerli;
+            case EthereumNetworkRepository.XDAI_ID:
+                return R.color.xdai;
+            case EthereumNetworkRepository.ARTIS_SIGMA1_ID:
+                return R.color.artis_sigma1;
+            case EthereumNetworkRepository.ARTIS_TAU1_ID:
+                return R.color.artis_tau1;
+            default:
+                return R.color.mine;
+        }
     }
 
     public static void setChainColour(View view, int chainId)

--- a/app/src/main/res/drawable/background_round.xml
+++ b/app/src/main/res/drawable/background_round.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners
+        android:radius="5dp" />
+</shape>

--- a/app/src/main/res/drawable/grid_icon.xml
+++ b/app/src/main/res/drawable/grid_icon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="@dimen/dp20"
+        android:height="@dimen/dp20" />
+</shape>

--- a/app/src/main/res/layout/item_token_grid.xml
+++ b/app/src/main/res/layout/item_token_grid.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/token_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_margin="@dimen/dp5"
+    android:background="@drawable/background_round"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:padding="@dimen/dp10">
+
+    <ImageView
+        android:id="@+id/token_icon"
+        android:layout_width="@dimen/grid_icon_height"
+        android:layout_height="@dimen/grid_icon_height"
+        android:src="@drawable/ic_ethereum"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/text_icon"
+        android:layout_width="@dimen/grid_icon_height"
+        android:layout_height="@dimen/grid_icon_height"
+        android:background="@drawable/grid_icon"
+        android:backgroundTint="@color/azure"
+        android:fontFamily="@font/font_bold"
+        android:gravity="center"
+        android:lines="1"
+        android:padding="@dimen/dp5"
+        android:text="UEFA"
+        android:textColor="@color/white"
+        android:visibility="visible"
+        app:autoSizeMaxTextSize="@dimen/sp32"
+        app:autoSizeMinTextSize="@dimen/sp24"
+        app:autoSizeStepGranularity="1sp"
+        app:autoSizeTextType="uniform" />
+
+    <TextView
+        android:id="@+id/token_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/dp10"
+        android:ellipsize="end"
+        android:fontFamily="@font/font_bold"
+        android:gravity="center_horizontal"
+        android:lines="2"
+        android:maxLines="2"
+        android:text="Token Name"
+        android:textColor="@color/black" />
+
+</LinearLayout>

--- a/app/src/main/res/values-xhdpi/dimens.xml
+++ b/app/src/main/res/values-xhdpi/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="sp20">18sp</dimen>
     <dimen name="sp24">22sp</dimen>
     <dimen name="sp28">26sp</dimen>
+    <dimen name="sp32">30sp</dimen>
     <dimen name="sp36">34sp</dimen>
 
     <!-- Padding/Margin Dimens -->
@@ -47,5 +48,8 @@
     <dimen name="dp23">22dp</dimen>
     <dimen name="dp24">23dp</dimen>
     <dimen name="dp25">24dp</dimen>
+
+    <!-- Collectible Grid Item -->
+    <dimen name="grid_icon_height">85dp</dimen>
 
 </resources>

--- a/app/src/main/res/values-xxhdpi/dimens.xml
+++ b/app/src/main/res/values-xxhdpi/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="sp20">20sp</dimen>
     <dimen name="sp24">24sp</dimen>
     <dimen name="sp28">28sp</dimen>
+    <dimen name="sp32">32sp</dimen>
     <dimen name="sp36">36sp</dimen>
 
     <!-- Padding/Margin Dimens -->
@@ -47,5 +48,8 @@
     <dimen name="dp23">23dp</dimen>
     <dimen name="dp24">24dp</dimen>
     <dimen name="dp25">25dp</dimen>
+
+    <!-- Collectible Grid Item -->
+    <dimen name="grid_icon_height">100dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="sp20">17sp</dimen>
     <dimen name="sp24">20sp</dimen>
     <dimen name="sp28">24sp</dimen>
+    <dimen name="sp32">28sp</dimen>
     <dimen name="sp36">32sp</dimen>
 
     <!-- Padding/Margin Dimens -->
@@ -47,4 +48,8 @@
     <dimen name="dp23">21dp</dimen>
     <dimen name="dp24">22dp</dimen>
     <dimen name="dp25">23dp</dimen>
+
+    <!-- Collectible Grid Item -->
+    <dimen name="grid_icon_height">70dp</dimen>
+
 </resources>


### PR DESCRIPTION
Closes #1283 

Collectibles tab is now displayed as a grid, showing the first asset's image as the thumbnail. If no images related to the asset are found, display an iconised text instead.