### PR TITLE
Fix TokenScript Item-View Sizing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -4,13 +4,7 @@ import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
-import android.util.Base64;
-import android.view.View;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
-import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.TicketRangeElement;
@@ -20,37 +14,24 @@ import com.alphawallet.app.interact.SetupTokensInteract;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.entity.RealmToken;
 import com.alphawallet.app.service.AssetDefinitionService;
-import com.alphawallet.app.ui.widget.holder.TokenHolder;
 import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.viewmodel.BaseViewModel;
-import com.alphawallet.app.web3.Web3TokenView;
 import com.alphawallet.app.web3j.datatypes.Function;
-import com.alphawallet.token.entity.TSAction;
 import com.alphawallet.token.entity.TicketRange;
 import com.alphawallet.token.entity.TokenScriptResult;
-import com.alphawallet.token.tools.TokenDefinition;
 
 import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
-
-import static com.alphawallet.token.tools.TokenDefinition.TOKENSCRIPT_ERROR;
-import static com.alphawallet.app.service.AssetDefinitionService.ASSET_DETAIL_VIEW_NAME;
-import static com.alphawallet.app.service.AssetDefinitionService.ASSET_SUMMARY_VIEW_NAME;
 
 public class Token implements Parcelable, Comparable<Token>
 {
@@ -74,10 +55,8 @@ public class Token implements Parcelable, Comparable<Token>
     public long lastTxCheck;
     public long lastTxUpdate;
     public long lastTxTime;
-
-    public int iconifiedWebviewHeight;
-    public int nonIconifiedWebviewHeight;
     private int nameWeight;
+    public int itemViewHeight;
 
     private final Map<BigInteger, Map<String, TokenScriptResult.Attribute>> resultMap = new ConcurrentHashMap<>(); //Build result map for function parse, per tokenId
     private Map<BigInteger, List<String>> functionAvailabilityMap = null;
@@ -121,8 +100,6 @@ public class Token implements Parcelable, Comparable<Token>
             balanceChanged = oldToken.balanceChanged;
             hasTokenScript = oldToken.hasTokenScript;
             lastTxTime = oldToken.lastTxTime;
-            iconifiedWebviewHeight = oldToken.iconifiedWebviewHeight;
-            nonIconifiedWebviewHeight = oldToken.nonIconifiedWebviewHeight;
             functionAvailabilityMap = oldToken.functionAvailabilityMap;
         }
         refreshCheck = false;
@@ -141,8 +118,6 @@ public class Token implements Parcelable, Comparable<Token>
         lastTxUpdate = in.readLong();
         lastTxTime = in.readLong();
         hasTokenScript = in.readByte() == 1;
-        nonIconifiedWebviewHeight = in.readInt();
-        iconifiedWebviewHeight = in.readInt();
         nameWeight = in.readInt();
         ticker = in.readParcelable(TokenTicker.class.getClassLoader());
         functionAvailabilityMap = in.readHashMap(List.class.getClassLoader());
@@ -247,8 +222,6 @@ public class Token implements Parcelable, Comparable<Token>
         dest.writeLong(lastTxUpdate);
         dest.writeLong(lastTxTime);
         dest.writeByte(hasTokenScript?(byte)1:(byte)0);
-        dest.writeInt(nonIconifiedWebviewHeight);
-        dest.writeInt(iconifiedWebviewHeight);
         dest.writeInt(nameWeight);
         dest.writeParcelable(ticker, flags);
         dest.writeMap(functionAvailabilityMap);

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -522,16 +522,6 @@ public class TokensService
         return classTokens.toArray(new Token[0]);
     }
 
-    public void updateTokenViewSizes(Token updatedToken)
-    {
-        Token cachedToken = getToken(updatedToken.tokenInfo.chainId, updatedToken.getAddress());
-        if (cachedToken != null)
-        {
-            cachedToken.iconifiedWebviewHeight = updatedToken.iconifiedWebviewHeight;
-            cachedToken.nonIconifiedWebviewHeight = updatedToken.nonIconifiedWebviewHeight;
-        }
-    }
-
     public String getNetworkName(int chainId)
     {
         NetworkInfo info = ethereumNetworkRepository.getNetworkByChain(chainId);

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -90,7 +90,6 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     private String actionMethod;
     private SystemView systemView;
     private Web3TokenView tokenView;
-    private ProgressBar waitSpinner;
     private SignMessageDialog dialog;
     private final Map<String, String> args = new HashMap<>();
     private StringBuilder attrs;
@@ -117,7 +116,6 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         }
 
         tokenView = findViewById(R.id.web3_tokenview);
-        waitSpinner = findViewById(R.id.progress_element);
 
         tokenView.setChainId(token.tokenInfo.chainId);
         tokenView.setWalletAddress(new Address(token.getWallet()));
