### PR TITLE
Fix DappBrowser issues

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -345,7 +345,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
                     break;
             }
 
-            if (f != null) showFragment(f, tag);
+            if (f != null && !f.isAdded()) showFragment(f, tag);
         }
     }
 
@@ -816,7 +816,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
                 }
             });
             dialog.setOnRejectListener(v -> {
-                web3.onSignCancel(message);
+                if (web3 != null) web3.onSignCancel(message);
                 dialog.dismiss();
             });
             dialog.show();


### PR DESCRIPTION
Fix for fragment already added and callback crash.

Both reported on crashlytics:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.alphawallet.app.web3.Web3View.onSignTransactionSuccessful(com.alphawallet.app.web3.entity.Web3Transaction, java.lang.String)' on a null object reference
       at com.alphawallet.app.ui.DappBrowserFragment.handleTransactionCallback + 819(DappBrowserFragment.java:819)
       at com.alphawallet.app.ui.HomeActivity.onActivityResult + 861(HomeActivity.java:861)
       at android.app.Activity.dispatchActivityResult + 7385(Activity.java:7385)
       at android.app.ActivityThread.deliverResults + 4397(ActivityThread.java:4397)
       at android.app.ActivityThread.handleSendResult + 4445(ActivityThread.java:4445)
       at android.app.ActivityThread.-wrap19()
       at android.app.ActivityThread$H.handleMessage + 1724(ActivityThread.java:1724)
       at android.os.Handler.dispatchMessage + 106(Handler.java:106)
       at android.os.Looper.loop + 192(Looper.java:192)
       at android.app.ActivityThread.main + 6702(ActivityThread.java:6702)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 549(RuntimeInit.java:549)
       at com.android.internal.os.ZygoteInit.main + 826(ZygoteInit.java:826)
```
```
Fatal Exception: java.lang.IllegalStateException: Fragment already added: DappHomeFragment{d1b86eb #1 id=0x7f0a00d5 DAPP_HOME}
       at android.support.v4.app.FragmentManagerImpl.addFragment + 1916(FragmentManager.java:1916)
       at android.support.v4.app.BackStackRecord.executeOps + 765(BackStackRecord.java:765)
       at android.support.v4.app.FragmentManagerImpl.executeOps + 2625(FragmentManager.java:2625)
       at android.support.v4.app.FragmentManagerImpl.executeOpsTogether + 2411(FragmentManager.java:2411)
       at android.support.v4.app.FragmentManagerImpl.removeRedundantOperationsAndExecute + 2366(FragmentManager.java:2366)
       at android.support.v4.app.FragmentManagerImpl.execPendingActions + 2273(FragmentManager.java:2273)
       at android.support.v4.app.FragmentManagerImpl$1.run + 733(FragmentManager.java:733)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 226(Looper.java:226)
       at android.app.ActivityThread.main + 7212(ActivityThread.java:7212)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 576(RuntimeInit.java:576)
       at com.android.internal.os.ZygoteInit.main + 956(ZygoteInit.java:956)
```