### PR TITLE
rename class Module to NamedType

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokenscript/EventUtils.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokenscript/EventUtils.java
@@ -1,12 +1,11 @@
 package com.alphawallet.app.entity.tokenscript;
 
-import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.token.entity.Attribute;
 import com.alphawallet.token.entity.AttributeInterface;
 import com.alphawallet.token.entity.ContractAddress;
 import com.alphawallet.token.entity.EventDefinition;
-import com.alphawallet.token.entity.Module;
+import com.alphawallet.token.entity.NamedType;
 import com.alphawallet.token.entity.TokenScriptResult;
 
 import org.web3j.abi.EventEncoder;
@@ -129,7 +128,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import io.reactivex.Single;
 
@@ -167,7 +165,7 @@ public abstract class EventUtils
         int topicIndex = ev.getTopicIndex(filterTopic);
 
         //isolate which indexed param it is
-        List<String> indexedParams = ev.eventModule.getArgNames(true);
+        List<String> indexedParams = ev.type.getArgNames(true);
 
         DefaultBlockParameter startBlock = DefaultBlockParameterName.EARLIEST;
 
@@ -297,10 +295,10 @@ public abstract class EventUtils
      * @param args
      * @return
      */
-    private static List<TypeReference<?>> generateFunctionDefinition(List<Module.SequenceElement> args)
+    private static List<TypeReference<?>> generateFunctionDefinition(List<NamedType.SequenceElement> args)
     {
         List<TypeReference<?>> paramList = new ArrayList<>();
-        for (Module.SequenceElement element : args)
+        for (NamedType.SequenceElement element : args)
         {
             switch (element.type)
             {
@@ -619,8 +617,8 @@ public abstract class EventUtils
 
     private Event generateEventFunction(EventDefinition ev)
     {
-        List<TypeReference<?>> eventArgSpec = EventUtils.generateFunctionDefinition(ev.eventModule.getSequenceArgs());
-        return new Event(ev.eventModule.name, eventArgSpec);
+        List<TypeReference<?>> eventArgSpec = EventUtils.generateFunctionDefinition(ev.type.getSequenceArgs());
+        return new Event(ev.type.name, eventArgSpec);
     }
 
     private void addTopicFilter(EventDefinition ev, EthFilter filter, String filterTopicValue, Token originToken, String contractAddr, AttributeInterface attrIf) throws Exception

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -1205,7 +1205,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         boolean hasEvent = false;
         for (EventDefinition ev : eventList)
         {
-            if (ev.eventModule == null || ev.contract == null) continue;
+            if (ev.type == null || ev.contract == null) continue;
             if (ev.contract.addresses.containsKey(token.tokenInfo.chainId))
             {
                 if (ev.contract.addresses.get(token.tokenInfo.chainId).contains(token.getAddress().toLowerCase()))

--- a/lib/src/main/java/com/alphawallet/token/entity/EventDefinition.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/EventDefinition.java
@@ -1,7 +1,6 @@
 package com.alphawallet.token.entity;
 
 import java.math.BigInteger;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -12,7 +11,7 @@ public class EventDefinition
 {
     public ContractInfo contract;
     public String attributeName; //TransactionResult: method
-    public Module eventModule;
+    public NamedType type;
     public String filter;
     public String select;
     public BigInteger readBlock;
@@ -35,15 +34,15 @@ public class EventDefinition
 
     public int getTopicIndex(String filterTopic)
     {
-        if (eventModule == null || filterTopic == null) return -1;
-        return eventModule.getTopicIndex(filterTopic);
+        if (type == null || filterTopic == null) return -1;
+        return type.getTopicIndex(filterTopic);
     }
 
     public int getSelectIndex(boolean indexed)
     {
         int index = 0;
         boolean found = false;
-        for (String label : eventModule.getArgNames(indexed))
+        for (String label : type.getArgNames(indexed))
         {
             if (label.equals(select))
             {

--- a/lib/src/main/java/com/alphawallet/token/entity/NamedType.java
+++ b/lib/src/main/java/com/alphawallet/token/entity/NamedType.java
@@ -8,14 +8,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created by JB on 20/03/2020.
+ * Created by JB on 20/03/2020 for namedType in ASN.X included in TokenScript. It's used for events & attestations.
  */
-public class Module
+public class NamedType
 {
     public final String name;
     public List<SequenceElement> sequence = new ArrayList<>();
 
-    public Module(String moduleName)
+    public NamedType(String moduleName)
     {
         name = moduleName;
     }

--- a/lib/src/main/java/com/alphawallet/token/tools/TokenDefinition.java
+++ b/lib/src/main/java/com/alphawallet/token/tools/TokenDefinition.java
@@ -26,7 +26,7 @@ public class TokenDefinition {
     public Map<String, ContractInfo> contracts = new HashMap<>();
     public Map<String, TSAction> actions = new HashMap<>();
     private Map<String, String> labels = new HashMap<>(); // store plural etc for token name
-    private Map<String, Module> moduleLookup = new HashMap<>(); //used to protect against name collision
+    private Map<String, Module> namedTypeLookup = new HashMap<>(); //used to protect against name collision
     private TSTokenViewHolder tokenViews = new TSTokenViewHolder();
     private Map<String, TSSelection> selections = new HashMap<>();
 
@@ -94,7 +94,7 @@ public class TokenDefinition {
                     ev.contract = contracts.get(attrValue);
                     break;
                 case "type":
-                    ev.eventModule = moduleLookup.get(attrValue);
+                    ev.eventModule = namedTypeLookup.get(attrValue);
                     if (ev.eventModule == null)
                     {
                         throw new SAXException("Event module not found: " + attrValue);
@@ -866,7 +866,7 @@ public class TokenDefinition {
                         {
                             throw new SAXException("namedType must have name attribute.");
                         }
-                        else if (moduleLookup.containsKey(namedType))
+                        else if (namedTypeLookup.containsKey(namedType))
                         {
                             throw new SAXException("Duplicate Module label: " + namedType);
                         }
@@ -880,7 +880,7 @@ public class TokenDefinition {
                             throw new SAXException("Sequence must be enclosed within <namedType name=... />");
                         }
                         Module eventModule = handleElementSequence(element, namedType);
-                        moduleLookup.put(namedType, eventModule);
+                        namedTypeLookup.put(namedType, eventModule);
                         namedType = null;
                         n = n.getNextSibling();
                         break;

--- a/lib/src/main/java/com/alphawallet/token/tools/TokenDefinition.java
+++ b/lib/src/main/java/com/alphawallet/token/tools/TokenDefinition.java
@@ -26,7 +26,7 @@ public class TokenDefinition {
     public Map<String, ContractInfo> contracts = new HashMap<>();
     public Map<String, TSAction> actions = new HashMap<>();
     private Map<String, String> labels = new HashMap<>(); // store plural etc for token name
-    private Map<String, Module> namedTypeLookup = new HashMap<>(); //used to protect against name collision
+    private Map<String, NamedType> namedTypeLookup = new HashMap<>(); //used to protect against name collision
     private TSTokenViewHolder tokenViews = new TSTokenViewHolder();
     private Map<String, TSSelection> selections = new HashMap<>();
 
@@ -94,8 +94,8 @@ public class TokenDefinition {
                     ev.contract = contracts.get(attrValue);
                     break;
                 case "type":
-                    ev.eventModule = namedTypeLookup.get(attrValue);
-                    if (ev.eventModule == null)
+                    ev.type = namedTypeLookup.get(attrValue);
+                    if (ev.type == null)
                     {
                         throw new SAXException("Event module not found: " + attrValue);
                     }
@@ -879,8 +879,8 @@ public class TokenDefinition {
                         if (namedType == null) {
                             throw new SAXException("Sequence must be enclosed within <namedType name=... />");
                         }
-                        Module eventModule = handleElementSequence(element, namedType);
-                        namedTypeLookup.put(namedType, eventModule);
+                        NamedType eventDataType = handleElementSequence(element, namedType);
+                        namedTypeLookup.put(namedType, eventDataType);
                         namedType = null;
                         n = n.getNextSibling();
                         break;
@@ -895,9 +895,9 @@ public class TokenDefinition {
         }
     }
 
-    private Module handleElementSequence(Node c, String moduleName) throws SAXException
+    private NamedType handleElementSequence(Node c, String moduleName) throws SAXException
     {
-        Module module = new Module(moduleName);
+        NamedType module = new NamedType(moduleName);
         for (Node n = c.getFirstChild(); n != null; n = n.getNextSibling())
         {
             if (n.getNodeType() == ELEMENT_NODE)


### PR DESCRIPTION
Module is just a container for NamedType. It's not used as an object in TokenScript.

- Please squash. The 2 commits are for the same thing.
- Please rebase all working local copies as soon as this is approved to avoid conflict (as this is a rename).
