### PR TITLE
Fix for issues where Iris/Face unlock fails for whatever reason.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/KeyService.java
+++ b/app/src/main/java/com/alphawallet/app/service/KeyService.java
@@ -616,10 +616,10 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             boolean success = writeBytesToFile(ivPath, iv);
             if (!success)
             {
-                deleteKey(fileName);
+                //deleteKey(fileName);
                 throw new ServiceErrorException(
                         ServiceErrorException.ServiceErrorCode.FAIL_TO_SAVE_IV_FILE,
-                        "Failed to saveTokens the iv file for: " + fileName + "iv");
+                        "Failed to create the iv file for: " + fileName + "iv");
             }
 
             try (CipherOutputStream cipherOutputStream = new CipherOutputStream(
@@ -630,17 +630,17 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
             }
             catch (Exception ex)
             {
-                deleteKey(fileName);
+                //deleteKey(fileName);
                 throw new ServiceErrorException(
                         ServiceErrorException.ServiceErrorCode.KEY_STORE_ERROR,
-                        "Failed to saveTokens the file for: " + fileName);
+                        "Failed to create the file for: " + fileName);
             }
 
             return true;
         }
         catch (Exception ex)
         {
-            deleteKey(fileName);
+            //deleteKey(fileName);
             Log.d(TAG, "Key store error", ex);
         }
 
@@ -796,13 +796,6 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
 
         signDialog = new SignTransactionDialog(activity, operation, dialogTitle, null);
         signDialog.setCanceledOnTouchOutside(false);
-        signDialog.setCancelListener(v -> {
-            authenticateFail("Cancelled", AuthenticationFailType.AUTHENTICATION_DIALOG_CANCELLED, operation);
-        });
-        signDialog.setOnDismissListener(v -> {
-            signDialog = null;
-        });
-        signDialog.show();
         signDialog.getFingerprintAuthorisation(this);
         requireAuthentication = false;
     }
@@ -848,7 +841,7 @@ public class KeyService implements AuthenticationCallback, PinAuthenticationCall
                 importHDKey();
                 break;
             case CHECK_AUTHENTICATION:
-                getAuthenticationForSignature();
+                signCallback.gotAuthorisation(true);
                 break;
             case UPGRADE_HD_KEY:
             case UPGRADE_KEYSTORE_KEY:

--- a/app/src/main/java/com/alphawallet/app/widget/SignTransactionDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/SignTransactionDialog.java
@@ -24,7 +24,10 @@ import com.alphawallet.app.entity.AuthenticationCallback;
 import com.alphawallet.app.entity.AuthenticationFailType;
 import com.alphawallet.app.entity.Operation;
 
+import org.jetbrains.annotations.NotNull;
+
 import static android.content.Context.KEYGUARD_SERVICE;
+import static android.hardware.biometrics.BiometricPrompt.BIOMETRIC_ERROR_TIMEOUT;
 import static android.hardware.fingerprint.FingerprintManager.*;
 
 /**
@@ -42,7 +45,8 @@ public class SignTransactionDialog extends BottomSheetDialog
     private final TextView usePin;
     private final TextView fingerprintError;
     private final String unlockTitle;
-    private final String unlockDetail;
+    @NotNull
+    private String unlockDetail;
     private AuthenticationCallback authCallback;
     private BiometricPrompt biometricPrompt;
     private CancellationSignal cancellationSignal;
@@ -274,12 +278,14 @@ public class SignTransactionDialog extends BottomSheetDialog
                     case BiometricPrompt.BIOMETRIC_ERROR_LOCKOUT_PERMANENT:
                     case BiometricPrompt.BIOMETRIC_ERROR_UNABLE_TO_PROCESS:
                     case BiometricPrompt.BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL:
+                    case BiometricPrompt.BIOMETRIC_ERROR_TIMEOUT:
+                    case BiometricPrompt.BIOMETRIC_ERROR_NO_BIOMETRICS: //on each of these errors, default to the OS authentication screen.
+                    case BiometricPrompt.BIOMETRIC_ACQUIRED_PARTIAL:
+                    case BiometricPrompt.BIOMETRIC_ACQUIRED_TOO_FAST:
+                    case BiometricPrompt.BIOMETRIC_ACQUIRED_TOO_SLOW:
+                        unlockDetail = context.getString(R.string.unable_to_get_biometrics);
                         cancellationSignal.cancel();
                         showAuthenticationScreen();
-                        break;
-                    case BiometricPrompt.BIOMETRIC_ERROR_NO_BIOMETRICS:
-                        //display legacy screen
-                        authCallback.legacyAuthRequired(callBackId, unlockTitle, unlockDetail);
                         break;
                     default:
                         authCallback.authenticateFail(context.getString(R.string.authentication_failed), AuthenticationFailType.FINGERPRINT_NOT_VALIDATED, callBackId);

--- a/app/src/main/java/com/alphawallet/app/widget/SignTransactionDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/SignTransactionDialog.java
@@ -76,41 +76,63 @@ public class SignTransactionDialog extends BottomSheetDialog
     }
 
     //get fingerprint or PIN
+    //TODO: Final strategy:
+    // 1. allow user to supply locking authentication using face/iris unlock. If user supplies this authentication, keep key unlocked but always ask the user for face unlock - ie soft lock - when using teh key
+    // 2. if user supplies fingerprint or PIN then use existing behaviour - ie setup key to require a hard unlock event to unlock the key.
+
+    // Android 11 will finally give the fine control we need for implementing the Biometric class correctly.
+    // Currently the support in Android OS is a mess. Some manufacturers mark some biometrics (eg face unlock) as not sufficient for unlocking a protected key
+    // But, Android 10 doesn't allow you to specify 'fingerprint only' for biometrics.
+    // Therefore, we are constrained for now.
+
     public void getFingerprintAuthorisation(AuthenticationCallback authCallback) {
         this.authCallback = authCallback;
         // Create the Confirm Credentials screen. You can customize the title and description. Or
         // we will provide a generic one for you if you leave it null
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P)
+
+        if (hasPINLockSetup())
         {
-            /*
-            Dismiss current dialog and let OS prompt for its own
-             */
-            dismiss();
-
-            /*
-            Check if Biometric authentication is possible for the device or not
-             */
-            if (!hasPINLockSetup() && !checkBiometricSupport())
-            {
-                authCallback.authenticateFail(context.getString(R.string.device_not_secure_warning), AuthenticationFailType.BIOMETRIC_AUTHENTICATION_NOT_AVAILABLE, callBackId);
-                return;
-            }
-
-            biometricPrompt = new BiometricPrompt.Builder(context)
-                    .setTitle(unlockTitle)
-                    .setSubtitle(unlockDetail)
-                    .setNegativeButton(context.getString(R.string.action_cancel), context.getMainExecutor(),
-                            (dialogInterface, i) ->
-                                    authCallback.authenticateFail(context.getString(R.string.authentication_cancelled),
-                                            AuthenticationFailType.AUTHENTICATION_DIALOG_CANCELLED, callBackId))
-                    .build();
-            biometricPrompt.authenticate(getCancellationSignal(), context.getMainExecutor(), getAuthenticationCallback());
+            showAuthenticationScreen();
         }
         else
         {
-            getLegacyAuthentication(authCallback);
+            authCallback.authenticateFail("Device unlocked", AuthenticationFailType.DEVICE_NOT_SECURE, callBackId);
         }
     }
