### PR TITLE
Update POA info

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
+++ b/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
@@ -4,19 +4,6 @@ public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
     public String backupNodeUrl = null;
     public String etherscanTxUrl = null;
 
-
-    public NetworkInfo(
-            String name,
-            String symbol,
-            String rpcServerUrl,
-            String etherscanUrl,
-            int chainId,
-            boolean isMainNetwork,
-            String tickerId,
-            String blockscoutAPI) {
-        super(name, symbol, rpcServerUrl, etherscanUrl, chainId, isMainNetwork, tickerId, blockscoutAPI);
-    }
-
     public NetworkInfo(
             String name,
             String symbol,

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -47,20 +47,20 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
      */
 
     //Fallback nodes: these nodes are used if there's no Amberdata key, and also as a fallback in case the primary node times out while attempting a call
-    public static final String MAINNET_FALLBACK_RPC_URL = "https://mainnet.infura.io/v3/" + BuildConfig.InfuraAPI;
-    public static final String RINKEBY_FALLBACK_RPC_URL = "https://rinkeby.infura.io/v3/" + BuildConfig.InfuraAPI;
+    public static final String MAINNET_RPC_URL = "https://mainnet.infura.io/v3/" + BuildConfig.InfuraAPI;
+    public static final String RINKEBY_RPC_URL = "https://rinkeby.infura.io/v3/" + BuildConfig.InfuraAPI;
 
     //Note that AlphaWallet now uses a double node configuration. See class AWHttpService comment 'try primary node'.
     //If you supply a main RPC and secondary it will try the secondary if the primary node times out after 10 seconds.
     //See the declaration of NetworkInfo - it has a member backupNodeUrl. Put your secondary node here.
 
     public static final String BACKUP_INFURA_KEY = BuildConfig.InfuraAPI;
-    public static final String MAINNET_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI : MAINNET_FALLBACK_RPC_URL;
+    public static final String MAINNET_FALLBACK_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI : MAINNET_RPC_URL;
     public static final String CLASSIC_RPC_URL = "https://ethereumclassic.network";
     public static final String XDAI_RPC_URL = "https://dai.poa.network";
     public static final String POA_RPC_URL = "https://core.poa.network/";
     public static final String ROPSTEN_RPC_URL = "https://ropsten.infura.io/v3/" + BuildConfig.InfuraAPI;
-    public static final String RINKEBY_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI + "&x-amberdata-blockchain-id=1b3f7a72b3e99c13" : RINKEBY_FALLBACK_RPC_URL;
+    public static final String RINKEBY_FALLBACK_RPC_URL = !BuildConfig.AmberdataAPI.startsWith("obtain") ? "https://rpc.web3api.io?x-api-key=" + BuildConfig.AmberdataAPI + "&x-amberdata-blockchain-id=1b3f7a72b3e99c13" : RINKEBY_RPC_URL;
     public static final String KOVAN_RPC_URL = "https://kovan.infura.io/v3/" + BuildConfig.InfuraAPI;
     public static final String SOKOL_RPC_URL = "https://sokol.poa.network";
     public static final String GOERLI_RPC_URL = "https://goerli.infura.io/v3/" + BuildConfig.InfuraAPI;
@@ -102,7 +102,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                     MAINNET_BLOCKSCOUT),
             new NetworkInfo(C.CLASSIC_NETWORK_NAME, C.ETC_SYMBOL,
                     CLASSIC_RPC_URL,
-                    "https://gastracker.io/tx/",CLASSIC_ID, true, C.CLASSIC_TICKER_NAME, CLASSIC_BLOCKSCOUT),
+                    "https://gastracker.io/tx/",CLASSIC_ID, true, CLASSIC_RPC_URL, null, C.CLASSIC_TICKER_NAME, CLASSIC_BLOCKSCOUT),
             new NetworkInfo(C.XDAI_NETWORK_NAME,
                     C.xDAI_SYMBOL,
                     XDAI_RPC_URL,
@@ -113,7 +113,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                     "https://blockscout.com/poa/dai/", C.XDAI_TICKER_NAME, XDAI_BLOCKSCOUT),
             new NetworkInfo(C.POA_NETWORK_NAME, C.POA_SYMBOL,
                     POA_RPC_URL,
-                    "https://poaexplorer.com/txid/search/", POA_ID, false, C.ETHEREUM_TICKER_NAME, POA_BLOCKSCOUT),
+                    "https://blockscout.com/poa/core/tx/", POA_ID, false, POA_RPC_URL, "https://blockscout.com/poa/core/", C.ETHEREUM_TICKER_NAME, POA_BLOCKSCOUT),
             new NetworkInfo(C.ARTIS_SIGMA1_NETWORK, C.ARTIS_SIGMA1_SYMBOL, ARTIS_SIGMA1_RPC_URL,
                     "https://explorer.sigma1.artis.network/tx/", ARTIS_SIGMA1_ID, false,
                     ARTIS_SIGMA1_RPC_URL,
@@ -129,7 +129,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                     "https://api-ropsten.etherscan.io/", C.ETHEREUM_TICKER_NAME, ROPSTEN_BLOCKSCOUT),
             new NetworkInfo(C.SOKOL_NETWORK_NAME, C.POA_SYMBOL,
                     SOKOL_RPC_URL,
-                    "https://sokol-explorer.poa.network/account/",SOKOL_ID, false, C.ETHEREUM_TICKER_NAME, SOKOL_BLOCKSCOUT),
+                    "https://blockscout.com/poa/sokol/tx/",SOKOL_ID, false, SOKOL_RPC_URL, "https://blockscout.com/poa/sokol/", C.ETHEREUM_TICKER_NAME, SOKOL_BLOCKSCOUT),
             new NetworkInfo(C.RINKEBY_NETWORK_NAME, C.ETH_SYMBOL, RINKEBY_RPC_URL,
                     "https://rinkeby.etherscan.io/tx/",RINKEBY_ID, false,
                     RINKEBY_FALLBACK_RPC_URL,

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -50,7 +50,7 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
                     CLASSIC_ID, true, "ethereum-classic", CLASSIC_BLOCKSCOUT));
             put(XDAI_ID, new NetworkInfo("xDAI", "xDAI", XDAI_RPC_URL, "https://blockscout.com/poa/dai/tx/",
                     XDAI_ID, false, "dai", XDAI_BLOCKSCOUT));
