### PR TITLE
Fix Token Categorisation

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -58,6 +58,13 @@ public class ERC721Token extends Token implements Parcelable
 
     @Override
     public void addAssetToTokenBalanceAssets(Asset asset) {
+        for (Asset a : tokenBalanceAssets) //don't add the same assets twice (should this be a map?)
+        {
+            if (a.getTokenId().equalsIgnoreCase(asset.getTokenId()))
+            {
+                return;
+            }
+        }
         tokenBalanceAssets.add(asset);
     }
 

--- a/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/FetchTokensInteract.java
@@ -7,6 +7,7 @@ import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.OrderContractAddressPair;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.entity.opensea.Asset;
 import com.alphawallet.app.entity.tokens.ERC721Ticket;
 import com.alphawallet.app.entity.tokens.ERC721Token;
 import com.alphawallet.app.entity.tokens.Token;
@@ -130,7 +131,8 @@ public class FetchTokensInteract {
                             type = ContractType.ERC721;
                         case ERC721:
                         case ERC721_LEGACY:
-                            t = new ERC721Token(t.tokenInfo, new ArrayList<>(), System.currentTimeMillis(), t.getNetworkName(), type);
+                            List<Asset> erc721Balance = t.getTokenAssets(); //add balance from Opensea
+                            t = new ERC721Token(t.tokenInfo, erc721Balance, System.currentTimeMillis(), t.getNetworkName(), type);
                             tokens[i] = t;
                             break;
                         case ERC721_TICKET:

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -1294,10 +1294,10 @@ public class TokenRepository implements TokenRepositoryType {
                 else if (getContractData(network, tokenInfo.address, supportsInterface(INTERFACE_OLD_ERC721), Boolean.TRUE)) returnType = ContractType.ERC721_LEGACY;
                 else
                 {
+                    Boolean isERC875 = getContractData(network, tokenInfo.address, boolParam("isStormBirdContract"), Boolean.TRUE); //Use old isStormbird as another datum point
                     List<BigInteger> balance875 = checkERC875BalanceArray(new Wallet(ZERO_ADDRESS), tokenInfo, null);
-                    List<BigInteger> balance721 = checkERC721TicketBalanceArray(new Wallet(ZERO_ADDRESS), tokenInfo, null);
                     String      responseValue = callSmartContractFunction(balanceOf(ZERO_ADDRESS), tokenInfo.address, network, new Wallet(ZERO_ADDRESS));
-                    returnType = findContractTypeFromResponse(balance875, balance721, responseValue);
+                    returnType = findContractTypeFromResponse(balance875, responseValue, isERC875);
                 }
             }
             catch (Exception e)
@@ -1310,17 +1310,13 @@ public class TokenRepository implements TokenRepositoryType {
         });
     }
 
