### PR TITLE
Remove redundant node health check

### DIFF
--- a/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
+++ b/app/src/awallet/java/com/alphawallet/app/repository/EthereumNetworkRepository.java
@@ -28,44 +28,6 @@ public class EthereumNetworkRepository extends EthereumNetworkBase
     {
         super(preferenceRepository, tickerService, new NetworkInfo[0], true);
         context = ctx;
-
-        //test main-net node see if we need to switch to backup.
-        fetchLatestBlockNumber()
-                .subscribeOn(Schedulers.io())
-                .observeOn(Schedulers.io())
-                .subscribe(this::gotBlock, this::onBlockError)
-                .isDisposed();
-    }
-
-    private void gotBlock(BigInteger blockNumber)
-    {
-        if (blockNumber.equals(BigInteger.ZERO)) //return of block zero signifies an error
-        {
-            useBackupNode = true;
-        }
-    }
-
-    private void onBlockError(Throwable throwable)
-    {
-        //no connection, use backup
-        useBackupNode = true;
-    }
-
-    private Single<BigInteger> fetchLatestBlockNumber()
-    {
-        return Single.fromCallable(() -> {
-            try
-            {
-                Web3j web3j = TokenRepository.getWeb3jService(MAINNET_ID);
-                EthBlockNumber blk = web3j.ethBlockNumber()
-                        .send();
-                return blk.getBlockNumber();
-            }
-            catch (Exception e)
-            {
-                return BigInteger.ZERO;
-            }
-        });
     }
 
     public static void setChainColour(View view, int chainId)

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -90,7 +90,6 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
     public static final String GOERLI_BLOCKSCOUT = "eth/goerli";
 
     final Map<Integer, NetworkInfo> networkMap;
-    protected static boolean useBackupNode = false;
 
     final NetworkInfo[] NETWORKS;
     static final NetworkInfo[] DEFAULT_NETWORKS = new NetworkInfo[] {
@@ -359,8 +358,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         switch (networkId)
         {
             case MAINNET_ID:
-                if (useBackupNode) return MAINNET_FALLBACK_RPC_URL;
-                else return MAINNET_RPC_URL;
+                return MAINNET_RPC_URL;
             case KOVAN_ID:
                 return KOVAN_RPC_URL;
             case ROPSTEN_ID:
@@ -543,10 +541,5 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
     public Token getBlankOverrideToken()
     {
         return null;
-    }
-
-    public boolean shouldUseBackupNode()
-    {
-        return useBackupNode;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkRepositoryType.java
@@ -42,7 +42,6 @@ public interface EthereumNetworkRepositoryType {
 
 	void refreshTickers();
 	boolean checkTickers();
-	boolean shouldUseBackupNode();
 
 	List<ContractLocator> getAllKnownContracts(List<Integer> networkFilters);
 	Single<Token[]> getBlankOverrideTokens(Wallet wallet);

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -106,9 +106,7 @@ public class TokenRepository implements TokenRepositoryType {
 
     private void buildWeb3jClient(NetworkInfo networkInfo)
     {
-        String rpcServerUrl = ethereumNetworkRepository.shouldUseBackupNode() ? networkInfo.backupNodeUrl : networkInfo.rpcServerUrl;
-        String rpcSecondary = ethereumNetworkRepository.shouldUseBackupNode() ? networkInfo.rpcServerUrl : networkInfo.backupNodeUrl;
-        AWHttpService publicNodeService = new AWHttpService(rpcServerUrl, rpcSecondary, okClient, false);
+        AWHttpService publicNodeService = new AWHttpService(networkInfo.backupNodeUrl, networkInfo.rpcServerUrl, okClient, false);
         EthereumNetworkRepository.addRequiredCredentials(networkInfo.chainId, publicNodeService);
         web3jNodeServers.put(networkInfo.chainId, Web3j.build(publicNodeService));
     }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -316,9 +316,4 @@ public class DappBrowserViewModel extends BaseViewModel  {
         intent.putExtra(WALLET, defaultWallet.getValue());
         ctx.startActivity(intent);
     }
-
-    public boolean shouldUseBackupNode()
-    {
-        return ethereumNetworkRepository.shouldUseBackupNode();
-    }
 }


### PR DESCRIPTION
Remove requirement for node health check, so we can remove this code now.

This code used to switch between the primary or secondary node based on a health check at startup. Since we now always try primary then secondary node if primary times out, this check is now pointless.

See ```class AWHttpService``` ```performIO``` for more details.