### PR TITLE
to be technically correct, ts is not a standard yet.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -206,7 +206,7 @@ public class NewSettingsFragment extends BaseFragment {
     private void setInitialSettingsData(View view) {
         TextView appVersionText = view.findViewById(R.id.text_version);
         appVersionText.setText(String.format("%s (%d)", BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE));
-        TextView tokenScriptVersionText = view.findViewById(R.id.text_tokenscript_standard);
+        TextView tokenScriptVersionText = view.findViewById(R.id.text_tokenscript_compatibility);
         tokenScriptVersionText.setText(TOKENSCRIPT_CURRENT_SCHEMA);
 
         notificationsSetting.setToggleState(viewModel.getNotificationState());

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -140,7 +140,7 @@
                 android:background="@color/mercury" />
 
             <RelativeLayout
-                android:id="@+id/layout_tokenscript_standard"
+                android:id="@+id/layout_tokenscript_compatibility"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
                 android:background="@color/alabaster"
@@ -152,19 +152,34 @@
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
                     android:fontFamily="@font/font_regular"
-                    android:text="@string/tokenscript_standard"
+                    android:text="@string/tokenscript_compatibility"
                     android:textColor="@color/dove"
                     android:textSize="15sp" />
 
-                <TextView
-                    android:id="@+id/text_tokenscript_standard"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
-                    android:fontFamily="@font/font_regular"
-                    android:textColor="@color/dove"
-                    android:textSize="13sp" />
+                >
+
+                <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/font_regular"
+                        android:textColor="@color/dove"
+                        android:text="@string/version"
+                        android:textSize="13sp" />
+
+                <TextView
+                        android:id="@+id/text_tokenscript_compatibility"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/default_gap"
+                        android:fontFamily="@font/font_regular"
+                        android:textColor="@color/dove"
+                        android:textSize="13sp" />
+                </LinearLayout>
             </RelativeLayout>
 
         </LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -534,7 +534,7 @@
     <string name="fail_sign">Failed to sign redeem message</string>
     <string name="hint_contract_type">Token Type</string>
     <string name="reddit">Reddit</string>
-    <string name="tokenscript_standard">TokenScript Standard</string>
+    <string name="tokenscript_compatibility">Compatibilidad de TokenScript</string>
     <string name="version">Version</string>
     <string name="debug_script">TokenScript depurar</string>
     <string name="unsigned_script">no confiable</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -523,7 +523,7 @@
     <string name="fail_sign">无法签署兑换消息</string>
     <string name="hint_contract_type">通证类型</string>
     <string name="reddit">Reddit</string>
-    <string name="tokenscript_standard">TokenScript 标准</string>
+    <string name="tokenscript_compatibility">TokenScript 标准兼容性</string>
     <string name="version">版本</string>
     <string name="debug_script">TokenScript 调试</string>
     <string name="unsigned_script">不信任</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,7 +534,7 @@
     <string name="fail_sign">Failed to sign redeem message</string>
     <string name="hint_contract_type">Token Type</string>
     <string name="reddit">Reddit</string>
-    <string name="tokenscript_standard">TokenScript Standard</string>
+    <string name="tokenscript_compatibility">TokenScript Compatibiity</string>
     <string name="version">Version</string>
     <string name="debug_script">TokenScript debug</string>
     <string name="unsigned_script">untrusted</string>


### PR DESCRIPTION
reword TokenScript to avoid using the word standard. we do use "standard" in PR but technically not yet. e.g. W3C calls HTML a "recommendation" and IETF calls theirs "RFC", to be humble where ISO, ASN.1 and ITU are supposedly proper standard.