### PR TITLE
Fix for default and override locale setting

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/NewSettingsModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/NewSettingsModule.java
@@ -2,17 +2,11 @@ package com.alphawallet.app.di;
 
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.interact.GetDefaultWalletBalance;
-
-import com.alphawallet.app.repository.CurrencyRepository;
-import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
-import com.alphawallet.app.repository.LocaleRepository;
-import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.repository.WalletRepositoryType;
 import com.alphawallet.app.router.ManageWalletsRouter;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.viewmodel.NewSettingsViewModelFactory;
 
 import dagger.Module;
@@ -23,25 +17,17 @@ class NewSettingsModule {
     @Provides
     NewSettingsViewModelFactory provideNewSettingsViewModelFactory(
             GenericWalletInteract genericWalletInteract,
-            GetDefaultWalletBalance getDefaultWalletBalance,
             MyAddressRouter myAddressRouter,
             EthereumNetworkRepositoryType ethereumNetworkRepository,
             ManageWalletsRouter manageWalletsRouter,
-            PreferenceRepositoryType preferenceRepository,
-            LocaleRepositoryType localeRepository,
-            TokensService tokensService,
-            CurrencyRepositoryType currencyRepository
+            PreferenceRepositoryType preferenceRepository
     ) {
         return new NewSettingsViewModelFactory(
                 genericWalletInteract,
-                getDefaultWalletBalance,
                 myAddressRouter,
                 ethereumNetworkRepository,
                 manageWalletsRouter,
-                preferenceRepository,
-                localeRepository,
-                tokensService,
-                currencyRepository);
+                preferenceRepository);
     }
 
     @Provides
