### PR TITLE
Fix for incorrect Pending Transaction

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -208,8 +208,8 @@ public class RepositoriesModule {
 	@Provides
     AssetDefinitionService provideAssetDefinitionService(OkHttpClient okHttpClient, Context ctx, NotificationService notificationService, RealmManager realmManager,
 														 EthereumNetworkRepositoryType ethereumNetworkRepository, TokensService tokensService,
-														 TokenLocalSource tls, TransactionLocalSource trs, AlphaWalletService alphaService) {
-		return new AssetDefinitionService(okHttpClient, ctx, notificationService, realmManager, ethereumNetworkRepository, tokensService, tls, trs, alphaService);
+														 TokenLocalSource tls, TransactionRepositoryType trt, AlphaWalletService alphaService) {
+		return new AssetDefinitionService(okHttpClient, ctx, notificationService, realmManager, ethereumNetworkRepository, tokensService, tls, trt, alphaService);
 	}
 
 	@Singleton

--- a/app/src/main/java/com/alphawallet/app/entity/Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Transaction.java
@@ -55,6 +55,11 @@ public class Transaction implements Parcelable {
 	private static TransactionDecoder decoder = null;
 	private static ParseMagicLink parser = null;
 
+	public boolean isPending()
+	{
+		return TextUtils.isEmpty(blockNumber) || blockNumber.equals("0") || blockNumber.equals("-2");
+	}
+
     public Transaction(
             String hash,
             String error,
@@ -481,7 +486,7 @@ public class Transaction implements Parcelable {
 		String txName = null;
 		try
 		{
-			if (blockNumber != null && blockNumber.equals("0"))
+			if (isPending())
 			{
 				txName = ctx.getString(R.string.status_pending);
 			}
@@ -586,7 +591,7 @@ public class Transaction implements Parcelable {
 		{
 			return StatusType.REJECTED;
 		}
-		else if (blockNumber.equals("0"))
+		else if (isPending())
 		{
 			return StatusType.PENDING;
 		}

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionMeta.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionMeta.java
@@ -19,10 +19,10 @@ public class TransactionMeta extends ActivityMeta
     public final String contractAddress;
     public final int chainId;
 
-    public TransactionMeta(String hash, long timeStamp, String contractAddress, int chainId, boolean pending)
+    public TransactionMeta(String hash, long timeStamp, String contractAddress, int chainId, String blockNumber)
     {
         super(timeStamp, hash);
-        this.isPending = pending;
+        this.isPending = blockNumber.equals("0") || blockNumber.equals("-2");
         this.contractAddress = contractAddress;
         this.chainId = chainId;
     }

--- a/app/src/main/java/com/alphawallet/app/interact/FetchTransactionsInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/FetchTransactionsInteract.java
@@ -75,7 +75,7 @@ public class FetchTransactionsInteract {
                 .fetchCachedEvent(walletAddress, eventKey);
     }
 
-    public Transaction storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
+    public Single<Transaction> storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
     {
         return transactionRepository.storeRawTx(wallet, rawTx, timeStamp);
     }

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
@@ -22,10 +22,10 @@ public interface TransactionLocalSource {
 	Realm getRealmInstance(Wallet wallet);
 	Single<ActivityMeta[]> fetchActivityMetas(Wallet wallet, int chainId, String tokenAddress, int historyCount);
 	Single<ActivityMeta[]> fetchEventMetas(Wallet wallet, List<Integer> networkFilters);
-	void markTransactionDropped(String walletAddress, String hash);
+	void markTransactionBlock(String walletAddress, String hash, long blockValue);
 	Transaction[] fetchPendingTransactions(String currentAddress);
 
 	RealmAuxData fetchEvent(String walletAddress, String eventKey);
 
-	Transaction storeRawTx(Wallet wallet, EthTransaction object, long timeStamp);
+	Transaction storeRawTx(Wallet wallet, EthTransaction object, long timeStamp, boolean isSuccessful);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
@@ -38,5 +38,5 @@ public interface TransactionRepositoryType {
 	Realm getRealmInstance(Wallet wallet);
 
 	RealmAuxData fetchCachedEvent(String walletAddress, String eventKey);
-	Transaction storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp);
+	Single<Transaction> storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransaction.java
@@ -1,5 +1,7 @@
 package com.alphawallet.app.repository.entity;
 
+import android.text.TextUtils;
+
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
@@ -140,5 +142,10 @@ public class RealmTransaction extends RealmObject {
     public void setToken(String token)
     {
         this.token = token;
+    }
+
+    public boolean isPending()
+    {
+        return blockNumber == null || blockNumber.length() == 0 || (blockNumber.equals("0") || blockNumber.equals("-2"));
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -429,7 +429,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
             for (RealmTransaction item : txs)
             {
-                TransactionMeta tm = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber().equals("0"));
+                TransactionMeta tm = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber());
                 metas.add(tm);
             }
         }

--- a/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
@@ -121,8 +121,7 @@ public class ActivityFragment extends BaseFragment implements View.OnClickListen
                 {
                     if (viewModel.getTokensService().getNetworkFilters().contains(item.getChainId()))
                     {
-                        boolean pendingTx = item.getBlockNumber().equals("0");
-                        TransactionMeta newMeta = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), pendingTx);
+                        TransactionMeta newMeta = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber());
                         metas.add(newMeta);
                     }
                 }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -135,7 +135,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
             tokenIcon.setStatusIcon(StatusType.REJECTED);
             address.setText(R.string.tx_rejected);
         }
-        else if (transaction.blockNumber.equals("0") || transaction.blockNumber.equals("-2"))
+        else if (transaction.isPending())
         {
             tokenIcon.setStatusIcon(StatusType.PENDING);
             type.setText(R.string.pending_transaction);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -135,7 +135,7 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
             tokenIcon.setStatusIcon(StatusType.REJECTED);
             address.setText(R.string.tx_rejected);
         }
-        else if (transaction.blockNumber.equals("0"))
+        else if (transaction.blockNumber.equals("0") || transaction.blockNumber.equals("-2"))
         {
             tokenIcon.setStatusIcon(StatusType.PENDING);
             type.setText(R.string.pending_transaction);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
@@ -76,7 +76,7 @@ public class TransactionDetailViewModel extends BaseViewModel {
     public void prepare(final int chainId, final String walletAddr)
     {
         walletAddress = walletAddr;
-        currentBlockUpdateDisposable = Observable.interval(0, 10, TimeUnit.SECONDS)
+        currentBlockUpdateDisposable = Observable.interval(0, 6, TimeUnit.SECONDS)
                 .doOnNext(l -> {
                     disposable = tokenRepository.fetchLatestBlockNumber(chainId)
                             .subscribeOn(Schedulers.io())
@@ -106,7 +106,7 @@ public class TransactionDetailViewModel extends BaseViewModel {
         if (tx != null)
         {
             lastestTx.postValue(tx);
-            if (!tx.blockNumber.equals("0"))
+            if (!tx.isPending())
             {
                 if (pendingUpdateDisposable != null && !pendingUpdateDisposable.isDisposed())
                     pendingUpdateDisposable.dispose();

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
@@ -25,16 +25,12 @@ import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.ui.ConfirmationActivity;
 
 import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthTransaction;
-import org.web3j.protocol.core.methods.response.Log;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Observable;
-import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
@@ -219,7 +215,7 @@ public class TransactionDetailViewModel extends BaseViewModel {
 
         org.web3j.protocol.core.methods.response.Transaction ethTx = rawTx.getTransaction().get();
         disposable = EventUtils.getBlockDetails(ethTx.getBlockHash(), web3j)
-                .map(ethBlock -> fetchTransactionsInteract.storeRawTx(wallet, rawTx, ethBlock.getBlock().getTimestamp().longValue()))
+                .flatMap(ethBlock -> fetchTransactionsInteract.storeRawTx(wallet, rawTx, ethBlock.getBlock().getTimestamp().longValue()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(transaction::postValue, this::onError);

--- a/app/src/main/java/com/alphawallet/app/widget/ActivityHistoryList.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActivityHistoryList.java
@@ -91,7 +91,7 @@ public class ActivityHistoryList extends LinearLayout
             //make list
             for (RealmTransaction item : realmTransactions)
             {
-                TransactionMeta tm = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber().equals("0"));
+                TransactionMeta tm = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber());
                 metas.add(tm);
             }
 

--- a/app/src/main/res/layout/activity_token_activity.xml
+++ b/app/src/main/res/layout/activity_token_activity.xml
@@ -67,6 +67,29 @@
                 android:layout_marginBottom="10dp"
                 android:textSize="@dimen/sp24" />
 
+            <LinearLayout
+                android:id="@+id/pending_time_layout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <ProgressBar
+                    android:layout_width="@dimen/dp14"
+                    android:layout_gravity="center_vertical"
+                    android:layout_height="@dimen/dp14"
+                    android:layout_marginEnd="6dp"
+                    android:contentDescription="@string/empty"/>
+
+                <TextView
+                    android:id="@+id/pending_time"
+                    style="@style/TransactionDetailsStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="@string/transaction_pending_for" />
+
+            </LinearLayout>
+
             <include layout="@layout/item_ticket" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -76,6 +76,26 @@
                         android:layout_height="wrap_content"
                         tools:text="4238793"  />
 
+                    <TextView
+                        android:id="@+id/failed"
+                        android:layout_marginStart="@dimen/dp16"
+                        style="@style/TransactionDetailsStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/warning_red"
+                        android:text="@string/failed"
+                        android:visibility="gone"/>
+
+                    <TextView
+                        android:id="@+id/failedFace"
+                        style="@style/TransactionDetailsStyle"
+                        android:layout_marginStart="@dimen/dp5"
+                        android:textColor="@color/warning_red"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="☹"
+                        android:visibility="gone"/>
+
                 </LinearLayout>
 
             </RelativeLayout>

--- a/app/src/test/java/com/alphawallet/app/MarketOrderTest.java
+++ b/app/src/test/java/com/alphawallet/app/MarketOrderTest.java
@@ -191,7 +191,7 @@ public class MarketOrderTest
             }
 
             @Override
-            public Transaction storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
+            public Single<Transaction> storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
             {
                 return null;
             }

--- a/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
+++ b/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
@@ -175,7 +175,7 @@ public class QRSelectionTest
             }
 
             @Override
-            public Transaction storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
+            public Single<Transaction> storeRawTx(Wallet wallet, EthTransaction rawTx, long timeStamp)
             {
                 return null;
             }


### PR DESCRIPTION
Fixes #1609, and also 2 directly related issues.

- Sometimes when sending mainnet transactions they would be incorrectly labelled as rejected when they are not.
- Incorrect date storage in some instances (when pending transactions dropped).
- Ensure that transactions which errored are displayed correctly.