-            put(POA_ID, new NetworkInfo("POA", "POA", POA_RPC_URL, "https://poaexplorer.com/txid/search/",
+            put(POA_ID, new NetworkInfo("POA", "POA", POA_RPC_URL, "https://blockscout.com/poa/core/tx/",
                     POA_ID, false, "ethereum", POA_BLOCKSCOUT));
             put(ARTIS_SIGMA1_ID, new NetworkInfo("ARTIS sigma1", "ATS", ARTIS_SIGMA1_RPC_URL, "https://explorer.sigma1.artis.network/tx/",
                     ARTIS_SIGMA1_ID, false, "artis", ""));
@@ -58,7 +58,7 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
                     KOVAN_ID, false, "ethereum", KOVAN_BLOCKSCOUT));
             put(ROPSTEN_ID, new NetworkInfo("Ropsten (Test)", "ETH", ROPSTEN_RPC_URL, "https://ropsten.etherscan.io/tx/",
                     ROPSTEN_ID, false, "ethereum", ROPSTEN_BLOCKSCOUT));
-            put(SOKOL_ID, new NetworkInfo("Sokol (Test)", "POA", SOKOL_RPC_URL, "https://sokol-explorer.poa.network/account/",
+            put(SOKOL_ID, new NetworkInfo("Sokol (Test)", "POA", SOKOL_RPC_URL, "https://blockscout.com/poa/sokol/tx/",
                     SOKOL_ID, false, "ethereum", SOKOL_BLOCKSCOUT));
             put(RINKEBY_ID, new NetworkInfo("Rinkeby (Test)", "ETH", RINKEBY_RPC_URL, "https://rinkeby.etherscan.io/tx/",
                     RINKEBY_ID, false, "ethereum", RINKEBY_BLOCKSCOUT));

--- a/lib/src/main/java/com/alphawallet/token/entity/MagicLinkInfo.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/MagicLinkInfo.java
@@ -29,8 +29,8 @@ public class MagicLinkInfo
     private static final String kovanEtherscan = "https://kovan.etherscan.io/";
     private static final String ropstenEtherscan = "https://ropsten.etherscan.io/";
     private static final String rinkebyEtherscan = "https://rinkeby.etherscan.io/";
-    private static final String poaEtherscan = "https://poaexplorer.com/";
-    private static final String sokolEtherscan = "https://sokol-explorer.poa.network/account/";
+    private static final String poaEtherscan = "https://blockscout.com/poa/core/";
+    private static final String sokolEtherscan = "https://blockscout.com/poa/sokol/";
     private static final String xDaiEtherscan = "https://blockscout.com/poa/dai/";
     private static final String goerliEtherscan = "https://goerli.etherscan.io/";
     private static final String artisSigma1Etherscan = "https://explorer.sigma1.artis.network/";


### PR DESCRIPTION
- Update the URL nodes with the correct POA info for Core and Sokol.
- Fortify the contract type checker as the node model that POA uses returns VM error and throws an exception if the contract method isn't found. This is critical to identify Sokol/POA contracts as previously the checker would just throw an exception at the first check and skip.

@hboon you may want to check iOS is using these for checking transactions on POA chains:

SOKOL (test):
Fetch Transactions: ```https://blockscout.com/poa/sokol/``` (uses same syntax as etherscan eg: ```https://blockscout.com/poa/sokol/api?module=account&action=txlist&address=0xabcdef...```
Show transaction detail page: ```https://blockscout.com/poa/sokol/tx/0x123456...(tx hash)```

POA Core:
Fetch Transactions: ```https://blockscout.com/poa/core/```
Show detail: ```https://blockscout.com/poa/core/tx/```