### PR TITLE
Fix for usage of CopyTextView

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -5,12 +5,12 @@ import android.text.format.DateUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
@@ -20,11 +20,11 @@ import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionOperation;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.ui.widget.holder.TransactionHolder;
 import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.util.LocaleUtils;
 import com.alphawallet.app.util.Utils;
-import com.alphawallet.app.viewmodel.TokenScriptManagementViewModel;
 import com.alphawallet.app.viewmodel.TransactionDetailViewModel;
 import com.alphawallet.app.viewmodel.TransactionDetailViewModelFactory;
 import com.alphawallet.app.widget.CopyTextView;
@@ -129,6 +129,7 @@ public class TransactionDetailActivity extends BaseActivity implements StandardF
 
         chainName = viewModel.getNetworkName(transaction.chainId);
         ((TextView) findViewById(R.id.network)).setText(chainName);
+        ((ImageView) findViewById(R.id.network_icon)).setImageResource(EthereumNetworkRepository.getChainLogo(transaction.chainId));
 
         token = viewModel.getToken(transaction.chainId, transaction.to);
         TextView chainLabel = findViewById(R.id.text_chain_name);

--- a/app/src/main/java/com/alphawallet/app/widget/CopyTextView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/CopyTextView.java
@@ -52,7 +52,7 @@ public class CopyTextView extends LinearLayout {
 
         try {
             textResId = a.getResourceId(R.styleable.CopyTextView_text, R.string.action_add_wallet);
-            textColor = a.getColor(R.styleable.CopyTextView_textColour, -1);
+            textColor = a.getColor(R.styleable.CopyTextView_textColour, context.getColor(R.color.mine));
             gravity = a.getInt(R.styleable.CopyTextView_grav, Gravity.NO_GRAVITY);
             showToast = a.getBoolean(R.styleable.CopyTextView_showToast, true);
             boldFont = a.getBoolean(R.styleable.CopyTextView_bold, false);

--- a/app/src/main/res/layout/activity_contract_address.xml
+++ b/app/src/main/res/layout/activity_contract_address.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorPrimary"
@@ -88,9 +89,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_horizontal"
-                app:gravity="center"
-                app:bold="true"
-                app:textColor="@color/black" />
+                custom:gravity="center"
+                custom:bold="true"
+                custom:textColor="@color/black" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_my_address.xml
+++ b/app/src/main/res/layout/activity_my_address.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorPrimary"
@@ -71,11 +72,11 @@
                 android:layout_marginBottom="@dimen/dp24"
                 android:gravity="center"
                 android:visibility="gone"
-                app:gravity="center_vertical"
-                app:text="@string/ethereum"
-                app:bold="true"
-                app:removePadding="true"
-                app:textColor="@color/black" />
+                custom:gravity="center_vertical"
+                custom:text="@string/ethereum"
+                custom:bold="true"
+                custom:removePadding="true"
+                custom:textColor="@color/black" />
 
             <com.alphawallet.app.widget.CopyTextView
                 android:id="@+id/copy_address"
@@ -83,9 +84,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_horizontal"
-                app:gravity="center"
-                app:bold="true"
-                app:textColor="@color/black" />
+                custom:gravity="center"
+                custom:bold="true"
+                custom:textColor="@color/black" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -1,6 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorPrimary">
@@ -112,10 +112,10 @@
                 style="@style/TransactionDetailsCopyTextStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:gravity="start"
-                app:bold="false"
-                app:textColor="@color/mine"
-                app:marginRight="@dimen/dp18" />
+                custom:gravity="start"
+                custom:bold="false"
+                custom:textColor="@color/mine"
+                custom:marginRight="@dimen/dp18" />
 
             <TextView
                 style="@style/TransactionDetailsSubTitleStyle"
@@ -123,14 +123,29 @@
                 android:layout_height="wrap_content"
                 android:text="@string/subtitle_network" />
 
-            <TextView
-                android:id="@+id/network"
-                style="@style/TransactionDetailsStyle"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawableLeft="@drawable/ic_coin_eth_small"
-                android:drawablePadding="@dimen/dp5"
-                android:text="@string/ethereum" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/network_icon"
+                    android:layout_width="@dimen/dp24"
+                    android:layout_height="@dimen/dp24"
+                    android:layout_marginEnd="@dimen/dp5"
+                    android:layout_gravity="center_vertical"
+                    android:src="@drawable/ic_coin_eth_small" />
+
+                <TextView
+                    android:id="@+id/network"
+                    style="@style/TransactionDetailsStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="2dp"
+                    android:text="@string/ethereum" />
+
+            </LinearLayout>
 
             <TextView
                 style="@style/TransactionDetailsSubTitleStyle"
@@ -143,10 +158,10 @@
                 style="@style/TransactionDetailsCopyTextStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:gravity="start"
-                app:bold="false"
-                app:textColor="@color/mine"
-                app:marginRight="@dimen/dp18" />
+                custom:gravity="start"
+                custom:bold="false"
+                custom:textColor="@color/mine"
+                custom:marginRight="@dimen/dp18" />
 
             <TextView
                 style="@style/TransactionDetailsSubTitleStyle"
@@ -159,10 +174,10 @@
                 style="@style/TransactionDetailsCopyTextStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:gravity="start"
-                app:bold="false"
-                app:textColor="@color/mine"
-                app:marginRight="@dimen/dp18" />
+                custom:gravity="start"
+                custom:bold="false"
+                custom:textColor="@color/mine"
+                custom:marginRight="@dimen/dp18" />
 
             <TextView
                 style="@style/TransactionDetailsSubTitleStyle"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -82,7 +82,7 @@
 
     <style name="TransactionDetailsCopyTextStyle">
         <item name="android:paddingTop">@dimen/dp5</item>
-        <item name="android:background">@color/white</item>
+        <item name="android:background">@color/transparent</item>
         <item name="android:paddingEnd">@dimen/dp16</item>
         <item name="android:paddingBottom">@dimen/dp5</item>
     </style>


### PR DESCRIPTION
This PR fixes the issue where the text for 'CopyTextView' graphic widget would be in white.

This is happening now because of the upgrade to AndroidX, looks like the Android team restricted how you can pass widget setup values:

```
            <com.alphawallet.app.widget.CopyTextView
                android:id="@+id/copy_address"
                style="@style/MyAddressCopyTextStyle"
                android:layout_width="wrap_content"
                android:layout_height="wrap_content"
                android:gravity="center_horizontal"
                custom:gravity="center"
                custom:bold="true"
                custom:textColor="@color/black" />
```

The passed values like bold, textColor etc need to use the 'custom' prefix not 'app' prefix as was previously acceptable. The default text colour was white because the default value was -1, now it defaults to the app default text colour which removes a gotcha for a future dev.

Also change the Icon graphic on the detail page so it reflects the chain we're looking at.