### PR TITLE
Refactor TokenHolder to make token display more deterministic.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -150,26 +150,11 @@ public class ERC721Ticket extends Token implements Parcelable {
     {
         viewModel.showRedeemToken(context, this);
     }
-
+    
     @Override
-    public void setupContent(TokenHolder tokenHolder, AssetDefinitionService asset)
+    public int getContractType()
     {
-        tokenHolder.balanceCurrency.setText("--");
-        tokenHolder.textAppreciation.setText("--");
-        tokenHolder.contractType.setVisibility(View.VISIBLE);
-        if (VisibilityFilter.getImageOverride() != 0)
-        {
-            tokenHolder.icon.setVisibility(View.VISIBLE);
-            tokenHolder.icon.setImageResource(VisibilityFilter.getImageOverride());
-        }
-        tokenHolder.chainName.setVisibility(View.VISIBLE);
-        tokenHolder.extendedInfo.setVisibility(View.VISIBLE);
-        tokenHolder.contractType.setText(R.string.ERC721T);
-
-        String composite = getTicketCount() + " " + getFullName(asset, getTicketCount());
-        tokenHolder.balanceEth.setText(composite);
-
-        tokenHolder.layoutValueDetails.setVisibility(View.GONE);
+        return R.string.ERC721T;
     }
 
     public void checkIsMatchedInXML(AssetDefinitionService assetService)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -121,21 +121,9 @@ public class ERC721Token extends Token implements Parcelable
     }
 
     @Override
-    public void setupContent(TokenHolder holder, AssetDefinitionService definition)
+    public int getContractType()
     {
-        //721 Balance
-        int balance = tokenBalanceAssets.size();
-
-        holder.balanceEth.setText(String.valueOf(balance));
-        holder.layoutValueDetails.setVisibility(View.GONE);
-
-        holder.contractType.setVisibility(View.VISIBLE);
-        holder.contractSeparator.setVisibility(View.VISIBLE);
-        holder.contractType.setText(R.string.erc721);
-
-        holder.balanceEth.setVisibility(View.VISIBLE);
-
-        addTokenName(holder, definition);
+        return R.string.erc721;
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -156,26 +156,16 @@ public class Ticket extends Token implements Parcelable
     }
 
     @Override
-    public void setupContent(TokenHolder tokenHolder, AssetDefinitionService asset)
+    public int getContractType()
     {
-        tokenHolder.balanceCurrency.setText("--");
-        tokenHolder.textAppreciation.setText("--");
-
-        tokenHolder.contractType.setVisibility(View.VISIBLE);
-        tokenHolder.contractSeparator.setVisibility(View.VISIBLE);
-        tokenHolder.layoutValueDetails.setVisibility(View.GONE);
         if (contractType == ContractType.ERC875_LEGACY)
         {
-            tokenHolder.contractType.setText(R.string.erc875legacy);
+            return R.string.erc875legacy;
         }
         else
         {
-            tokenHolder.contractType.setText(R.string.erc875);
+            return R.string.erc875;
         }
-
-        String composite = getTicketCount() + " " + getFullName(asset, getTicketCount());
-
-        tokenHolder.balanceEth.setText(composite);
     }
 
     @Override


### PR DESCRIPTION
Remove a lot of view setting code from the tokens and abstract only the bare minimum parts.

This will make it easier to implement the next phase of TokenScript view abstraction where views on the main wallet page can be overridden on a per contract type basis, or from the tokenscript as discussed in the TokenScript meetings.