### PR TITLE
Fix my address activity crash

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -401,6 +401,12 @@ public class MyAddressActivity extends BaseActivity implements AmountUpdateCallb
         wallet = getIntent().getParcelableExtra(C.Key.WALLET);
         token = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
         overrideNetwork = getIntent().getIntExtra(OVERRIDE_DEFAULT, 1);
+
+        if (wallet == null)
+        {
+            //have no address. Can only quit the activity
+            finish();
+        }
     }
 
     private boolean checkWritePermission() {


### PR DESCRIPTION
If there was no wallet object recovered from the Intent we can't proceed. Only makes sense to terminate the activity.