### PR TITLE
Tighten URL handling for TokenScript.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -1595,7 +1595,8 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     {
         String view = getTokenView(token.tokenInfo.chainId, token.tokenInfo.address, ASSET_DETAIL_VIEW_NAME);
         String iconifiedView = getTokenView(token.tokenInfo.chainId, token.tokenInfo.address, ASSET_SUMMARY_VIEW_NAME);
-        return view.equals(iconifiedView);
+        if (view == null || iconifiedView == null) return false;
+        else return view.equals(iconifiedView);
     }
 
     public List<ContractLocator> getHoldingContracts(TokenDefinition td)

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -97,7 +97,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     private AWalletAlertDialog alertDialog;
     private Message<String> messageToSign;
     private FunctionButtonBar functionBar;
-    private Handler handler;
+    private final Handler handler = new Handler();
     private boolean reloaded;
     private int userInputCheckCount;
 
@@ -126,15 +126,6 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         reloaded = false;
 
         getAttrs();
-
-        tokenView.setWebViewClient(new WebViewClient() {
-            @Override
-            public boolean shouldOverrideUrlLoading(WebView view, String url)
-            {
-                if (handleMapClick(url)) return true; //handle specific map click
-                else return handleURLClick(url);      //otherwise handle an attempt to visit a URL from TokenScript. If URL isn't in the approved DAPP list then fail
-            }
-        });
     }
 
     private void displayFunction(String tokenAttrs)
@@ -483,7 +474,6 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     @Override
     public void functionSuccess()
     {
-        if (handler == null) handler = new Handler();
         LinearLayout successOverlay = findViewById(R.id.layout_success_overlay);
         if (successOverlay != null) successOverlay.setVisibility(View.VISIBLE);
         handler.postDelayed(closer, 1000);
@@ -533,6 +523,15 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     {
         if (!reloaded) tokenView.reload();
         reloaded = true;
+    }
+
+    @Override
+    public boolean overridePageLoad(WebView view, String url)
+    {
+        if (handleMapClick(url))
+            return true;                     //handle specific map click
+        else
+            return handleURLClick(url);      //otherwise handle an attempt to visit a URL from TokenScript. If URL isn't in the approved DAPP list then fail
     }
 
     @Override
@@ -620,7 +619,6 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
 
     protected void showProgressSpinner(boolean show)
     {
-        if (handler == null) handler = new Handler();
         if (show) handler.post(progress);
         else handler.post(progressOff);
     }

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -279,6 +279,19 @@ public class Web3TokenView extends WebView
         }
 
         @Override
+        public boolean shouldOverrideUrlLoading(WebView view, String url)
+        {
+            if (assetHolder != null)
+            {
+                return assetHolder.overridePageLoad(view, url);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        @Override
         public void onUnhandledKeyEvent(WebView view, KeyEvent event) {
             if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER)
             {

--- a/app/src/main/java/com/alphawallet/app/web3/entity/PageReadyCallback.java
+++ b/app/src/main/java/com/alphawallet/app/web3/entity/PageReadyCallback.java
@@ -10,4 +10,5 @@ public interface PageReadyCallback
 {
     void onPageLoaded(WebView view);
     void onPageRendered(WebView view);
+    default boolean overridePageLoad(WebView view, String url) { return true; }; //by default, don't allow TokenScript to access any U
 }


### PR DESCRIPTION
Add an interface method for URL override so that URL interception for TS can be handled consistently. 

If left non-overridden then don't allow any URL call from within TokenScript.