### PR TITLE
View size Optimisation

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -112,6 +112,8 @@ public class Token implements Parcelable, Comparable<Token>
             hasTokenScript = oldToken.hasTokenScript;
             hasDebugTokenscript = oldToken.hasDebugTokenscript;
             lastTxTime = oldToken.lastTxTime;
+            iconifiedWebviewHeight = oldToken.iconifiedWebviewHeight;
+            nonIconifiedWebviewHeight = oldToken.nonIconifiedWebviewHeight;
         }
         refreshCheck = false;
     }

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -501,4 +501,14 @@ public class TokensService
 
         return classTokens.toArray(new Token[0]);
     }
+
+    public void updateTokenViewSizes(Token updatedToken)
+    {
+        Token cachedToken = getToken(updatedToken.tokenInfo.chainId, updatedToken.getAddress());
+        if (cachedToken != null)
+        {
+            cachedToken.iconifiedWebviewHeight = updatedToken.iconifiedWebviewHeight;
+            cachedToken.nonIconifiedWebviewHeight = updatedToken.nonIconifiedWebviewHeight;
+        }
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/AssetDisplayActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AssetDisplayActivity.java
@@ -127,10 +127,8 @@ public class AssetDisplayActivity extends BaseActivity implements StandardFuncti
         findViewById(R.id.certificate_spinner).setVisibility(View.VISIBLE);
         viewModel.checkTokenScriptValidity(token);
 
-        token.iconifiedWebviewHeight = 0;
-        token.nonIconifiedWebviewHeight = 0;
         iconifiedCheck = true;
-        if (token.getArrayBalance().size() > 0 && viewModel.getAssetDefinitionService().hasDefinition(token.tokenInfo.chainId, token.tokenInfo.address))
+        if (token.iconifiedWebviewHeight == 0 && token.getArrayBalance().size() > 0 && viewModel.getAssetDefinitionService().hasDefinition(token.tokenInfo.chainId, token.tokenInfo.address))
         {
             initWebViewCheck(iconifiedCheck);
             handler.postDelayed(this, 1500);
@@ -276,9 +274,10 @@ public class AssetDisplayActivity extends BaseActivity implements StandardFuncti
         testView.addOnLayoutChangeListener((v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
             if (token != null)
             {
-                if (iconifiedCheck)token.iconifiedWebviewHeight = bottom - top;
+                if (iconifiedCheck) token.iconifiedWebviewHeight = bottom - top;
                 else token.nonIconifiedWebviewHeight = bottom - top;
                 checkVal++;
+                viewModel.updateTokenScriptViewSize(token);
             }
 
             if (checkVal == 3) addRunCall(0); //received the third webview render update - this is always the final size we want, but sometimes there's only 1 or 2 updates

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -454,4 +454,9 @@ public class TokenFunctionViewModel extends BaseViewModel
     {
         return openseaService;
     }
+
+    public void updateTokenScriptViewSize(Token token)
+    {
+        tokensService.updateTokenViewSizes(token);
+    }
 }


### PR DESCRIPTION
Only need to calculate the token view size once per session.

This is tricky because the view can change without the tokenscript file hash changing due to attributes. Take the middle ground where an app or wallet refresh will make the app recompute the view size.

Although it's always best to take the high ground, especially when dealing with Sith lords.