@@ -126,15 +124,9 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         tokenView.setOnReadyCallback(this);
         tokenView.setOnSignPersonalMessageListener(this);
         tokenView.setOnSetValuesListener(this);
-        tokenView.setVisibility(View.GONE);
-        waitSpinner.setVisibility(View.VISIBLE);
         tokenView.setKeyboardListenerCallback(this);
         viewModel.startGasPriceUpdate(token.tokenInfo.chainId);
         viewModel.getCurrentWallet();
-
-        //expose the webview and remove the token 'card' background
-        findViewById(R.id.layout_webwrapper).setBackgroundResource(R.drawable.background_card);
-        findViewById(R.id.layout_webwrapper).setVisibility(View.VISIBLE);
 
         parsePass = 1;
         viewModel.getAssetDefinitionService().clearResultMap();
@@ -238,6 +230,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
 
     private void fillEmpty()
     {
+        findViewById(R.id.layout_webwrapper).setVisibility(View.VISIBLE);
         tokenView.loadData("<html><body>No Data</body></html>", "text/html", "utf-8");
     }
 
@@ -512,11 +505,10 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     @Override
     public void onPageRendered(WebView view)
     {
+        findViewById(R.id.layout_webwrapper).setVisibility(View.VISIBLE);
         if (parsePass == 1)
         {
             tokenView.reload();
-            waitSpinner.setVisibility(View.GONE);
-            tokenView.setVisibility(View.VISIBLE);
         }
 
         parsePass++;

--- a/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
@@ -100,7 +100,7 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
         //given a webview populate with rendered token
         tokenView.displayTicketHolder(token, ticketRange.range, viewModel.getAssetDefinitionService());
         tokenView.setOnReadyCallback(this);
-        tokenView.setLayout(token, false);
+        tokenView.setLayout(token, true);
         finishReceiver = new FinishReceiver(this);
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/AssetInstanceScriptHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/AssetInstanceScriptHolder.java
@@ -12,7 +12,6 @@ import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import android.widget.RelativeLayout;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
@@ -22,16 +21,7 @@ import com.alphawallet.app.ui.TokenFunctionActivity;
 import com.alphawallet.app.ui.widget.OnTokenClickListener;
 import com.alphawallet.app.web3.Web3TokenView;
 import com.alphawallet.app.web3.entity.PageReadyCallback;
-import com.alphawallet.token.entity.TSAction;
 import com.alphawallet.token.entity.TicketRange;
-
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
 
 import static com.alphawallet.app.C.Key.TICKET;
 
@@ -47,7 +37,6 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
     private final Token token;
     private final LinearLayout clickWrapper;
     private final LinearLayout webWrapper;
-    private final ProgressBar waitSpinner;
     private final boolean iconified;
     private OnTokenClickListener tokenClickListener;
     private final AppCompatRadioButton itemSelect;
@@ -59,7 +48,6 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
     {
         super(resId, parent);
         tokenView = findViewById(R.id.web3_tokenview);
-        waitSpinner = findViewById(R.id.progress_element);
         webWrapper = findViewById(R.id.layout_webwrapper);
         assetDefinitionService = assetService;
         clickWrapper = findViewById(R.id.click_layer);
@@ -67,8 +55,6 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
         token = t;
         tokenView.setOnReadyCallback(this);
         this.iconified = iconified;
-
-        tokenView.setLayout(token, iconified);
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -78,6 +64,7 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
         activeClick = false;
         try
         {
+            tokenView.setLayout(token, iconified);
             if (data.tokenIds.size() == 0) { fillEmpty(); return; }
             if (data.exposeRadio)
             {
@@ -88,7 +75,6 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
                 itemSelect.setVisibility(View.GONE);
             }
 
-            waitSpinner.setVisibility(View.VISIBLE);
             itemSelect.setChecked(data.isChecked);
             tokenView.displayTicketHolder(token, data, assetDefinitionService, iconified);
             tokenView.setOnReadyCallback(this);
@@ -121,7 +107,6 @@ public class AssetInstanceScriptHolder extends BinderViewHolder<TicketRange> imp
     public void onPageRendered(WebView view)
     {
         webWrapper.setVisibility(View.VISIBLE);
-        waitSpinner.setVisibility(View.GONE);
     }
 
     public void handleClick(View v, TicketRange data)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/BaseTicketHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/BaseTicketHolder.java
@@ -26,7 +26,6 @@ public class BaseTicketHolder extends BinderViewHolder<TicketRange> implements V
     private Token token;
     private final Web3TokenView tokenView;
     private final LinearLayout webWrapper;
-    private final ProgressBar waitSpinner;
     private OnTokenClickListener onTokenClickListener;
     private final AssetDefinitionService assetService; //need to cache this locally, unless we cache every string we need in the constructor
 
@@ -39,13 +38,11 @@ public class BaseTicketHolder extends BinderViewHolder<TicketRange> implements V
         activityView = this.itemView;
         tokenView = findViewById(R.id.web3_tokenview);
         webWrapper = findViewById(R.id.layout_webwrapper);
-        waitSpinner = findViewById(R.id.progress_element);
         itemView.setOnClickListener(this);
         ticketLayout = findViewById(R.id.layout_select_ticket);
         assetService = service;
         token = ticket;
         tokenView.setOnReadyCallback(this);
-        waitSpinner.setVisibility(View.VISIBLE);
     }
 
     @Override
@@ -90,7 +87,6 @@ public class BaseTicketHolder extends BinderViewHolder<TicketRange> implements V
     @Override
     public void onPageRendered(WebView view)
     {
-        waitSpinner.setVisibility(View.GONE);
         webWrapper.setVisibility(View.VISIBLE);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -160,7 +160,6 @@ public class TokenFunctionViewModel extends BaseViewModel
     {
         if (assetDefinitionService.checkTokenForNewEvent(t) || token.checkBalanceChange(t))
         {
-            t.transferPreviousData(token);
             token = t;
             tokenUpdate.postValue(token);
         }
@@ -451,9 +450,10 @@ public class TokenFunctionViewModel extends BaseViewModel
         return openseaService;
     }
 
-    public void updateTokenScriptViewSize(Token token)
+    public void updateTokenScriptViewSize(Token token, int itemViewHeight)
     {
-        tokensService.updateTokenViewSizes(token);
+        assetDefinitionService.storeTokenViewHeight(token.tokenInfo.chainId, token.getAddress(), itemViewHeight)
+                    .isDisposed();
     }
 
     public void checkForNewScript(Token token)

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -172,6 +172,7 @@ public class Web3TokenView extends WebView
     public void showError(String error)
     {
         showingError = true;
+        setVisibility(View.VISIBLE);
         loadData(error, "text/html", "utf-8");
     }
 
@@ -319,28 +320,18 @@ public class Web3TokenView extends WebView
 
     public void setLayout(Token token, boolean iconified)
     {
-        if (iconified && token.iconifiedWebviewHeight > 0)
+        if (iconified && token.itemViewHeight > 0)
         {
-            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, token.iconifiedWebviewHeight);
-            setLayoutParams(params);
-        }
-        else if (token.nonIconifiedWebviewHeight > 0)
-        {
-            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, token.nonIconifiedWebviewHeight);
+            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, token.itemViewHeight);
             setLayoutParams(params);
         }
     }
 
     private class TokenScriptClient extends WebViewClient
     {
-        private boolean loadingFinished = true;
-        private boolean redirect = false;
-        private Web3TokenView parent;
-
         public TokenScriptClient(Web3TokenView web3)
         {
             super();
-            parent = web3;
         }
 
         @Override
@@ -391,11 +382,9 @@ public class Web3TokenView extends WebView
         }
     }
 
