### PR TITLE
Cancel Authentication should have a different result from key failure

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/CreateWalletCallbackInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/CreateWalletCallbackInterface.java
@@ -9,5 +9,5 @@ public interface CreateWalletCallbackInterface
     void HDKeyCreated(String address, Context ctx, KeyService.AuthenticationLevel level);
     void keyFailure(String message);
     void cancelAuthentication();
-    void FetchMnemonic(String mnemonic);
+    void fetchMnemonic(String mnemonic);
 }

--- a/app/src/main/java/com/alphawallet/app/entity/SignAuthenticationCallback.java
+++ b/app/src/main/java/com/alphawallet/app/entity/SignAuthenticationCallback.java
@@ -6,6 +6,7 @@ package com.alphawallet.app.entity;
  */
 public interface SignAuthenticationCallback
 {
-    void GotAuthorisation(boolean gotAuth);
-    default void CreatedKey(String keyAddress) { };
+    void gotAuthorisation(boolean gotAuth);
+    default void createdKey(String keyAddress) { };
+    void cancelAuthentication();
 }

--- a/app/src/main/java/com/alphawallet/app/service/KeyService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeyService.java
@@ -219,7 +219,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         try
         {
             String mnemonic = unpackMnemonic();
-            callback.FetchMnemonic(mnemonic);
+            callback.fetchMnemonic(mnemonic);
         }
         catch (KeyServiceException e)
         {
@@ -252,7 +252,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
         switch (wallet.type)
         {
             case KEYSTORE_LEGACY:
-                signCallback.GotAuthorisation(true); //Legacy keys don't require authentication
+                signCallback.gotAuthorisation(true); //Legacy keys don't require authentication
                 break;
             case KEYSTORE:
             case HDKEY:
@@ -261,7 +261,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             case NOT_DEFINED:
             case TEXT_MARKER:
             case WATCH:
-                signCallback.GotAuthorisation(false);
+                signCallback.gotAuthorisation(false);
                 break;
         }
     }
@@ -386,11 +386,11 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             {
                 case KEYSTORE:
                     password = unpackMnemonic();
-                    callback.FetchMnemonic(password);
+                    callback.fetchMnemonic(password);
                     break;
                 case KEYSTORE_LEGACY:
                     password = new String(getLegacyPassword(context, wallet.address));
-                    callback.FetchMnemonic(password);
+                    callback.fetchMnemonic(password);
                     break;
                 default:
                     break;
@@ -433,14 +433,14 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             String encryptedHDKeyPath = getFilePath(context, matchingAddr);
             if (!new File(encryptedHDKeyPath).exists() || secretKey == null)
             {
-                signCallback.GotAuthorisation(false);
+                signCallback.gotAuthorisation(false);
                 return;
             }
             byte[] iv = readBytesFromFile(getFilePath(context, matchingAddr + "iv"));
             Cipher outCipher = Cipher.getInstance(CIPHER_ALGORITHM);
             final GCMParameterSpec spec = new GCMParameterSpec(128, iv);
             outCipher.init(Cipher.DECRYPT_MODE, secretKey, spec);
-            signCallback.GotAuthorisation(true);
+            signCallback.gotAuthorisation(true);
             return;
         }
         catch (UserNotAuthenticatedException e)
@@ -460,7 +460,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             e.printStackTrace();
         }
 
-        signCallback.GotAuthorisation(false);
+        signCallback.gotAuthorisation(false);
     }
 
     private synchronized String unpackMnemonic() throws KeyServiceException, UserNotAuthenticatedException
@@ -783,7 +783,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
                 if (!requireAuthentication && (currentWallet.authLevel == TEE_NO_AUTHENTICATION || currentWallet.authLevel == STRONGBOX_NO_AUTHENTICATION)
                         && !requiresUnlock() && signCallback != null)
                 {
-                    signCallback.GotAuthorisation(true);
+                    signCallback.gotAuthorisation(true);
                     return;
                 }
                 break;