-    private ContractType findContractTypeFromResponse(List<BigInteger> balance875, List<BigInteger> balance721Ticket, String balanceResponse) throws Exception
+    private ContractType findContractTypeFromResponse(List<BigInteger> balance875, String balanceResponse, Boolean isERC875) throws Exception
     {
         ContractType returnType = ContractType.OTHER;
 
         int responseLength = balanceResponse.length();
 
-        if (balance721Ticket != null && balance721Ticket.size() > 0)
-        {
-            returnType = ContractType.ERC721_TICKET;
-        }
-        else if (balance875 != null && balance875.size() > 0 && responseLength > 66)
+        if (isERC875 || (balance875 != null && balance875.size() > 0 && responseLength > 66))
         {
             returnType = ContractType.ERC875;
         }

--- a/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
+++ b/app/src/main/java/com/alphawallet/app/service/OpenseaService.java
@@ -14,9 +14,13 @@ import com.alphawallet.app.entity.opensea.OpenseaServiceError;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.InterruptedIOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +35,7 @@ public class OpenseaService {
     private static Map<String, Long> balanceAccess = new ConcurrentHashMap<>();
     private final Context context;
     private final TokensService tokensService;
+    private static final int PAGE_SIZE = 40;
 
     //TODO: remove old files not accessed for some time
     //      On service creation, check files for old files and delete
@@ -48,28 +53,45 @@ public class OpenseaService {
     }
 
     public Single<Token[]> getTokens(String address, int networkId, String networkName) {
-        return queryBalance(address, networkId)
-                .map(json -> gotOpenseaTokens(json, address, networkId, networkName));
+        return queryBalance(address, networkId, networkName);
     }
 
-    private Token[] gotOpenseaTokens(JSONObject object, String address, int networkId, String networkName) throws Exception
+    private Single<Token[]> queryBalance(String address, int networkId, String networkName)
     {
-        Map<String, Token> foundTokens = new HashMap<>();
+        return Single.fromCallable(() -> {
+            int receivedTokens;
+            int offset = 0;
+            Map<String, Token> foundTokens = new HashMap<>();
 
-        if (!object.has("assets"))
-        {
-            throw new OpenseaServiceError("Opensea API Comms failure"); //if we didn't receive any sensible result then
-        }
-        JSONArray assets = object.getJSONArray("assets");
+            do
+            {
+                String jsonData = fetchTokensFromOpensea(address, networkId, offset);
+                if (!verifyData(jsonData)) return foundTokens.values().toArray(new Token[0]); //on error return results found so far
+                JSONObject result = new JSONObject(jsonData);
+                JSONArray assets = result.getJSONArray("assets");
+                receivedTokens = assets.length();
+                offset++;
 
+                //process this page of results
+                processOpenseaTokens(foundTokens, assets, address, networkId, networkName);
+            }
+            while (receivedTokens == PAGE_SIZE); //keep fetching until last page
+
+            return foundTokens.values().toArray(new Token[0]);
+        });
+    }
+
+
+    private void processOpenseaTokens(Map<String, Token> foundTokens, JSONArray assets, String address, int networkId, String networkName) throws Exception
+    {
         TokenFactory tf = new TokenFactory();
 
         for (int i = 0; i < assets.length(); i++)
         {
             Asset asset = new Gson().fromJson(assets.getJSONObject(i).toString(), Asset.class);
             if (asset != null && (asset.getAssetContract().getSchemaName() == null
-                                || asset.getAssetContract().getSchemaName().length() == 0
-                                || asset.getAssetContract().getSchemaName().equalsIgnoreCase("ERC721"))) //filter ERC721
+                    || asset.getAssetContract().getSchemaName().length() == 0
+                    || asset.getAssetContract().getSchemaName().equalsIgnoreCase("ERC721"))) //filter ERC721
             {
                 Token token = foundTokens.get(asset.getAssetContract().getAddress());
                 if (token == null)
@@ -77,15 +99,15 @@ public class OpenseaService {
                     TokenInfo tInfo;
                     ContractType type;
                     Token checkToken = tokensService.getToken(networkId, asset.getAssetContract().getAddress());
-                    if (checkToken != null)
+                    if (checkToken != null && (checkToken.isERC721() || checkToken.isERC721Ticket()))
                     {
                         tInfo = checkToken.tokenInfo;
                         type = checkToken.getInterfaceSpec();
                     }
-                    else
+                    else //if we haven't seen the contract before, or it was previously logged as something other than a ERC721 variant then specify undetermined flag
                     {
                         tInfo = new TokenInfo(asset.getAssetContract().getAddress(), asset.getAssetContract().getName(), asset.getAssetContract().getSymbol(), 0, true, networkId);
-						type = ContractType.ERC721_UNDETERMINED;
+                        type = ContractType.ERC721_UNDETERMINED;
                     }
 
                     token = tf.createToken(tInfo, type, networkName);
@@ -95,61 +117,59 @@ public class OpenseaService {
                 token.addAssetToTokenBalanceAssets(asset);
             }
         }
-
-        return foundTokens.values().toArray(new Token[0]);
     }
 
-    private Single<JSONObject> queryBalance(String address, int networkId)
+    private boolean verifyData(String jsonData)
     {
-        return Single.fromCallable(() -> {
-            String apiBase = "";
-            // if no result we should throw an error - this distinguishes a comms error from a zero balance
-            JSONObject result = new JSONObject("{\"noresult\":[]}");
-            switch (networkId)
-            {
-                case 1:
-                    apiBase = "https://api.opensea.io";
-                    break;
-                case 4:
-                    apiBase = "https://rinkeby-api.opensea.io";
-                    break;
-                default:
-                    return result;
-            }
+        return jsonData != null && jsonData.length() >= 10 && jsonData.contains("assets"); //validate return from API
+    }
 
-            StringBuilder sb = new StringBuilder();
-            sb.append(apiBase);
-            sb.append("/api/v1/assets/?owner=");
-            sb.append(address);
-            sb.append("&order_direction=asc");
+    private String fetchTokensFromOpensea(String address, int networkId, int offset)
+    {
+        String jsonResult = "{\"noresult\":[]}";
+        String apiBase;
+        switch (networkId)
+        {
+            case 1:
+                apiBase = "https://api.opensea.io";
+                break;
+            case 4:
+                apiBase = "https://rinkeby-api.opensea.io";
+                break;
+            default:
+                return jsonResult;
+        }
 
-            try {
-                if (balanceAccess.containsKey(address)) {
-                    long lastAccess = balanceAccess.get(address);
-                    if (lastAccess > 0 && (System.currentTimeMillis() - lastAccess) < 1000 * 30) {
-                        Log.d("OPENSEA", "Polling Opensea very frequently: " + (System.currentTimeMillis() - lastAccess));
-                    }
-                }
+        StringBuilder sb = new StringBuilder();
+        sb.append(apiBase);
+        sb.append("/api/v1/assets/?owner=");
+        sb.append(address);
+        sb.append("&limit=" + PAGE_SIZE);
+        sb.append("&offset=");
+        sb.append(offset);
 
-                Request request = new Request.Builder()
-                        .url(sb.toString())
-                        .get()
-                        .build();
+        try
+        {
+            Request request = new Request.Builder()
+                    .url(sb.toString())
+                    .get()
+                    .build();
 
-                okhttp3.Response response = httpClient.newCall(request).execute();
-                String jsonResult = response.body().string();
-                balanceAccess.put(address, System.currentTimeMillis());
+            okhttp3.Response response = httpClient.newCall(request).execute();
+            jsonResult = response.body().string();
+            balanceAccess.put(address, System.currentTimeMillis());
+        }
+        catch (InterruptedIOException e)
+        {
+            //If user switches account or network during a fetch
+            //this exception is going to be thrown because we're terminating the API call
+            //Don't display error
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
 
-                if (jsonResult != null && jsonResult.length() > 10) {
-                    result = new JSONObject(jsonResult);
-                }
-            } catch (java.net.SocketTimeoutException e) {
-                Log.i("Opensea", "Socket timeout");
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-
-            return result;
-        });
+        return jsonResult;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TickerService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TickerService.java
@@ -303,17 +303,26 @@ public class TickerService implements TickerServiceInterface
 
             for (int i = 0; i < tokens.length(); i++)
             {
+                ContractType cType = ContractType.ERC20;
                 JSONObject t          = (JSONObject) tokens.get(i);
                 String     balanceStr = t.getString("amount");
                 if (balanceStr.length() == 0 || balanceStr.equals("0")) continue;
                 String decimalsStr   = t.getString("decimals");
                 int    decimals      = (decimalsStr.length() > 0) ? Integer.parseInt(decimalsStr) : 0;
                 Token  existingToken = tokensService.getToken(network.chainId, t.getString("address"));
-                if (decimals == 0 || (existingToken != null && !existingToken.isERC20())) continue;
+                if (existingToken == null)
+                {
+                    cType = ContractType.OTHER; //if we haven't seen this token before mark as needing contract type check
+                }
+                else if (!existingToken.isERC20())
+                {
+                    continue;
+                }
+
                 TokenInfo info = new TokenInfo(t.getString("address"), t.getString("name"), t.getString("symbol"), decimals, true, network.chainId);
                 //now create token with balance info, only for ERC20 for now
                 BigDecimal balance  = new BigDecimal(balanceStr);
-                Token      newToken = tf.createToken(info, balance, null, System.currentTimeMillis(), ContractType.ERC20, network.getShortName(), System.currentTimeMillis());
+                Token      newToken = tf.createToken(info, balance, null, System.currentTimeMillis(), cType, network.getShortName(), System.currentTimeMillis());
                 newToken.setTokenWallet(currentAddress);
                 if (existingToken != null) //TODO: after token module refactor this won't be necessary.
                 {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -50,9 +50,9 @@ public class WalletViewModel extends BaseViewModel
 {
     private static final int BALANCE_CHECK_INTERVAL_MILLIS = 500; //Balance check interval in milliseconds - should be integer divisible with 1000 (1 second)
     private static final int CHECK_OPENSEA_INTERVAL_TIME = 40; //Opensea refresh interval in seconds
-    private static final int CHECK_TOKENS_INTERVAL_TIME = 30;
     private static final int OPENSEA_RINKEBY_CHECK = 3; //check Rinkeby opensea once per XX opensea checks (ie if interval time is 25 and rinkeby check is 1 in 6, rinkeby refresh time is once per 300 seconds).
     public static double VALUE_THRESHOLD = 200.0; //$200 USD value is difference between red and grey backup warnings
+    private static final int BALANCE_UPDATE_CORRECTION_FACTOR = 1000 / BALANCE_CHECK_INTERVAL_MILLIS;
 
     private final MutableLiveData<Token[]> tokens = new MutableLiveData<>();
     private final MutableLiveData<BigDecimal> total = new MutableLiveData<>();
@@ -179,7 +179,7 @@ public class WalletViewModel extends BaseViewModel
     {
         if (currentWallet != null)
         {
-            openSeaCheckCounter = 0;
+            openSeaCheckCounter = CHECK_OPENSEA_INTERVAL_TIME * BALANCE_UPDATE_CORRECTION_FACTOR - 10; //schedule opensea check soon after refresh
             backupCheckVal = 0;
             tokensService.setCurrentAddress(currentWallet.address);
             updateTokens = fetchTokensInteract.fetchStoredWithEth(currentWallet)
@@ -218,7 +218,6 @@ public class WalletViewModel extends BaseViewModel
 
     private void startBalanceUpdate()
     {
-        fetchFromOpensea(ethereumNetworkRepository.getNetworkByChain(MAINNET_ID));
         updateTokenBalances();
         assetDefinitionService.checkTokenscriptEnabledTokens(tokensService);
         assetDefinitionService.getAllLoadedScripts() //holds for loading complete then returns origin contracts
@@ -244,15 +243,12 @@ public class WalletViewModel extends BaseViewModel
 
     private void gotOpenseaTokens(int chainId, Token[] openSeaTokens)
     {
-        //zero out balance of tokens
-        //tokens.postValue(openSeaTokens);
-        ContractType[] filterTypes = { ContractType.ERC721, ContractType.ERC721_LEGACY, ContractType.ERC721_TICKET };
+        ContractType[] filterTypes = { ContractType.ERC721, ContractType.ERC721_LEGACY, ContractType.ERC721_TICKET, ContractType.ERC721_UNDETERMINED };
         List<Token> erc721Tokens = tokensService.getChangedTokenBalance(chainId, openSeaTokens, filterTypes); //zeroiseBalanceOfSpentTokens(chainId, openSeaTokens, ERC721Token.class);
+        tokens.postValue(openSeaTokens);
 
         if (erc721Tokens.size() > 0)
         {
-            tokens.postValue(erc721Tokens.toArray(new Token[0]));
-
             //store these tokens
             updateTokens = addTokenInteract.storeTokens(currentWallet, erc721Tokens.toArray(new Token[0]))
                     .subscribeOn(Schedulers.io())
@@ -260,7 +256,8 @@ public class WalletViewModel extends BaseViewModel
                     .subscribe(this::storedTokens, this::onError);
         }
 
-        progress.postValue(false);
+        //now update network tokens
+        if (chainId == MAINNET_ID) getTokensOnNetwork();
     }
 
     private void onOpenseaError(Throwable throwable)
@@ -285,9 +282,17 @@ public class WalletViewModel extends BaseViewModel
 
     private void receiveNetworkTokens(Token[] receivedTokens)
     {
+        Token[] updatedTokens = tokensService.addTokens(receivedTokens); 
         //add these tokens to the display
-        tokens.postValue(receivedTokens);
-        Token[] updatedTokens = tokensService.addTokens(receivedTokens);
+        tokens.postValue(updatedTokens); //Note: return from addTokens filters out the ContractType.OTHER tokens
+
+        for (Token t : receivedTokens) //Now add unrecognised tokens to scan list
+        {
+            if (t.getInterfaceSpec() == ContractType.OTHER)
+            {
+                unknownAddresses.add(new ContractLocator(t.getAddress(), t.tokenInfo.chainId));
+            }
+        }
 
         //now store the updated tokens
         if (updatedTokens.length > 0)
@@ -320,6 +325,7 @@ public class WalletViewModel extends BaseViewModel
      */
     private void updateTokenBalances()
     {
+        progress.postValue(false);
         addUnresolvedContracts(ethereumNetworkRepository.getAllKnownContracts(tokensService.getNetworkFilters()));
         if (balanceTimerDisposable == null || balanceTimerDisposable.isDisposed())
         {
@@ -405,27 +411,6 @@ public class WalletViewModel extends BaseViewModel
     {
         return assetDefinitionService;
     }
-
-    //NB: This function is used to calculate total value of all tokens plus eth.
-    //TODO: On mainnet, get tickers for all token values and calculate the overall $ value of all tokens + eth
-//    private void showTotalBalance(Token[] tokens) {
-//        BigDecimal total = new BigDecimal("0");
-//        for (Token token : tokens) {
-//            if (token.balance != null && token.ticker != null
-//                    && token.balance.compareTo(BigDecimal.ZERO) != 0) {
-//                BigDecimal decimalDivisor = new BigDecimal(Math.pow(10, token.tokenInfo.decimals));
-//                BigDecimal ethBalance = token.tokenInfo.decimals > 0
-//                        ? token.balance.divide(decimalDivisor)
-//                        : token.balance;
-//                total = total.add(ethBalance.multiply(new BigDecimal(token.ticker.price)));
-//            }
-//        }
-//        total = total.setScale(2, BigDecimal.ROUND_HALF_UP).stripTrailingZeros();
-//        if (total.compareTo(BigDecimal.ZERO) == 0) {
-//            total = null;
-//        }
-//        this.total.postValue(total);
-//    }
 
     public void showAddToken(Context context) {
         addTokenRouter.open(context, null);
@@ -598,35 +583,18 @@ public class WalletViewModel extends BaseViewModel
             openSeaCheckCounter ++;
         }
 
-        //init events
-        switch (openSeaCheckCounter)
-        {
-            case 4:
-                if (ethereumNetworkRepository.getFilterNetworkList().contains(EthereumNetworkRepository.RINKEBY_ID))
-                    fetchFromOpensea(ethereumNetworkRepository.getNetworkByChain(EthereumNetworkRepository.RINKEBY_ID));
-                break;
-            default:
-                break;
-        }
-
         if (openSeaCheckCounter == backupCheckVal) checkBackup();
 
-        int updateCorrection = 1000 / BALANCE_CHECK_INTERVAL_MILLIS;
-
-        if (openSeaCheckCounter % (CHECK_OPENSEA_INTERVAL_TIME * updateCorrection) == 0)
+        if (openSeaCheckCounter % (CHECK_OPENSEA_INTERVAL_TIME * BALANCE_UPDATE_CORRECTION_FACTOR) == 0)
         {
             NetworkInfo openSeaCheck = ethereumNetworkRepository.getNetworkByChain(MAINNET_ID);
 
-            if (openSeaCheckCounter % (CHECK_OPENSEA_INTERVAL_TIME * updateCorrection * OPENSEA_RINKEBY_CHECK) == 0 && ethereumNetworkRepository.getFilterNetworkList().contains(EthereumNetworkRepository.RINKEBY_ID))
+            if (openSeaCheckCounter % (CHECK_OPENSEA_INTERVAL_TIME * BALANCE_UPDATE_CORRECTION_FACTOR * OPENSEA_RINKEBY_CHECK) == 0 && ethereumNetworkRepository.getFilterNetworkList().contains(EthereumNetworkRepository.RINKEBY_ID))
             {
                 openSeaCheck = ethereumNetworkRepository.getNetworkByChain(EthereumNetworkRepository.RINKEBY_ID);
             }
 
             fetchFromOpensea(openSeaCheck);
-        }
-        else if ((openSeaCheckCounter - 8) % (CHECK_TOKENS_INTERVAL_TIME * updateCorrection) == 0)
-        {
-            getTokensOnNetwork();
         }
     }
 


### PR DESCRIPTION
Fix up the token type resolution.

The following was happening:

- Race between AmberData market discovery and OpenSea token fetch. If AmberData completed first token could be classified as ERC20.
- Opensea defaults to a small token window, and requires paging through results. Some results were getting truncated, leading to incorrect balances and completely missing tokens.

Solution:

1. Page through opensea results until there's no more data.
2. Upon new token being added, treat with suspicion:
   if from generic source, like AmberData then mark as unknown.
   if from focused source such as OpenSea, mark as ERC721_unidentified
3. As opensea discovers new tokens, immediately resolve their types. If the system had categorised the token previously as non-ERC721 then re-classify as ERC721_unidentified
4. For ERC721_Unidentified, finalise the type by querying the interface spec and as a last resort do a get balance on it to find array type balance.