-
-
     // Rendering
     public void displayTicketHolder(Token token, TicketRange range, AssetDefinitionService assetService) {
-        displayTicketHolder(token, range, assetService, false);
+        displayTicketHolder(token, range, assetService, true);
     }
 
     /**

--- a/app/src/main/res/layout/item_ticket.xml
+++ b/app/src/main/res/layout/item_ticket.xml
@@ -20,9 +20,10 @@
         android:paddingEnd="6dp">
 
         <ProgressBar
-            android:id="@+id/progress_element"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignTop="@id/total_wrapper"
+            android:layout_alignBottom="@id/total_wrapper"
             android:layout_centerInParent="true"
             android:indeterminateTint="@color/tealish"
             android:visibility="visible" />
@@ -31,6 +32,7 @@
             android:id="@+id/total_wrapper"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="100dp"
             android:layout_centerHorizontal="true"
             android:orientation="horizontal">
 
@@ -50,18 +52,18 @@
                 android:id="@+id/layout_webwrapper"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:minHeight="100dp"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginBottom="6dp"
                 android:background="@color/white"
-                android:gravity="center"
+                android:gravity="top"
                 android:orientation="vertical"
                 android:visibility="gone">
 
                 <com.alphawallet.app.web3.Web3TokenView
                     android:id="@+id/web3_tokenview"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:minHeight="200dp">
+                    android:layout_height="wrap_content">
 
                 </com.alphawallet.app.web3.Web3TokenView>
 


### PR DESCRIPTION
This PR addresses the issue seen when viewing a large list of TokenScript enabled tokens with an item-view and rapidly scrolling through them while they're being rendered. Sometimes the views would be the wrong size or blank.

- Store the computed itemView size against the hash of the TokenScript file (if file changes, re-compute itemView size).
- Tidy up related code.