@@ -828,7 +828,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             case FETCH_MNEMONIC:
                 try
                 {
-                    callbackInterface.FetchMnemonic(unpackMnemonic());
+                    callbackInterface.fetchMnemonic(unpackMnemonic());
                 }
                 catch (UserNotAuthenticatedException e)
                 {
@@ -884,7 +884,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
 
         if (callbackId == UPGRADE_HD_KEY)
         {
-            signCallback.GotAuthorisation(false);
+            signCallback.gotAuthorisation(false);
         }
 
         if (activity == null || activity.isDestroyed())
@@ -900,7 +900,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             if (callbackInterface != null)
                 callbackInterface.keyFailure(message);
             else if (signCallback != null)
-                signCallback.GotAuthorisation(false);
+                signCallback.gotAuthorisation(false);
             else
                 AuthorisationFailMessage(message);
         }
@@ -908,10 +908,10 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
 
     private void cancelAuthentication()
     {
-        if (callbackInterface != null)
+        if (signCallback != null)
+            signCallback.cancelAuthentication();
+        else if (callbackInterface != null)
             callbackInterface.cancelAuthentication();
-        else if (signCallback != null)
-            signCallback.GotAuthorisation(false);
     }
 
     public boolean isChecking()

--- a/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/BackupKeyActivity.java
@@ -181,7 +181,7 @@ public class BackupKeyActivity extends BaseActivity implements
                 switch (viewModel.upgradeKeySecurity(wallet, this))
                 {
                     case SUCCESSFULLY_UPGRADED:
-                        CreatedKey(wallet.address);
+                        createdKey(wallet.address);
                         break;
                     case REQUESTING_SECURITY:
                         //Do nothing, callback will return to 'CreatedKey()'. If it fails the returned key is empty
@@ -203,7 +203,7 @@ public class BackupKeyActivity extends BaseActivity implements
     }
 
     @Override
-    public void CreatedKey(String address) {
+    public void createdKey(String address) {
         //key upgraded
         //store wallet upgrade
         if (wallet.address.equalsIgnoreCase(address)) {
@@ -576,15 +576,7 @@ public class BackupKeyActivity extends BaseActivity implements
     }
 
     @Override
-    public void cancelAuthentication() {
-        Intent intent = new Intent();
-        setResult(RESULT_CANCELED, intent);
-        intent.putExtra("Key", wallet.address);
-        finish();
-    }
-
-    @Override
-    public void FetchMnemonic(String mnemonic) {
+    public void fetchMnemonic(String mnemonic) {
         switch (state) {
             case WRITE_DOWN_SEED_PHRASE:
                 WriteDownSeedPhrase();
@@ -624,7 +616,7 @@ public class BackupKeyActivity extends BaseActivity implements
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth)
         {
@@ -655,6 +647,15 @@ public class BackupKeyActivity extends BaseActivity implements
                     break;
             }
         }
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+        Intent intent = new Intent();
+        setResult(RESULT_CANCELED, intent);
+        intent.putExtra("Key", wallet.address);
+        finish();
     }
 
     private void initViewModel() {

--- a/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ConfirmationActivity.java
@@ -547,12 +547,12 @@ public class ConfirmationActivity extends BaseActivity implements SignAuthentica
         }
         else if (requestCode >= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS && requestCode <= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS + 10)
         {
-            GotAuthorisation(resultCode == RESULT_OK);
+            gotAuthorisation(resultCode == RESULT_OK);
         }
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth)
         {
@@ -565,6 +565,12 @@ public class ConfirmationActivity extends BaseActivity implements SignAuthentica
         }
         //got authorisation, continue with transaction
         if (gotAuth) finaliseTransaction();
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+        hideDialog();
     }
 
     private void securityError() {

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -1505,7 +1505,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     {
         if (requestCode >= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS && requestCode <= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS + 10)
         {
-            GotAuthorisation(resultCode == RESULT_OK);
+            gotAuthorisation(resultCode == RESULT_OK);
         }
         else if (requestCode == UPLOAD_FILE && uploadMessage != null)
         {
@@ -1525,7 +1525,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth) viewModel.completeAuthentication(SIGN_DATA);
         else viewModel.failedAuthentication(SIGN_DATA);
@@ -1539,5 +1539,11 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
             web3.onSignCancel(messageToSign);
             dialog.dismiss();
         }
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -13,7 +13,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 
 import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
@@ -628,7 +627,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
 
         if (requestCode >= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS && requestCode <= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS + 10)
         {
-            GotAuthorisation(resultCode == RESULT_OK);
+            gotAuthorisation(resultCode == RESULT_OK);
         }
     }
 