+
+//    //get fingerprint or PIN
+//    public void getFingerprintAuthorisation(AuthenticationCallback authCallback)
+//    {
+//        this.authCallback = authCallback;
+//        // Create the Confirm Credentials screen. You can customize the title and description. Or
+//        // we will provide a generic one for you if you leave it null
+//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P)
+//        {
+//            // Dismiss current dialog and let OS prompt for its own
+//            dismiss();
+//
+//            //Check if Biometric authentication is possible for the device or not
+//            if (!hasPINLockSetup() && !checkBiometricSupport())
+//            {
+//                authCallback.authenticateFail(context.getString(R.string.device_not_secure_warning), AuthenticationFailType.BIOMETRIC_AUTHENTICATION_NOT_AVAILABLE, callBackId);
+//                return;
+//            }
+//
+//            biometricPrompt = new BiometricPrompt.Builder(context)
+//                    .setTitle(unlockTitle)
+//                    .setSubtitle(unlockDetail)
+//                    .setNegativeButton(context.getString(R.string.action_cancel), context.getMainExecutor(),
+//                            (dialogInterface, i) ->
+//                                    authCallback.authenticateFail(context.getString(R.string.authentication_cancelled),
+//                                            AuthenticationFailType.AUTHENTICATION_DIALOG_CANCELLED, callBackId))
+//                    .build();
+//            biometricPrompt.authenticate(getCancellationSignal(), context.getMainExecutor(), getAuthenticationCallback());
+//        } else
+//        {
+//            getLegacyAuthentication(authCallback);
+//        }
+//    }
+
 
     public void getLegacyAuthentication(AuthenticationCallback authCallback)
     {
@@ -141,7 +163,8 @@ public class SignTransactionDialog extends BottomSheetDialog
         fingerPrintText.setVisibility(View.GONE);
     }
 
-    private void showAuthenticationScreen()
+    // Continue to use legacy auth screen
+    public void showAuthenticationScreen()
     {
         KeyguardManager mKeyguardManager = (KeyguardManager) context.getSystemService(KEYGUARD_SERVICE);
         Intent intent = mKeyguardManager.createConfirmDeviceCredentialIntent(unlockTitle, unlockDetail);

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -669,4 +669,5 @@
     <string name="session_terminated">Session has been terminated. Switch back to Dapp and start a new WalletConnect session.</string>
     <string name="message_transaction_not_sent">Transaction not sent</string>
     <string name="popular_tokens">Tokens Populares</string>
+    <string name="unable_to_get_biometrics">No se puede obtener el desbloqueo Biométrico</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -669,4 +669,5 @@
     <string name="session_terminated">Session has been terminated. Switch back to Dapp and start a new WalletConnect session.</string>
     <string name="message_transaction_not_sent">Transaction not sent</string>
     <string name="popular_tokens">热门通证</string>
+    <string name="unable_to_get_biometrics">无法获得生物识别解锁</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,4 +687,5 @@
     <string name="session_terminated">Session has been terminated. Switch back to Dapp and start a new WalletConnect session.</string>
     <string name="message_transaction_not_sent">Transaction not sent</string>
     <string name="popular_tokens">Popular Tokens</string>
+    <string name="unable_to_get_biometrics">Unable to obtain Biometric unlock</string>
 </resources>


### PR DESCRIPTION
Fixes #1622

Fallback to system unlock prompt if biometric unlock fails.

Note - many developers report that Samsung face/iris unlock is not completely stable, so the fallback option ensures that there is always a way to unlock the key.