### PR TITLE
Improve EIP681 code handling

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EIP681Type.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EIP681Type.java
@@ -6,5 +6,5 @@ package com.alphawallet.app.entity;
  */
 public enum EIP681Type
 {
-    ADDRESS, PAYMENT, TRANSFER, FUNCTION_CALL, OTHER
+    ADDRESS, PAYMENT, TRANSFER, FUNCTION_CALL, URL, OTHER
 }

--- a/app/src/main/java/com/alphawallet/app/entity/QrUrlResult.java
+++ b/app/src/main/java/com/alphawallet/app/entity/QrUrlResult.java
@@ -42,6 +42,12 @@ public class QrUrlResult implements Parcelable
         defaultParams();
     }
 
+    public QrUrlResult(String data, EIP681Type type)
+    {
+        this.type = type;
+        this.address = data;
+    }
+
     private void defaultParams()
     {
         chainId = 1;
@@ -208,11 +214,6 @@ public class QrUrlResult implements Parcelable
             {
                 type = EIP681Type.OTHER;
             }
-        }
-
-        if (type == EIP681Type.TRANSFER && isEmpty(functionToAddress))
-        {
-            type = EIP681Type.OTHER;
         }
 
         if (type == EIP681Type.FUNCTION_CALL && isEmpty(functionDetail))

--- a/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
@@ -229,7 +229,6 @@ public class AddTokenActivity extends BaseActivity implements View.OnClickListen
                 showProgress(true);
                 //attempt to load the token and store to tokenService
                 viewModel.fetchToken(currentResult.chainId, currentResult.getAddress());
-                return;
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/util/QRURLParser.java
+++ b/app/src/main/java/com/alphawallet/app/util/QRURLParser.java
@@ -1,5 +1,6 @@
 package com.alphawallet.app.util;
 
+import com.alphawallet.app.entity.EIP681Type;
 import com.alphawallet.app.entity.EthereumProtocolParser;
 import com.alphawallet.app.entity.QrUrlResult;
 import com.alphawallet.app.ui.widget.entity.ENSHandler;
@@ -94,6 +95,10 @@ public class QRURLParser {
             String address = extractAddress(url);
             if (address != null) {
                 result = new QrUrlResult(address);
+            }
+            else
+            {
+                result = new QrUrlResult(url, EIP681Type.URL); //resolve to URL
             }
         }
 

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -9,10 +9,12 @@ import android.os.TransactionTooLargeException;
 import android.preference.PreferenceManager;
 
 import com.alphawallet.app.entity.Operation;
+import com.alphawallet.app.entity.QrUrlResult;
 import com.alphawallet.app.entity.tokens.TokenTicker;
 import com.alphawallet.app.repository.EthereumNetworkBase;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.service.TickerService;
+import com.alphawallet.app.ui.SendActivity;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.alphawallet.app.C;
@@ -293,5 +295,23 @@ public class DappBrowserViewModel extends BaseViewModel  {
     public void failedAuthentication(Operation signData)
     {
         keyService.failedAuthentication(signData);
+    }
+
+    public void showSend(Context ctx, QrUrlResult result)
+    {
+        Intent intent = new Intent(ctx, SendActivity.class);
+        boolean sendingTokens = (result.getFunction() != null && result.getFunction().length() > 0);
+        String address = defaultWallet.getValue().address;
+        int decimals = 18;
+
+        intent.putExtra(C.EXTRA_SENDING_TOKENS, sendingTokens);
+        intent.putExtra(C.EXTRA_CONTRACT_ADDRESS, address);
+        intent.putExtra(C.EXTRA_SYMBOL, ethereumNetworkRepository.getNetworkByChain(result.chainId).symbol);
+        intent.putExtra(C.EXTRA_DECIMALS, decimals);
+        intent.putExtra(C.Key.WALLET, defaultWallet.getValue());
+        intent.putExtra(C.EXTRA_TOKEN_ID, (Token)null);
+        intent.putExtra(C.EXTRA_AMOUNT, result);
+        intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        ctx.startActivity(intent);
     }
 }

--- a/app/src/main/res/layout/activity_send.xml
+++ b/app/src/main/res/layout/activity_send.xml
@@ -101,6 +101,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginEnd="20dp"
                     android:visibility="gone"
                     android:layout_marginTop="5dp"
                     android:textSize="18sp"

--- a/lib/src/main/java/com/alphawallet/token/tools/Convert.java
+++ b/lib/src/main/java/com/alphawallet/token/tools/Convert.java
@@ -39,17 +39,20 @@ public final class Convert {
         METHER("mether", 24),
         GETHER("gether", 27);
 
-        private String name;
-        private BigDecimal weiFactor;
+        private final String name;
+        private final BigDecimal weiFactor;
+        private final int factor;
 
         Unit(String name, int factor) {
             this.name = name;
             this.weiFactor = BigDecimal.TEN.pow(factor);
+            this.factor = factor;
         }
 
         public BigDecimal getWeiFactor() {
             return weiFactor;
         }
+        public int getFactor() { return factor; }
 
         @Override
         public String toString() {
@@ -81,6 +84,14 @@ public final class Convert {
         df.setRoundingMode(RoundingMode.CEILING);
         df.setMaximumFractionDigits(decimals);
         return df.format(ethFiatValue);
+    }
+
+    public static String getConvertedValue(BigDecimal rawValue, int divisor)
+    {
+        BigDecimal convertedValue = rawValue.divide(new BigDecimal(Math.pow(10, divisor)));
+        DecimalFormat df = new DecimalFormat("0.#####");
+        df.setRoundingMode(RoundingMode.HALF_DOWN);
+        return df.format(convertedValue);
     }
 
     public static String getEthStringSzabo(BigInteger szabo)


### PR DESCRIPTION
Improve EIP681 code handling to allow codes with no send address, such as this one:

```ethereum:0x744d70fdbe2ba4cf95131626614a1763df805b9e/transfer?uint256=314e17```

Equivalent to iOS PR here: https://github.com/AlphaWallet/alpha-wallet-ios/pull/1771

Also needed to update the send activity to correctly handle the change.