@@ -709,7 +708,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth) viewModel.completeAuthentication(SIGN_DATA);
         else viewModel.failedAuthentication(SIGN_DATA);
@@ -743,6 +742,12 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
                     + convertedMessage;
             signMessage(signMessage.getBytes(), dAppFunction, messageToSign);
         }
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -590,13 +590,19 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
 
     }
 
     @Override
-    public void CreatedKey(String keyAddress)
+    public void cancelAuthentication()
+    {
+
+    }
+
+    @Override
+    public void createdKey(String keyAddress)
     {
         //Key was upgraded
         //viewModel.upgradeWallet(keyAddress);
@@ -880,7 +886,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 switch (getSelectedItem())
                 {
                     case DAPP_BROWSER:
-                        ((DappBrowserFragment)dappBrowserFragment).GotAuthorisation(resultCode == RESULT_OK);
+                        ((DappBrowserFragment)dappBrowserFragment).gotAuthorisation(resultCode == RESULT_OK);
                         break;
                     default:
                         //continue with generating the authenticated key - NB currently no flow reaches this code but in future it could
@@ -888,7 +894,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                         else
                         {
                             authInterface.failedAuthentication(taskCode);
-                            GotAuthorisation(false);
+                            gotAuthorisation(false);
                         }
                         break;
                 }

--- a/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportTokenActivity.java
@@ -570,11 +570,16 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
             SignAuthenticationCallback cb = new SignAuthenticationCallback()
             {
                 @Override
-                public void GotAuthorisation(boolean gotAuth)
+                public void gotAuthorisation(boolean gotAuth)
                 {
                     viewModel.performImport();
                 }
 
+                @Override
+                public void cancelAuthentication()
+                {
+
+                }
             };
             viewModel.getAuthorisation(this, cb);
         }
@@ -635,7 +640,7 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
 
         if (requestCode >= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS && requestCode <= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS + 10)
         {
-            GotAuthorisation(resultCode == RESULT_OK);
+            gotAuthorisation(resultCode == RESULT_OK);
         }
     }
 
@@ -650,12 +655,26 @@ public class ImportTokenActivity extends BaseActivity implements View.OnClickLis
      * @param gotAuth authorisation was successful
      */
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth) viewModel.completeAuthentication(SIGN_DATA);
         else viewModel.failedAuthentication(SIGN_DATA);
         viewModel.performImport();
         onProgress(true);
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+        AWalletAlertDialog dialog = new AWalletAlertDialog(this);
+        dialog.setIcon(AWalletAlertDialog.NONE);
+        dialog.setTitle(R.string.authentication_cancelled);
+        dialog.setButtonText(R.string.ok);
+        dialog.setButtonListener(v -> {
+            dialog.dismiss();
+        });
+        dialog.setCancelable(true);
+        dialog.show();
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
@@ -23,7 +23,6 @@ import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.common.BitMatrix;
 import com.journeyapps.barcodescanner.BarcodeEncoder;
 import com.alphawallet.app.entity.FinishReceiver;
-import com.alphawallet.app.entity.PinAuthenticationCallbackInterface;
 import com.alphawallet.app.entity.SignAuthenticationCallback;
 import com.alphawallet.app.entity.SignaturePair;
 import com.alphawallet.app.entity.tokens.Token;
