### PR TITLE
Upgrade Web3j to v4.5.17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ project.ext {
     okhttpVersion = "4.0.0"
     picassoVersion = "2.71828"
     supportVersion = "28.0.0"
-    web3jVersion = "4.2.1-android"
+    web3jVersion = "4.5.17"
     gsonVersion = "2.8.5"
     rxJavaVersion = "2.2.10"
     rxAndroidVersion = "2.1.1"

--- a/app/src/main/java/com/alphawallet/app/entity/MagicLinkParcel.java
+++ b/app/src/main/java/com/alphawallet/app/entity/MagicLinkParcel.java
@@ -107,21 +107,22 @@ public class MagicLinkParcel implements Parcelable
             BigInteger expiry = BigInteger.valueOf(order.expiry);
             //convert to signature representation
             Sign.SignatureData sellerSig = CryptoFunctions.sigFromByteArray(order.signature);
+            int v = (new BigInteger(sellerSig.getV())).intValue();
 
             switch (order.contractType)
             {
                 case spawnable:
-                    data = TokenRepository.createSpawnPassTo(token, expiry, order.tokenIds, sellerSig.getV(), sellerSig.getR(), sellerSig.getS(), recipient);
+                    data = TokenRepository.createSpawnPassTo(token, expiry, order.tokenIds, v, sellerSig.getR(), sellerSig.getS(), recipient);
                     break;
                 case currencyLink:
                     // for testing only, we would be using an intermediate server
-                    data = TokenRepository.createDropCurrency(order, sellerSig.getV(), sellerSig.getR(), sellerSig.getS(), recipient);
+                    data = TokenRepository.createDropCurrency(order, v, sellerSig.getR(), sellerSig.getS(), recipient);
                     break;
                 default:
                     for (int ticketIndex : order.indices) {
                         tokenElements.add(BigInteger.valueOf(ticketIndex));
                     }
-                    data = TokenRepository.createTrade(token, expiry, tokenElements, sellerSig.getV(), sellerSig.getR(), sellerSig.getS());
+                    data = TokenRepository.createTrade(token, expiry, tokenElements, v, sellerSig.getR(), sellerSig.getS());
                     break;
             }
         }

--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/TokenscriptFunction.java
@@ -281,7 +281,7 @@ public abstract class TokenscriptFunction
                     params.add(new Utf8String(arg.element.value));
                     break;
                 case "bytes":
-                    params.add(new BytesType(Numeric.hexStringToByteArray(arg.element.value), "bytes"));
+                    params.add(new Bytes32(Numeric.hexStringToByteArray(arg.element.value)));
                     break;
                 case "bytes1":
                     params.add(new Bytes1(Numeric.hexStringToByteArray(arg.element.value)));

