### PR TITLE
DappBrowser Fixes from crashlytics

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -42,7 +42,7 @@ public class TokensService
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.tokenRepository = tokenRepository;
         loaded = false;
-        networkFilter = new ArrayList<>(10);
+        networkFilter = new ArrayList<>();
         setupFilter();
         focusToken = null;
         okHttpClient = client;
@@ -388,7 +388,15 @@ public class TokensService
     private Token checkCurrencies()
     {
         if (currencyCheckCount >= networkFilter.size()) return null;
-        int chainId = networkFilter.get(currencyCheckCount);
+        int chainId;
+        try
+        {
+            chainId = networkFilter.get(currencyCheckCount);
+        }
+        catch (IndexOutOfBoundsException e)
+        {
+            return null;
+        }
         currencyCheckCount++;
         return getToken(chainId, currentAddress);
     }

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -216,12 +216,15 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         homePressed = false;
         if (currentFragment == null) currentFragment = BROWSER_HOME;
         attachFragment(currentFragment);
-        if (web3 == null && getActivity() != null) //trigger reload
+        if ((web3 == null || viewModel == null) && getActivity() != null) //trigger reload
         {
-            web3.setWebLoadCallback(this);
             ((HomeActivity)getActivity()).ResetDappBrowser();
         }
-        if (viewModel != null) viewModel.resetDebounce();
+        else
+        {
+            web3.setWebLoadCallback(this);
+            if (viewModel != null) viewModel.resetDebounce();
+        }
     }
 
     @Nullable

--- a/app/src/main/java/com/alphawallet/app/util/DappBrowserUtils.java
+++ b/app/src/main/java/com/alphawallet/app/util/DappBrowserUtils.java
@@ -20,18 +20,23 @@ public class DappBrowserUtils {
     private static final String DAPPS_LIST_FILENAME = "dapps_list.json";
 
     public static void saveToPrefs(Context context, List<DApp> myDapps) {
-        //don't store custom dapps
-        List<DApp> primaryDapps = getPrimarySites(context);
-        Map<String, DApp> dappMap = new HashMap<>();
-        for (DApp d : myDapps) dappMap.put(d.getUrl(), d);
-        for (DApp d : primaryDapps) dappMap.remove(d.getUrl());
+        if (context != null)
+        {
+            //don't store custom dapps
+            List<DApp> primaryDapps = getPrimarySites(context);
+            Map<String, DApp> dappMap = new HashMap<>();
+            for (DApp d : myDapps)
+                dappMap.put(d.getUrl(), d);
+            for (DApp d : primaryDapps)
+                dappMap.remove(d.getUrl());
 
-        String myDappsJson = new Gson().toJson(dappMap.values());
-        PreferenceManager
-                .getDefaultSharedPreferences(context)
-                .edit()
-                .putString("my_dapps", myDappsJson)
-                .apply();
+            String myDappsJson = new Gson().toJson(dappMap.values());
+            PreferenceManager
+                    .getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString("my_dapps", myDappsJson)
+                    .apply();
+        }
     }
 
     private static List<DApp> getPrimarySites(Context context)
@@ -58,6 +63,7 @@ public class DappBrowserUtils {
     }
 
     public static List<DApp> getMyDapps(Context context) {
+        if (context == null) return new ArrayList<>();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String myDappsJson = prefs.getString("my_dapps", "");
 
@@ -72,6 +78,7 @@ public class DappBrowserUtils {
     }
 
     public static List<DApp> getBrowserHistory(Context context) {
+        if (context == null) return new ArrayList<>();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String historyJson = prefs.getString(C.DAPP_BROWSER_HISTORY, "");
 
@@ -86,11 +93,14 @@ public class DappBrowserUtils {
     }
 
     public static void clearHistory(Context context) {
-        PreferenceManager
-                .getDefaultSharedPreferences(context)
-                .edit()
-                .putString(C.DAPP_BROWSER_HISTORY, "")
-                .apply();
+        if (context != null)
+        {
+            PreferenceManager
+                    .getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString(C.DAPP_BROWSER_HISTORY, "")
+                    .apply();
+        }
     }
 
     public static void addToHistory(Context context, DApp dapp) {
@@ -127,11 +137,14 @@ public class DappBrowserUtils {
     }
 
     private static void saveHistory(Context context, List<DApp> history) {
-        String myDappsJson = new Gson().toJson(history);
-        PreferenceManager
-                .getDefaultSharedPreferences(context)
-                .edit()
-                .putString(C.DAPP_BROWSER_HISTORY, myDappsJson)
-                .apply();
+        if (context != null)
+        {
+            String myDappsJson = new Gson().toJson(history);
+            PreferenceManager
+                    .getDefaultSharedPreferences(context)
+                    .edit()
+                    .putString(C.DAPP_BROWSER_HISTORY, myDappsJson)
+                    .apply();
+        }
     }
 }


### PR DESCRIPTION
Fix for an old dappbrowser issue.
- When restarted, the browser should check if it has the web3 object initialised. If not then we need to reload the fragment.
- When using preferences, ensure the current context is valid.