### PR TITLE
Remove irrelevant option

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -486,6 +486,10 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         {
             toolbar.inflateMenu(R.menu.menu_scan);
         }
+        else if (EthereumNetworkRepository.defaultDapp() != null)
+        {
+            toolbar.inflateMenu(R.menu.menu_defaultdapp);
+        }
         else
         {
             toolbar.inflateMenu(R.menu.menu_bookmarks);

--- a/app/src/main/res/menu/menu_defaultdapp.xml
+++ b/app/src/main/res/menu/menu_defaultdapp.xml
@@ -4,13 +4,6 @@
 
     <group android:id="@+id/dapp_browser_menu">
         <item
-            android:id="@+id/action_add_to_my_dapps"
-            android:icon="@drawable/ic_add_24dp"
-            android:orderInCategory="15"
-            android:title="@string/add_to_my_dapps"
-            app:showAsAction="withText" />
-
-        <item
             android:id="@+id/action_reload"
             android:icon="@drawable/ic_dapp_reload"
             android:orderInCategory="15"


### PR DESCRIPTION
Prevent display and usage of 'add dapp' when default dapp is specified.

AWD_19: Can't access mydapps when wallet is built in this mode - option should be removed.

This is confusing to users - with a default dapp there's no way to access bookmarks, so remove options involving bookmarks.