### PR TITLE
Fix to correctly receive token events

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -37,7 +37,15 @@ public class EtherscanTransaction
         Transaction tx = new Transaction(hash, isError, blockNumber, timeStamp, nonce, from, to, value, gas, gasPrice, input,
                                          gasUsed, chainId, contractAddress);
 
-        if (walletAddress != null) tx.completeSetup(walletAddress);
+        if (walletAddress != null)
+        {
+            tx.completeSetup(walletAddress);
+            if (!walletInvolvedInTransaction(tx, walletAddress))
+            {
+                tx = null;
+            }
+        }
+
         return tx;
     }
 
@@ -49,7 +57,7 @@ public class EtherscanTransaction
         if ((data != null && data.functionData != null) && data.containsAddress(walletAddr)) return true;
         if (trans.from.equalsIgnoreCase(walletAddr)) return true;
         if (trans.to.equalsIgnoreCase(walletAddr)) return true;
-        if (input != null && input.length() > 40 && input.contains(Numeric.cleanHexPrefix(walletAddr))) return true;
+        if (input != null && input.length() > 40 && input.contains(Numeric.cleanHexPrefix(walletAddr.toLowerCase()))) return true;
         if (trans.operations != null && trans.operations.length > 0 && trans.operations[0].walletInvolvedWithTransaction(walletAddr))
             involved = true;
         return involved;

--- a/app/src/main/java/com/alphawallet/app/entity/Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Transaction.java
@@ -60,6 +60,16 @@ public class Transaction implements Parcelable {
 		return TextUtils.isEmpty(blockNumber) || blockNumber.equals("0") || blockNumber.equals("-2");
 	}
 