@@ -63,15 +49,5 @@ class NewSettingsModule {
     @Provides
     ManageWalletsRouter provideManageWalletsRouter() {
         return new ManageWalletsRouter();
-    }
-
-    @Provides
-    LocaleRepositoryType provideLocaleRepository(PreferenceRepositoryType preferenceRepository) {
-        return new LocaleRepository(preferenceRepository);
-    }
-
-    @Provides
-    CurrencyRepositoryType provideCurrencyRepository(PreferenceRepositoryType preferenceRepository) {
-        return new CurrencyRepository(preferenceRepository);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/LocaleRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/LocaleRepository.java
@@ -1,6 +1,7 @@
 package com.alphawallet.app.repository;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import com.alphawallet.app.util.LocaleUtils;
 
@@ -24,26 +25,36 @@ public class LocaleRepository implements LocaleRepositoryType {
     }
 
     @Override
-    public void setDefaultLocale(Context context, String locale) {
-        preferences.setDefaultLocale(locale);
+    public void setLocale(Context context, String locale) {
         LocaleUtils.setLocale(context, locale);
     }
 
-    public String getDefaultLocale() {
-        return preferences.getDefaultLocale();
+    @Override
+    public String getUserPreferenceLocale()
+    {
+        return preferences.getUserPreferenceLocale();
     }
 
     @Override
-    public boolean hasOverridenLangSetting() { return preferences.getHasOverriden(); }
+    public void setUserPreferenceLocale(String locale)
+    {
+        preferences.setUserPreferenceLocale(locale);
+    }
+
     @Override
-    public void setOverridenLangSetting() { preferences.setHasOverriden(); }
+    public String getActiveLocale()
+    {
+        String useLocale = preferences.getUserPreferenceLocale();
+        if (TextUtils.isEmpty(useLocale)) useLocale = preferences.getDefaultLocale();
+        return useLocale;
+    }
 
     @Override
     public ArrayList<LocaleItem> getLocaleList(Context context) {
         ArrayList<LocaleItem> list = new ArrayList<>();
         for (String locale : LOCALES) {
             Locale l = new Locale(locale);
-            list.add(new LocaleItem(LocaleUtils.getDisplayLanguage(locale, getDefaultLocale()), locale));
+            list.add(new LocaleItem(LocaleUtils.getDisplayLanguage(locale, getActiveLocale()), locale));
         }
         return list;
     }

--- a/app/src/main/java/com/alphawallet/app/repository/LocaleRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/LocaleRepositoryType.java
@@ -7,14 +7,14 @@ import java.util.ArrayList;
 import com.alphawallet.app.entity.LocaleItem;
 
 public interface LocaleRepositoryType {
-    String getDefaultLocale();
+    String getUserPreferenceLocale();
+    void setUserPreferenceLocale(String locale);
 
-    void setDefaultLocale(Context context, String locale);
+    void setLocale(Context context, String locale);
 
     ArrayList<LocaleItem> getLocaleList(Context context);
 
-    boolean isLocalePresent(String locale);
+    String getActiveLocale();
 
-    boolean hasOverridenLangSetting();
-    void setOverridenLangSetting();
+    boolean isLocalePresent(String locale);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/PreferenceRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/PreferenceRepositoryType.java
@@ -38,7 +38,6 @@ public interface PreferenceRepositoryType {
 
     String getDefaultCurrency();
 
-    boolean getHasOverriden();
-
-    void setHasOverriden();
+    String getUserPreferenceLocale();
+    void setUserPreferenceLocale(String locale);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/SharedPreferenceRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/SharedPreferenceRepository.java
@@ -13,9 +13,6 @@ public class SharedPreferenceRepository implements PreferenceRepositoryType {
     private static final String CURRENT_ACCOUNT_ADDRESS_KEY = "current_account_address";
     private static final String DEFAULT_NETWORK_NAME_KEY = "default_network_name";
     private static final String NETWORK_FILTER_KEY = "network_filters";
-    private static final String GAS_PRICE_KEY = "gas_price";
-    private static final String GAS_LIMIT_KEY = "gas_limit";
-    private static final String GAS_LIMIT_FOR_TOKENS_KEY = "gas_limit_for_tokens";
     private static final String NOTIFICATIONS_KEY = "notifications";
     private static final String DEFAULT_SET_KEY = "default_net_set";
     private static final String LOCALE_KEY = "locale";
@@ -23,7 +20,7 @@ public class SharedPreferenceRepository implements PreferenceRepositoryType {
     private static final String FIND_WALLET_ADDRESS_SHOWN = "find_wallet_address_shown";
     private static final String CURRENCY_CODE_KEY = "currency_locale";
     private static final String CURRENCY_SYMBOL_KEY = "currency_symbol";
-    private static final String OVERRIDE_LANG_PREFS = "override_lang";
+    public static final String USER_LOCALE_PREF = "user_locale_pref";
     public static final String HIDE_ZERO_BALANCE_TOKENS = "hide_zero_balance_tokens";
 
     private final SharedPreferences pref;
@@ -126,14 +123,14 @@ public class SharedPreferenceRepository implements PreferenceRepositoryType {
     }
 
     @Override
-    public boolean getHasOverriden()
+    public String getUserPreferenceLocale()
     {
-        return pref.getBoolean(OVERRIDE_LANG_PREFS, false);
+        return pref.getString(USER_LOCALE_PREF, "");
     }
 
     @Override
-    public void setHasOverriden()
+    public void setUserPreferenceLocale(String locale)
     {
-        pref.edit().putBoolean(OVERRIDE_LANG_PREFS, true).apply();
+        pref.edit().putString(USER_LOCALE_PREF, locale).apply();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.WebView;
 import android.widget.LinearLayout;
@@ -100,7 +101,7 @@ public class AdvancedSettingsActivity extends BaseActivity {
                 .withListener(this::onTokenScriptManagementClicked)
                 .build();
 
-        changeLanguage.setSubtitle(LocaleUtils.getDisplayLanguage(viewModel.getDefaultLocale(), viewModel.getDefaultLocale()));
+        changeLanguage.setSubtitle(LocaleUtils.getDisplayLanguage(viewModel.getActiveLocale(), viewModel.getActiveLocale()));
     }
 
     private void addSettingsToLayout() {
@@ -132,8 +133,8 @@ public class AdvancedSettingsActivity extends BaseActivity {
 
     private void onChangeLanguageClicked() {
         Intent intent = new Intent(this, SelectLocaleActivity.class);
-        String currentLocale = viewModel.getDefaultLocale();
-        intent.putExtra(EXTRA_LOCALE, currentLocale);
+        String selectedLocale = viewModel.getActiveLocale();
+        intent.putExtra(EXTRA_LOCALE, selectedLocale);
         intent.putParcelableArrayListExtra(EXTRA_STATE, viewModel.getLocaleList(this));
         startActivityForResult(intent, C.UPDATE_LOCALE);
     }
@@ -181,10 +182,15 @@ public class AdvancedSettingsActivity extends BaseActivity {
     }
 
     public void updateLocale(Intent data) {
-        if (data != null) {
+        if (data != null)
+        {
             String newLocale = data.getStringExtra(C.EXTRA_LOCALE);
-            sendBroadcast(new Intent(CHANGED_LOCALE));
-            viewModel.updateLocale(newLocale, this);
+            String oldLocale = viewModel.getActiveLocale();
+            if (!TextUtils.isEmpty(newLocale) && !newLocale.equals(oldLocale))
+            {
+                sendBroadcast(new Intent(CHANGED_LOCALE));
+                viewModel.updateLocale(newLocale, this);
+            }
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -18,6 +18,7 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.BuildConfig;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
@@ -25,6 +26,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,7 +46,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.CryptoFunctions;
@@ -76,6 +77,7 @@ import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.util.DappBrowserUtils;
 import com.alphawallet.app.util.Hex;
 import com.alphawallet.app.util.KeyboardUtils;
+import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.util.QRParser;
 import com.alphawallet.app.util.Utils;
 import com.alphawallet.app.viewmodel.DappBrowserViewModel;
@@ -229,6 +231,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
+        LocaleUtils.setActiveLocale(getContext());
         super.onCreate(savedInstanceState);
     }
 
@@ -252,6 +255,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         AndroidSupportInjection.inject(this);
+        LocaleUtils.setActiveLocale(getContext());
         int webViewID = CustomViewSettings.minimiseBrowserURLBar() ? R.layout.fragment_webview_compact : R.layout.fragment_webview;
         View view = inflater.inflate(webViewID, container, false);
         initViewModel();
@@ -515,20 +519,23 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         urlTv = view.findViewById(R.id.url_tv);
         swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
         swipeRefreshLayout.setRefreshInterface(this);
+
         toolbar = view.findViewById(R.id.address_bar);
 
-        layoutNavigation = view.findViewById(R.id.layout_navigator);
+        //If you are wondering about the strange way the menus are inflated - this is required to ensure
+        //that the menu text gets created with the correct localisation under every circumstance
+        MenuInflater inflater = new MenuInflater(LocaleUtils.getActiveLocaleContext(getContext()));
         if (CustomViewSettings.minimiseBrowserURLBar())
         {
-            toolbar.inflateMenu(R.menu.menu_scan);
+            inflater.inflate(R.menu.menu_scan, toolbar.getMenu());
         }
         else if (EthereumNetworkRepository.defaultDapp() != null)
         {
-            toolbar.inflateMenu(R.menu.menu_defaultdapp);
+            inflater.inflate(R.menu.menu_defaultdapp, toolbar.getMenu());
         }
         else
         {
-            toolbar.inflateMenu(R.menu.menu_bookmarks);
+            inflater.inflate(R.menu.menu_bookmarks, toolbar.getMenu());
         }
         refresh = view.findViewById(R.id.refresh);
         setupMenu(view);

--- a/app/src/main/java/com/alphawallet/app/ui/DappHomeFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappHomeFragment.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.DApp;
+import com.alphawallet.app.util.LocaleUtils;
 
 
 public class DappHomeFragment extends Fragment {
@@ -37,6 +38,7 @@ public class DappHomeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
+        LocaleUtils.setActiveLocale(getContext());
         View view = inflater.inflate(R.layout.layout_dapp_home, container, false);
         LinearLayout myDappsLayout = view.findViewById(R.id.my_dapps);
         myDappsLayout.setOnClickListener(v -> onDappHomeNavClickListener.onDappHomeNavClick(0));

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -59,6 +59,7 @@ import com.alphawallet.app.entity.WalletPage;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.service.NotificationService;
 import com.alphawallet.app.ui.widget.entity.ScrollControlViewPager;
+import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.util.RootUtil;
 import com.alphawallet.app.viewmodel.BaseNavigationActivity;
 import com.alphawallet.app.viewmodel.HomeViewModel;
@@ -162,6 +163,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
+        LocaleUtils.setActiveLocale(this);
 
         Bundle bundle = null;
         Intent intent = getIntent();
@@ -183,7 +185,6 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
         viewModel = ViewModelProviders.of(this, homeViewModelFactory)
                 .get(HomeViewModel.class);
-        viewModel.setLocale(this);
         viewModel.identify(this);
 
         setContentView(R.layout.activity_home);

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -25,6 +25,7 @@ import com.alphawallet.app.entity.WalletPage;
 import com.alphawallet.app.entity.WalletType;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
+import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.viewmodel.NewSettingsViewModel;
 import com.alphawallet.app.viewmodel.NewSettingsViewModelFactory;
 import com.alphawallet.app.widget.NotificationView;
@@ -75,6 +76,7 @@ public class NewSettingsFragment extends BaseFragment {
         viewModel = ViewModelProviders.of(this, newSettingsViewModelFactory).get(NewSettingsViewModel.class);
         viewModel.defaultWallet().observe(this, this::onDefaultWallet);
         viewModel.backUpMessage().observe(this, this::backupWarning);
+        LocaleUtils.setActiveLocale(getContext());
 
         View view = inflater.inflate(R.layout.fragment_settings, container, false);
 

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
@@ -29,8 +29,9 @@ public class AdvancedSettingsViewModel extends BaseViewModel {
         this.assetDefinitionService = assetDefinitionService;
     }
 
-    public String getDefaultLocale() {
-        return localeRepository.getDefaultLocale();
+    public String getUserPreferenceLocale()
+    {
+        return localeRepository.getUserPreferenceLocale();
     }
 
     public ArrayList<LocaleItem> getLocaleList(Context context) {
@@ -38,12 +39,13 @@ public class AdvancedSettingsViewModel extends BaseViewModel {
     }
 
     public void setLocale(Context activity) {
-        String currentLocale = localeRepository.getDefaultLocale();
+        String currentLocale = localeRepository.getActiveLocale();
         LocaleUtils.setLocale(activity, currentLocale);
     }
 
     public void updateLocale(String newLocale, Context context) {
-        localeRepository.setDefaultLocale(context, newLocale);
+        localeRepository.setUserPreferenceLocale(newLocale);
+        localeRepository.setLocale(context, newLocale);
         Intent intent = new Intent(context, HomeActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(intent);
@@ -79,5 +81,10 @@ public class AdvancedSettingsViewModel extends BaseViewModel {
     public void startFileListeners()
     {
         assetDefinitionService.startAlphaWalletListener();
+    }
+
+    public String getActiveLocale()
+    {
+        return localeRepository.getActiveLocale();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -203,55 +203,11 @@ public class HomeViewModel extends BaseViewModel {
 
     public void updateLocale(String newLocale, Context context)
     {
-        localeRepository.setDefaultLocale(context, newLocale);
+        localeRepository.setLocale(context, newLocale);
         //restart activity
         Intent intent = new Intent(context, HomeActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(intent);
-    }
-
-    public void setLocale(HomeActivity activity) {
-        //get the current locale
-        //only do this once, allow user to override
-        if (!localeRepository.hasOverridenLangSetting())
-        {
-            String currentLocale = localeRepository.getDefaultLocale();
-            //get the device locale
-            String deviceLocale = getDeviceLocale(activity);
-
-            if (currentLocale == null) currentLocale = "en";
-            /*
-            1. Check for Device language is different then current locale in application.
-            2. Check if application supports Device language in the app
-            */
-            if (!currentLocale.equalsIgnoreCase(deviceLocale)
-                    && localeRepository.isLocalePresent(deviceLocale))
-            {
-                currentLocale = deviceLocale;
-                localeRepository.setDefaultLocale(activity, currentLocale);
-                localeRepository.setOverridenLangSetting();
-            }
-            LocaleUtils.setLocale(activity, currentLocale);
-        }
-    }
-
-    /**
-     * This method will check for existing Device OS Language set.
-     * @param activity To reference with "Resource"
-     * @return String as a Language Locale
-     */
-    private String getDeviceLocale(HomeActivity activity) {
-        String locale;
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-        {
-            locale = activity.getResources().getConfiguration().getLocales().get(0).getLanguage();
-        }
-        else
-        {
-            locale = activity.getResources().getConfiguration().locale.getLanguage();
-        }
-        return locale;
     }
 
     public void downloadAndInstall(String build, Context ctx) {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModel.java
@@ -4,72 +4,40 @@ package com.alphawallet.app.viewmodel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.content.Context;
-import android.os.Handler;
-import android.support.annotation.Nullable;
-import android.text.format.DateUtils;
 
-import com.alphawallet.app.entity.CurrencyItem;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.interact.GenericWalletInteract;
-import com.alphawallet.app.interact.GetDefaultWalletBalance;
-import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
-import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.router.ManageWalletsRouter;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.service.TokensService;
-
-import java.util.ArrayList;
-import java.util.Map;
 
 import io.reactivex.Single;
-import io.reactivex.disposables.Disposable;
 
 public class NewSettingsViewModel extends BaseViewModel {
-    private static final long GET_BALANCE_INTERVAL = 10 * DateUtils.SECOND_IN_MILLIS;
 
     private final MutableLiveData<Wallet> defaultWallet = new MutableLiveData<>();
     private final MutableLiveData<Transaction[]> transactions = new MutableLiveData<>();
-    private final MutableLiveData<Map<String, String>> defaultWalletBalance = new MutableLiveData<>();
     private final MutableLiveData<String> backUpMessage = new MutableLiveData<>();
     private final GenericWalletInteract genericWalletInteract;
-    private final GetDefaultWalletBalance getDefaultWalletBalance;
     private final MyAddressRouter myAddressRouter;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final ManageWalletsRouter manageWalletsRouter;
     private final PreferenceRepositoryType preferenceRepository;
-    private final LocaleRepositoryType localeRepository;
-    private final TokensService tokensService;
-    private final CurrencyRepositoryType currencyRepository;
-
-    @Nullable
-    private Disposable getBalanceDisposable;
-    @Nullable
-    private Disposable fetchTransactionDisposable;
-    private Handler handler = new Handler();
 
     NewSettingsViewModel(
             GenericWalletInteract genericWalletInteract,
-            GetDefaultWalletBalance getDefaultWalletBalance,
             MyAddressRouter myAddressRouter,
             EthereumNetworkRepositoryType ethereumNetworkRepository,
             ManageWalletsRouter manageWalletsRouter,
-            PreferenceRepositoryType preferenceRepository,
-            LocaleRepositoryType localeRepository,
-            TokensService tokensService,
-            CurrencyRepositoryType currencyRepository) {
+            PreferenceRepositoryType preferenceRepository) {
         this.genericWalletInteract = genericWalletInteract;
-        this.getDefaultWalletBalance = getDefaultWalletBalance;
         this.myAddressRouter = myAddressRouter;
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.manageWalletsRouter = manageWalletsRouter;
         this.preferenceRepository = preferenceRepository;
-        this.localeRepository = localeRepository;
-        this.tokensService = tokensService;
-        this.currencyRepository = currencyRepository;
     }
 
     public void showManageWallets(Context context, boolean clearStack) {
@@ -98,8 +66,6 @@ public class NewSettingsViewModel extends BaseViewModel {
     @Override
     protected void onCleared() {
         super.onCleared();
-
-        handler.removeCallbacks(startGetBalanceTask);
     }
 
     public LiveData<Wallet> defaultWallet() {
@@ -115,17 +81,6 @@ public class NewSettingsViewModel extends BaseViewModel {
         disposable = genericWalletInteract
                 .find()
                 .subscribe(this::onDefaultWallet, this::onError);
-    }
-
-    public void getBalance() {
-        getBalanceDisposable = getDefaultWalletBalance
-                .get(defaultWallet.getValue())
-                .subscribe(values -> {
-                    defaultWalletBalance.postValue(values);
-                    handler.removeCallbacks(startGetBalanceTask);
-                    handler.postDelayed(startGetBalanceTask, GET_BALANCE_INTERVAL);
-                }, t -> {
-                });
     }
 
     private void onDefaultWallet(Wallet wallet) {
@@ -147,18 +102,8 @@ public class NewSettingsViewModel extends BaseViewModel {
         myAddressRouter.open(context, defaultWallet.getValue());
     }
 
-    private final Runnable startGetBalanceTask = this::getBalance;
-
     public Single<String> setIsDismissed(String walletAddr, boolean isDismissed)
     {
         return genericWalletInteract.setIsDismissed(walletAddr, isDismissed);
-    }
-
-    public String getDefaultCurrency() {
-        return currencyRepository.getDefaultCurrency();
-    }
-
-    public ArrayList<CurrencyItem> getCurrencyList() {
-        return currencyRepository.getCurrencyList();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModelFactory.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/NewSettingsViewModelFactory.java
@@ -6,45 +6,29 @@ import android.arch.lifecycle.ViewModelProvider;
 import android.support.annotation.NonNull;
 
 import com.alphawallet.app.interact.GenericWalletInteract;
-import com.alphawallet.app.interact.GetDefaultWalletBalance;
-import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
-import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.router.ManageWalletsRouter;
 import com.alphawallet.app.router.MyAddressRouter;
-import com.alphawallet.app.service.TokensService;
 
 public class NewSettingsViewModelFactory implements ViewModelProvider.Factory {
     private final MyAddressRouter myAddressRouter;
     private final GenericWalletInteract genericWalletInteract;
-    private final GetDefaultWalletBalance getDefaultWalletBalance;
     private final EthereumNetworkRepositoryType ethereumNetworkRepository;
     private final ManageWalletsRouter manageWalletsRouter;
     private final PreferenceRepositoryType preferenceRepository;
-    private final LocaleRepositoryType localeRepository;
-    private final TokensService tokensService;
-    private final CurrencyRepositoryType currencyRepository;
 
     public NewSettingsViewModelFactory(
             GenericWalletInteract genericWalletInteract,
-            GetDefaultWalletBalance getDefaultWalletBalance,
             MyAddressRouter myAddressRouter,
             EthereumNetworkRepositoryType ethereumNetworkRepository,
             ManageWalletsRouter manageWalletsRouter,
-            PreferenceRepositoryType preferenceRepository,
-            LocaleRepositoryType localeRepository,
-            TokensService tokensService,
-            CurrencyRepositoryType currencyRepository) {
+            PreferenceRepositoryType preferenceRepository) {
         this.genericWalletInteract = genericWalletInteract;
-        this.getDefaultWalletBalance = getDefaultWalletBalance;
         this.myAddressRouter = myAddressRouter;
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.manageWalletsRouter = manageWalletsRouter;
         this.preferenceRepository = preferenceRepository;
-        this.localeRepository = localeRepository;
-        this.tokensService = tokensService;
-        this.currencyRepository = currencyRepository;
     }
 
     @NonNull
@@ -52,14 +36,10 @@ public class NewSettingsViewModelFactory implements ViewModelProvider.Factory {
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
         return (T) new NewSettingsViewModel(
                 genericWalletInteract,
-                getDefaultWalletBalance,
                 myAddressRouter,
                 ethereumNetworkRepository,
                 manageWalletsRouter,
-                preferenceRepository,
-                localeRepository,
-                tokensService,
-                currencyRepository
+                preferenceRepository
         );
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/SplashViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/SplashViewModel.java
@@ -7,12 +7,10 @@ import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.preference.PreferenceManager;
-import android.support.v4.content.FileProvider;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.CreateWalletCallbackInterface;
@@ -20,38 +18,28 @@ import com.alphawallet.app.entity.FileData;
 import com.alphawallet.app.entity.Operation;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.WalletType;
+import com.alphawallet.app.interact.FetchWalletsInteract;
 import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
-import com.alphawallet.app.ui.SplashActivity;
-import com.alphawallet.app.util.Utils;
+import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.service.KeyService;
+import com.alphawallet.token.tools.TokenDefinition;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
-import com.alphawallet.token.tools.TokenDefinition;
-import com.alphawallet.app.entity.tokenscript.TokenScriptFile;
-import com.alphawallet.app.interact.FetchWalletsInteract;
-import com.alphawallet.app.service.AssetDefinitionService;
-import com.alphawallet.app.service.KeyService;
-
-import org.xml.sax.SAXException;
-
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.channels.FileChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 
 import static com.alphawallet.app.entity.tokenscript.TokenscriptFunction.ZERO_ADDRESS;
 import static com.alphawallet.app.viewmodel.HomeViewModel.ALPHAWALLET_DIR;
@@ -86,8 +74,9 @@ public class SplashViewModel extends ViewModel
         this.currencyRepository = currencyRepository;
     }
 
-    public void setLocale(Context context) {
-        localeRepository.setDefaultLocale(context, preferenceRepository.getDefaultLocale());
+    public void setLocale(Context context)
+    {
+        localeRepository.setLocale(context, localeRepository.getActiveLocale());
     }
 
     public void fetchWallets()


### PR DESCRIPTION
This PR fixes a few issues noticed with the locale settings, which has become a bit messy after a few re-edits.

Issues: 

1. When phone was switched to a different locale (without user explicitly choosing a locale from the settings), the phone wouldn't always pick up the changed locale.
2. Text in some menus didn't appear in the locale language on restarting the app.
3. Duplicated code.
4. Some translations were missed (see values-zh/strings.xml)

While editing the relevant classes, cleanup of redundant code was also done.

Code was checked on Pixel, Xiaomi and Huawei phones set to different locales. To repeat a check:

1. Create new emulator instance.
2. Set device language to Chinese or Spanish
3. Install AW - text should appear in the device language.
4. Change language - should be in the override language.
5. Restart app, setting should persist.
Bonus: Check the top right hamburger menu in DappBrowser; previously text was in English no matter what language settings were applied.