--- a/app/src/main/java/com/alphawallet/app/service/AlphaWalletService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AlphaWalletService.java
@@ -187,7 +187,7 @@ public class AlphaWalletService
         {
             args.put("r", Numeric.toHexString(sigData.getR()));
             args.put("s", Numeric.toHexString(sigData.getS()));
-            args.put("v", Integer.toHexString(sigData.getV()));
+            args.put("v", Numeric.toHexString(sigData.getV()));
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/util/AWEnsResolver.java
+++ b/app/src/main/java/com/alphawallet/app/util/AWEnsResolver.java
@@ -2,25 +2,11 @@ package com.alphawallet.app.util;
 
 import android.text.TextUtils;
 
-import org.web3j.crypto.WalletUtils;
-import org.web3j.ens.Contracts;
-import org.web3j.ens.EnsResolutionException;
-import org.web3j.ens.EnsResolver;
-import org.web3j.ens.NameHash;
-import org.web3j.ens.contracts.generated.ENS;
-import org.web3j.ens.contracts.generated.PublicResolver;
+import com.alphawallet.app.entity.Wallet;
+
 import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.DefaultBlockParameterName;
-import org.web3j.protocol.core.methods.response.EthBlock;
-import org.web3j.protocol.core.methods.response.EthSyncing;
-import org.web3j.protocol.core.methods.response.NetVersion;
-import org.web3j.tx.ClientTransactionManager;
-import org.web3j.tx.TransactionManager;
-import org.web3j.utils.Numeric;
 
 import io.reactivex.Single;
-import com.alphawallet.app.entity.Wallet;
-import com.alphawallet.app.service.GasService;
 
 /**
  * Created by James on 29/05/2019.
@@ -110,10 +96,5 @@ public class AWEnsResolver extends EnsResolver
             }
             return address;
         });
-    }
-
-    public static boolean isValidEnsName(String input) {
-        return input != null // will be set to null on new Contract creation
-                && (input.contains(".") || !WalletUtils.isValidAddress(input));
     }
 }

--- a/app/src/main/java/com/alphawallet/app/util/EnsResolver.java
+++ b/app/src/main/java/com/alphawallet/app/util/EnsResolver.java
@@ -1,0 +1,166 @@
+package com.alphawallet.app.util;
+
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.ens.Contracts;
+import org.web3j.ens.EnsResolutionException;
+import org.web3j.ens.NameHash;
+import org.web3j.ens.contracts.generated.ENS;
+import org.web3j.ens.contracts.generated.PublicResolver;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthSyncing;
+import org.web3j.protocol.core.methods.response.NetVersion;
+import org.web3j.tx.ClientTransactionManager;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.DefaultGasProvider;
+import org.web3j.utils.Numeric;
+
+/**
+ * EnsResolver from Web3j adapted for Android Java's BigInteger
+ */
+public class EnsResolver {
+
+    public static final long DEFAULT_SYNC_THRESHOLD = 1000 * 60 * 3;
+    public static final String REVERSE_NAME_SUFFIX = ".addr.reverse";
+
+    private final Web3j web3j;
+    private final int addressLength;
+    private final TransactionManager transactionManager;
+    private long syncThreshold; // non-final in case this value needs to be tweaked
+
+    public EnsResolver(Web3j web3j, long syncThreshold, int addressLength) {
+        this.web3j = web3j;
+        transactionManager = new ClientTransactionManager(web3j, null); // don't use empty string
+        this.syncThreshold = syncThreshold;
+        this.addressLength = addressLength;
+    }
+
+    public EnsResolver(Web3j web3j, long syncThreshold) {
+        this(web3j, syncThreshold, Keys.ADDRESS_LENGTH_IN_HEX);
+    }
+
+    public EnsResolver(Web3j web3j) {
+        this(web3j, DEFAULT_SYNC_THRESHOLD);
+    }
+
+    public void setSyncThreshold(long syncThreshold) {
+        this.syncThreshold = syncThreshold;
+    }
+
+    public long getSyncThreshold() {
+        return syncThreshold;
+    }
+
+    /**
+     * Provides an access to a valid public resolver in order to access other API methods.
+     *
+     * @param ensName our user input ENS name
+     * @return PublicResolver
+     */
+    protected PublicResolver obtainPublicResolver(String ensName) {
+        if (isValidEnsName(ensName, addressLength)) {
+            try {
+                if (!isSynced()) {
+                    throw new EnsResolutionException("Node is not currently synced");
+                } else {
+                    return lookupResolver(ensName);
+                }
+            } catch (Exception e) {
+                throw new EnsResolutionException("Unable to determine sync status of node", e);
+            }
+
+        } else {
+            throw new EnsResolutionException("EnsName is invalid: " + ensName);
+        }
+    }
+
+    public String resolve(String contractId) {
+        if (isValidEnsName(contractId, addressLength)) {
+            PublicResolver resolver = obtainPublicResolver(contractId);
+
+            byte[] nameHash = NameHash.nameHashAsBytes(contractId);
+            String contractAddress = null;
+            try {
+                contractAddress = resolver.addr(nameHash).send();
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to execute Ethereum request", e);
+            }
+
+            if (!WalletUtils.isValidAddress(contractAddress)) {
+                throw new RuntimeException("Unable to resolve address for name: " + contractId);
+            } else {
+                return contractAddress;
+            }
+        } else {
+            return contractId;
+        }
+    }
+
+    /**
+     * Reverse name resolution as documented in the <a
+     * href="https://docs.ens.domains/contract-api-reference/reverseregistrar">specification</a>.
+     *
+     * @param address an ethereum address, example: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
+     * @return a EnsName registered for provided address
+     */
+    public String reverseResolve(String address) {
+        if (WalletUtils.isValidAddress(address, addressLength)) {
+            String reverseName = Numeric.cleanHexPrefix(address) + REVERSE_NAME_SUFFIX;
+            PublicResolver resolver = obtainPublicResolver(reverseName);
+
+            byte[] nameHash = NameHash.nameHashAsBytes(reverseName);
+            String name;
+            try {
+                name = resolver.name(nameHash).send();
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to execute Ethereum request", e);
+            }
+
+            if (!isValidEnsName(name, addressLength)) {
+                throw new RuntimeException("Unable to resolve name for address: " + address);
+            } else {
+                return name;
+            }
+        } else {
+            throw new EnsResolutionException("Address is invalid: " + address);
+        }
+    }
+
+    private PublicResolver lookupResolver(String ensName) throws Exception {
+        NetVersion netVersion = web3j.netVersion().send();
+        String registryContract = Contracts.resolveRegistryContract(netVersion.getNetVersion());
+
+        ENS ensRegistry =
+                ENS.load(registryContract, web3j, transactionManager, new DefaultGasProvider());
+
+        byte[] nameHash = NameHash.nameHashAsBytes(ensName);
+        String resolverAddress = ensRegistry.resolver(nameHash).send();
+
+        return PublicResolver.load(
+                resolverAddress, web3j, transactionManager, new DefaultGasProvider());
+    }
+
+    boolean isSynced() throws Exception {
+        EthSyncing ethSyncing = web3j.ethSyncing().send();
+        if (ethSyncing.isSyncing()) {
+            return false;
+        } else {
+            EthBlock ethBlock =
+                    web3j.ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false).send();
+            long timestamp = ethBlock.getBlock().getTimestamp().longValue() * 1000;
+
+            return System.currentTimeMillis() - syncThreshold < timestamp;
+        }
+    }
+
+    public static boolean isValidEnsName(String input) {
+        return isValidEnsName(input, Keys.ADDRESS_LENGTH_IN_HEX);
+    }
+
+    public static boolean isValidEnsName(String input, int addressLength) {
+        return input != null // will be set to null on new Contract creation
+                && (input.contains(".") || !WalletUtils.isValidAddress(input, addressLength));
+    }
+}


### PR DESCRIPTION
Updating web3j to v4.5.17 in order to get two critical updates:

- ENS update to new resolver contract.
- Use correct Chain ID within EIP155 signature scheme.