+	public boolean hasError()
+	{
+		return TextUtils.isEmpty(error) && error.equals("1");
+	}
+
+	public boolean hasData()
+	{
+		return !TextUtils.isEmpty(input) && input.length() > 2;
+	}
+
     public Transaction(
             String hash,
             String error,
@@ -353,7 +363,7 @@ public class Transaction implements Parcelable {
 		else
 		{
 			if (to.equalsIgnoreCase(contractAddress)) return true;
-			else return operation != null && (operations[0].contract.address.equalsIgnoreCase(contractAddress));
+			else return operation != null && (operation.walletInvolvedWithTransaction(walletAddress) || operation.contract.address.equalsIgnoreCase(contractAddress));
 		}
 	}
 
@@ -458,7 +468,7 @@ public class Transaction implements Parcelable {
 	{
 		if (operations == null || operations.length == 0)
 			return token.getTransactionValue(this, precision);
-		if (error.equals("1")) return "";
+		if (hasError()) return "";
 
 		//TODO: Handle multiple operation transactions
 		TransactionOperation operation = operations[0];
@@ -583,7 +593,7 @@ public class Transaction implements Parcelable {
 
 	public StatusType getTransactionStatus()
 	{
-		if (error != null && error.equals("1"))
+		if (hasError())
 		{
 			return StatusType.FAILED;
 		}

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionOperation.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionOperation.java
@@ -78,7 +78,8 @@ public class TransactionOperation implements Parcelable {
     {
         if (contract != null)
         {
-            return contract.checkAddress(address);
+            if ((from != null && from.equalsIgnoreCase(address)) || (to != null && to.equalsIgnoreCase(address))) return true;
+            else return contract.checkAddress(address);
         }
         else
         {

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -3,6 +3,7 @@ package com.alphawallet.app.entity.tokens;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.format.DateUtils;
 
 import androidx.annotation.NonNull;
 
@@ -36,6 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static com.alphawallet.app.repository.EthereumNetworkBase.hasRealValue;
 
 public class Token implements Parcelable, Comparable<Token>
 {
@@ -638,7 +641,7 @@ public class Token implements Parcelable, Comparable<Token>
      */
     public String getTransactionValue(Transaction transaction, int precision)
     {
-        if (transaction.error.equals("1")) return "";
+        if (transaction.hasError()) return "";
         else if (transaction.value.equals("0")) return "0";
         return transaction.getPrefix(this) + BalanceUtils.getScaledValueFixed(new BigDecimal(transaction.value), tokenInfo.decimals, precision);
     }
@@ -923,5 +926,21 @@ public class Token implements Parcelable, Comparable<Token>
     public void setNameWeight(int weight)
     {
         nameWeight = weight;
+    }
+
+    public long getTransactionCheckInterval()
+    {
+        if (hasRealValue() && hasPositiveBalance())
+        {
+            return 1* DateUtils.MINUTE_IN_MILLIS;
+        }
+        else if (hasPositiveBalance())
+        {
+            return 150* DateUtils.SECOND_IN_MILLIS;
+        }
+        else
+        {
+            return 0;
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
@@ -34,9 +34,9 @@ public class TokenUpdateEntry
             case ERC875_LEGACY:
             case ERC875:
             case ETHEREUM:
-                return true;
             case ERC20:
             case ERC721_TICKET:
+                return true;
             case CURRENCY:
             case DELETED_ACCOUNT:
             case OTHER:

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
@@ -8,7 +8,6 @@ import com.alphawallet.app.entity.tokens.Token;
 import io.reactivex.Single;
 
 public interface TransactionsNetworkClientType {
-    Single<Transaction[]> storeNewTransactions(String walletAddress, NetworkInfo networkInfo, long lastBlock);
-    void storeBlockRead(Token token, String walletAddress);
+    Single<Transaction[]> storeNewTransactions(String walletAddress, NetworkInfo networkInfo, String tokenAddress, long lastBlock);
     Single<TransactionMeta[]> fetchMoreTransactions(String walletAddress, NetworkInfo network, long lastTxTime);
 }

--- a/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
@@ -128,9 +128,6 @@ public class ActivityFragment extends BaseFragment implements View.OnClickListen
                     adapter.updateActivityItems(metas.toArray(new TransactionMeta[0]));
                     systemView.hide();
                 }
-
-                //Check for new unknown tokens
-                viewModel.checkTokens(realmTransactions);
             });
 
             auxRealmUpdates = realm.where(RealmAuxData.class)

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -300,7 +300,7 @@ public class TransactionDetailActivity extends BaseActivity implements StandardF
 
     private void checkFailed()
     {
-        if (transaction.error != null && transaction.error.equals("1"))
+        if (transaction.hasError())
         {
             TextView failed = findViewById(R.id.failed);
             TextView failedF = findViewById(R.id.failedFace);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/ActivityViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/ActivityViewModel.java
@@ -132,23 +132,6 @@ public class ActivityViewModel extends BaseViewModel
         return fetchTransactionsInteract.getRealmInstance(wallet.getValue());
     }
 
-    /**
-     * Check new tokens for any unknowns, then find the unknowns
-     * @param rawTxList
-     */
-    public void checkTokens(RealmResults<RealmTransaction> rawTxList)
-    {
-        for (RealmTransaction tx : rawTxList)
-        {
-            if (tx.getError() != null && tx.getError().equals("0") &&
-                    tx.getInput() != null && tx.getInput().length() > 2) //is this a successful contract transaction?
-            {
-                Token token = tokensService.getToken(tx.getChainId(), tx.getTo());
-                if (token == null) tokensService.addUnknownTokenToCheck(new ContractAddress(tx.getChainId(), tx.getTo()));
-            }
-        }
-    }
-
     public AssetDefinitionService getAssetDefinitionService()
     {
         return assetDefinitionService;


### PR DESCRIPTION
This PR fixes the issue with not being able to see token receive events.

It has the following changes and improvements:

- when discovering token contracts the account interacted with, it puts checking those at the front of the token discovery queue.
- check token contracts with positive balance for events relating to the current account.
- refactor checking for new contracts - remove from UI adapter and place in backend where the check should be.
- add convenience methods to establish detecting transaction error and if transaction has function input data.