### PR TITLE
Prevent keyboard hiding webpage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,6 +140,9 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:$project.rxJavaVersion"
     implementation "io.reactivex.rxjava2:rxandroid:$project.rxAndroidVersion"
 
+    // Keyboard visibility
+    implementation 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:3.0.0-RC2'
+
     // Dagger 2
 
     // Dagger core

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -34,6 +34,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.Toast;
@@ -64,6 +65,8 @@ import com.alphawallet.app.widget.DepositView;
 import com.alphawallet.app.widget.SignTransactionDialog;
 import com.alphawallet.token.tools.ParseMagicLink;
 import com.github.florent37.tutoshowcase.TutoShowcase;
+
+import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent;
 
 import org.web3j.crypto.WalletUtils;
 
@@ -105,6 +108,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     private TutoShowcase findWalletAddressDialog;
     private PinAuthenticationCallbackInterface authInterface;
     private String importFileName;
+    private boolean bottomMarginSet = false;
 
     public static final int RC_DOWNLOAD_EXTERNAL_WRITE_PERM = 222;
     public static final int RC_ASSET_EXTERNAL_WRITE_PERM = 223;
@@ -234,6 +238,23 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         }
 
         viewModel.cleanDatabases(this);
+
+        //Ensure when keyboard appears the webview gets squashed into remaining view. Also remove navigation bar to increase screen size
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        KeyboardVisibilityEvent.setEventListener(
+                this, isOpen -> {
+                    if (isOpen)
+                    {
+                        bottomMarginSet = viewPager.hasBottomMargin();
+                        viewPager.setBottomMargin(false);
+                        setNavBarVisibility(View.GONE);
+                    }
+                    else
+                    {
+                        if (bottomMarginSet) viewPager.setBottomMargin(true);
+                        setNavBarVisibility(View.VISIBLE);
+                    }
+                });
     }
 
     private void onBackup(String address)
@@ -371,6 +392,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 return true;
             }
             case DAPP_BROWSER: {
+                viewPager.setBottomMargin(true);
                 if (getSelectedItem() == DAPP_BROWSER) {
                     ((DappBrowserFragment)dappBrowserFragment).homePressed();
                 } else {
@@ -379,10 +401,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 return true;
             }
             case WALLET: {
+                viewPager.setBottomMargin(false);
                 showPage(WALLET);
                 return true;
             }
             case SETTINGS: {
+                viewPager.setBottomMargin(false);
                 showPage(SETTINGS);
                 return true;
             }
@@ -439,6 +463,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         switch (page) {
             case DAPP_BROWSER: {
                 hideToolbar();
+                viewPager.setBottomMargin(true);
                 viewPager.setCurrentItem(DAPP_BROWSER);
                 setTitle(getString(R.string.toolbar_header_browser));
                 selectNavigationItem(DAPP_BROWSER);
@@ -448,6 +473,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             }
             case WALLET: {
                 showToolbar();
+                viewPager.setBottomMargin(false);
                 viewPager.setCurrentItem(WALLET);
                 if (walletTitle == null || walletTitle.isEmpty()) {
                     setTitle(getString(R.string.toolbar_header_wallet));
@@ -462,6 +488,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             }
             case SETTINGS: {
                 showToolbar();
+                viewPager.setBottomMargin(false);
                 viewPager.setCurrentItem(SETTINGS);
                 setTitle(getString(R.string.toolbar_header_settings));
                 selectNavigationItem(SETTINGS);
@@ -471,6 +498,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             }
             case TRANSACTIONS: {
                 showToolbar();
+                viewPager.setBottomMargin(true);
                 viewPager.setCurrentItem(TRANSACTIONS);
                 setTitle(getString(R.string.toolbar_header_transactions));
                 selectNavigationItem(TRANSACTIONS);
@@ -482,6 +510,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             default:
                 showToolbar();
                 viewPager.setCurrentItem(WALLET);
+                viewPager.setBottomMargin(false);
                 setTitle(getString(R.string.toolbar_header_wallet));
                 selectNavigationItem(WALLET);
                 enableDisplayHomeAsHome(false);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/ScrollControlViewPager.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/ScrollControlViewPager.java
@@ -4,7 +4,11 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.MotionEvent;
+import android.view.ViewGroup;
+
+import com.alphawallet.app.util.Utils;
 
 /**
  * Created by James on 8/07/2019.
@@ -26,6 +30,30 @@ public class ScrollControlViewPager extends ViewPager
     public void lockPages(boolean locked)
     {
         isLocked = locked;
+    }
+
+    public void setBottomMargin(boolean active)
+    {
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) this.getLayoutParams();
+
+        if (active)
+        {
+            TypedValue tv = new TypedValue();
+            if (getContext().getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true))
+            {
+                layoutParams.bottomMargin = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+            }
+        }
+        else
+        {
+            layoutParams.bottomMargin = 0;
+        }
+    }
+
+    public boolean hasBottomMargin()
+    {
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) this.getLayoutParams();
+        return layoutParams.bottomMargin > 0;
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/viewmodel/BaseNavigationActivity.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/BaseNavigationActivity.java
@@ -48,4 +48,10 @@ public class BaseNavigationActivity extends BaseActivity implements AWalletBotto
     public void hideNavBar() { nav.setVisibility(View.GONE); }
 
     public boolean isNavBarVisible() { return nav.getVisibility() == View.VISIBLE; }
+
+    public void setNavBarVisibility(int view)
+    {
+        if (nav == null) nav = findViewById(R.id.nav);
+        if (nav != null) nav.setVisibility(view);
+    }
 }


### PR DESCRIPTION
Fix issue where soft keyboard covers webpage areas.

Fix related issues:

- clear up old issue with bottom of webpage last transaction being hidden by the bottom nav bar (issue since 'sliding view' (in wallet view that covers the title when you slide up) was introduced).
- Refactor the keyboard presence sensing in PasswordInputView using the keyboard event library. This removes some of the onscreen clutter (buttons, info) when the keyboard is active - needed on lower resolution devices.