### PR TITLE
Show chain for ease of use

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -36,6 +36,8 @@ import java.math.RoundingMode;
 import io.realm.Realm;
 import io.realm.RealmResults;
 
+import static com.alphawallet.app.repository.EthereumNetworkBase.MAINNET_ID;
+
 public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View.OnClickListener, View.OnLongClickListener {
 
     public static final int VIEW_TYPE = 1005;
@@ -167,6 +169,15 @@ public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View
             layoutAppreciation.setVisibility(View.GONE);
             setIssuerDetails();
         }
+
+        if (!token.isEthereum() && token.tokenInfo.chainId != MAINNET_ID)
+        {
+            showNetworkLabel();
+        }
+        else
+        {
+            hideNetworkLabel();
+        }
     }
 
     private void handleTicker()
@@ -175,17 +186,16 @@ public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View
         hideIssuerViews();
         layoutAppreciation.setVisibility(View.VISIBLE);
         balanceCurrency.setVisibility(View.VISIBLE);
-        hideTestnet();
         startTickerRealmListener();
     }
 
-    private void showTestnet() {
+    private void showNetworkLabel() {
         testnet.setVisibility(View.VISIBLE);
         Utils.setChainColour(testnet, token.tokenInfo.chainId);
         testnet.setText(token.getNetworkName());
     }
 
-    private void hideTestnet() {
+    private void hideNetworkLabel() {
         testnet.setVisibility(View.GONE);
     }
 

--- a/app/src/main/res/layout/activity_token_activity.xml
+++ b/app/src/main/res/layout/activity_token_activity.xml
@@ -64,13 +64,28 @@
                 tools:text="+ 1.234 ETH"
                 android:textColor="@color/black"
                 android:layout_marginTop="@dimen/dp16"
-                android:layout_marginBottom="10dp"
                 android:textSize="@dimen/sp24" />
+
+            <TextView
+                android:id="@+id/text_chain_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/dp5"
+                android:layout_marginEnd="@dimen/dp8"
+                android:layout_marginStart="@dimen/dp5"
+                android:background="@drawable/background_status_pending"
+                android:fontFamily="@font/font_bold"
+                android:padding="2dp"
+                android:text="@string/action_clear"
+                android:textColor="@color/white"
+                android:textSize="10sp"
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/pending_time_layout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/dp5"
                 android:orientation="horizontal"
                 android:visibility="gone">
 
@@ -89,6 +104,11 @@
                     tools:text="@string/transaction_pending_for" />
 
             </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/dp5"
+                android:orientation="horizontal"/>
 
             <include layout="@layout/item_ticket" />
 


### PR DESCRIPTION
This PR adds code to show the chain spec for Tokens (eg ERC20, ERC721) on non ETH Mainnet chains same as iOS.

It was noticed that with many chains showing it's difficult to see what chain the token is on. Esp with xdai tokens.

Also add the chain name box for non mainnet tokens in the Activity page (click on the Event in Activity view to see Activity page).