@@ -65,6 +64,7 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
     private Web3TokenView tokenView;
     private LinearLayout webWrapper;
     private boolean signRequest;
+    private AWalletAlertDialog dialog;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -212,12 +212,12 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
 
         if (requestCode >= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS && requestCode <= SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS + 10)
         {
-            GotAuthorisation(resultCode == RESULT_OK);
+            gotAuthorisation(resultCode == RESULT_OK);
         }
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth)
         {
@@ -230,9 +230,25 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
         }
     }
 
+    @Override
+    public void cancelAuthentication()
+    {
+        if (dialog != null && dialog.isShowing()) dialog.cancel();
+        dialog = new AWalletAlertDialog(this);
+        dialog.setIcon(AWalletAlertDialog.NONE);
+        dialog.setTitle(R.string.authentication_cancelled);
+        dialog.setButtonText(R.string.ok);
+        dialog.setButtonListener(v -> {
+            dialog.dismiss();
+        });
+        dialog.setCancelable(true);
+        dialog.show();
+    }
+
     private void dialogKeyNotAvailableError()
     {
-        AWalletAlertDialog dialog = new AWalletAlertDialog(this);
+        if (dialog != null && dialog.isShowing()) dialog.cancel();
+        dialog = new AWalletAlertDialog(this);
         dialog.setTitle(R.string.key_error);
         dialog.setIcon(AWalletAlertDialog.ERROR);
         dialog.setMessage(getString(R.string.fail_sign));

--- a/app/src/main/java/com/alphawallet/app/ui/SellDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SellDetailActivity.java
@@ -281,12 +281,6 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
                     viewModel.getAuthorisation(this, this);
                 }
                 break;
-            case SET_MARKET_SALE:
-                if (isPriceAndQuantityValid())
-                {
-                    confirmPlaceMarketOrderDialog();
-                }
-                break;
         }
     }
 
@@ -516,27 +510,6 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
         dialog.show();
     }
 
-    private void confirmPlaceMarketOrderDialog()
-    {
-        //how many indices are we selling?
-        int quantity = selection.size();
-        String unit = quantity > 1 ? getString(R.string.tickets) : getString(R.string.ticket);
-        String qty = String.valueOf(quantity) + " " + unit + " @" + getEthString(sellPriceValue) + getString(R.string.eth_per_ticket);
-
-        AWalletConfirmationDialog dialog = new AWalletConfirmationDialog(this);
-        dialog.setTitle(R.string.confirm_sale_title);
-        dialog.setSmallText(R.string.place_tickets_marketplace);
-        dialog.setMediumText(qty);
-        dialog.setPrimaryButtonText(R.string.create_sell_order);
-        dialog.setSecondaryButtonText(R.string.dialog_cancel_back);
-        dialog.setPrimaryButtonListener(v1 -> {
-            sellTicketFinal();
-            sendBroadcast(new Intent(PRUNE_ACTIVITY));
-        });
-        dialog.setSecondaryButtonListener(v1 -> dialog.dismiss());
-        dialog.show();
-    }
-
     private void sellLinkFinal(String universalLink) {
         //create share intent
         Intent sendIntent = new Intent();
@@ -594,7 +567,7 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
                 break;
 
             case SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS:
-                GotAuthorisation(resultCode == RESULT_OK);
+                gotAuthorisation(resultCode == RESULT_OK);
                 break;
 
             default:
@@ -609,7 +582,7 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
     }
 
     @Override
-    public void GotAuthorisation(boolean gotAuth)
+    public void gotAuthorisation(boolean gotAuth)
     {
         if (gotAuth)
         {
@@ -617,5 +590,11 @@ public class SellDetailActivity extends BaseActivity implements OnTokenClickList
             sellTicketLinkFinal();
         }
         else viewModel.failedAuthentication(SIGN_DATA);
+    }
+
+    @Override
+    public void cancelAuthentication()
+    {
+
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SplashActivity.java
@@ -257,7 +257,7 @@ public class SplashActivity extends BaseActivity implements CreateWalletCallback
     }
 
     @Override
-    public void FetchMnemonic(String mnemonic)
+    public void fetchMnemonic(String mnemonic)
     {
 
     }

--- a/app/src/main/java/com/alphawallet/app/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransferTicketDetailActivity.java
@@ -9,7 +9,6 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatRadioButton;
 import android.support.v7.widget.LinearLayoutManager;
@@ -20,7 +19,6 @@ import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.AutoCompleteTextView;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -31,10 +29,8 @@ import android.widget.Toast;
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.DisplayState;
-import com.alphawallet.app.entity.ENSCallback;
 import com.alphawallet.app.entity.ErrorEnvelope;
 import com.alphawallet.app.entity.FinishReceiver;
-import com.alphawallet.app.entity.PinAuthenticationCallbackInterface;
 import com.alphawallet.app.entity.SignAuthenticationCallback;
 import com.alphawallet.app.entity.StandardFunctionInterface;
 import com.alphawallet.app.entity.VisibilityFilter;
@@ -360,7 +356,7 @@ public class TransferTicketDetailActivity extends BaseActivity implements ItemCl
         signCallback = new SignAuthenticationCallback()
         {
             @Override
-            public void GotAuthorisation(boolean gotAuth)
+            public void gotAuthorisation(boolean gotAuth)
             {
                 if (gotAuth) viewModel.completeAuthentication(SIGN_DATA);
                 else viewModel.failedAuthentication(SIGN_DATA);
@@ -381,6 +377,12 @@ public class TransferTicketDetailActivity extends BaseActivity implements ItemCl
                     //display fail auth
                     onError(new ErrorEnvelope(getString(R.string.authentication_failed)));
                 }
+            }
+
+            @Override
+            public void cancelAuthentication()
+            {
+
             }
         };
 
@@ -639,7 +641,7 @@ public class TransferTicketDetailActivity extends BaseActivity implements ItemCl
                 break;
 
             case SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS:
-                signCallback.GotAuthorisation(resultCode == RESULT_OK);
+                signCallback.gotAuthorisation(resultCode == RESULT_OK);
                 break;
 
             default:
@@ -717,12 +719,26 @@ public class TransferTicketDetailActivity extends BaseActivity implements ItemCl
         signCallback = new SignAuthenticationCallback()
         {
             @Override
-            public void GotAuthorisation(boolean gotAuth)
+            public void gotAuthorisation(boolean gotAuth)
             {
                 if (gotAuth) viewModel.completeAuthentication(SIGN_DATA);
                 else viewModel.failedAuthentication(SIGN_DATA);
 
                 if (gotAuth) transferTicketFinal();
+            }
+
+            @Override
+            public void cancelAuthentication()
+            {
+                AWalletAlertDialog dialog = new AWalletAlertDialog(getParent());
+                dialog.setIcon(AWalletAlertDialog.NONE);
+                dialog.setTitle(R.string.authentication_cancelled);
+                dialog.setButtonText(R.string.ok);
+                dialog.setButtonListener(v -> {
+                    dialog.dismiss();
+                });
+                dialog.setCancelable(true);
+                dialog.show();
             }
         };
 

--- a/app/src/main/java/com/alphawallet/app/ui/WalletsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletsActivity.java
@@ -373,7 +373,7 @@ public class WalletsActivity extends BaseActivity implements
     }
 
     @Override
-    public void FetchMnemonic(String mnemonic)
+    public void fetchMnemonic(String mnemonic)
     {
 
     }


### PR DESCRIPTION
Ensure key failure and cancel of authentication request are handled by separate paths. Key failure is a real issue but cancel authentication is not.

Previously - if you cancelled a request to unlock private key, the 'key has failed' dialog was popped up. This is wrong. If you press cancel, operation should just return back to the dialog.

Also normalised the function naming for the interface.