### PR TITLE
Add token transfer events from Etherscan

### DIFF
--- a/app/src/androidTest/java/com/alphawallet/app/WalletTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletTest.java
@@ -1,6 +1,6 @@
 package com.alphawallet.app;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 
 
 import org.junit.runner.RunWith;

--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -81,12 +81,10 @@ public class RepositoriesModule {
 			PreferenceRepositoryType preferenceRepositoryType,
 			AccountKeystoreService accountKeystoreService,
 			EthereumNetworkRepositoryType networkRepository,
-			TransactionsNetworkClientType blockExplorerClient,
 			WalletDataRealmSource walletDataRealmSource,
-			OkHttpClient httpClient,
 			KeyService keyService) {
 		return new WalletRepository(
-		        preferenceRepositoryType, accountKeystoreService, networkRepository, blockExplorerClient, walletDataRealmSource, httpClient, keyService);
+		        preferenceRepositoryType, accountKeystoreService, networkRepository, walletDataRealmSource, keyService);
 	}
 
 	@Singleton
@@ -114,9 +112,8 @@ public class RepositoriesModule {
     TransactionsNetworkClientType provideBlockExplorerClient(
 			OkHttpClient httpClient,
 			Gson gson,
-			RealmManager realmManager,
-			Context context) {
-		return new TransactionsNetworkClient(httpClient, gson, realmManager, context);
+			RealmManager realmManager) {
+		return new TransactionsNetworkClient(httpClient, gson, realmManager);
 	}
 
 	@Singleton
@@ -126,15 +123,13 @@ public class RepositoriesModule {
             TokenLocalSource tokenLocalSource,
 			OkHttpClient httpClient,
 			Context context,
-			TickerService tickerService,
-			TransactionsNetworkClientType transactionClient) {
+			TickerService tickerService) {
 	    return new TokenRepository(
 	            ethereumNetworkRepository,
 				tokenLocalSource,
 				httpClient,
 				context,
-				tickerService,
-				transactionClient);
+				tickerService);
     }
 
     @Singleton

--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
@@ -1,0 +1,93 @@
+package com.alphawallet.app.entity;
+
+import android.text.TextUtils;
+
+/**
+ * Created by JB on 21/10/2020.
+ */
+public class EtherscanEvent
+{
+    public String blockNumber;
+    public long timeStamp;
+    public String hash;
+    public int nonce;
+    String blockHash;
+    String from;
+    public String contractAddress;
+    String to;
+    String tokenID;
+    String value;
+    public String tokenName;
+    public String tokenSymbol;
+    public String tokenDecimal;
+    String gas;
+    String gasPrice;
+    String gasUsed;
+
+    public Transaction createTransaction(String walletAddress, NetworkInfo networkInfo)
+    {
+        TransactionOperation[] operations = createOperation(walletAddress);
+
+        return new Transaction(hash, "0", blockNumber, timeStamp, nonce, from, contractAddress, "0", gas, gasPrice, "0x",
+                gasUsed, networkInfo.chainId, operations);
+    }
+
+    private TransactionOperation[] createOperation(String walletAddress)
+    {
+        TransactionOperation[] o = generateOp();
+        TransactionOperation op = o[0];
+        op.from = from;
+        op.to = to;
+        if (!TextUtils.isEmpty(value) && !value.equals("null"))
+        {
+            op.value = value;
+        }
+        else
+        {
+            op.value = tokenID;
+            if (tokenID.length() > 10)
+            {
+                op.value = "1";
+            }
+        }
+        op.contract.address = contractAddress;
+        if (from.equalsIgnoreCase(walletAddress))
+        {
+            setName(o, TransactionType.TRANSFER_TO);
+        }
+        else
+        {
+            setName(o, TransactionType.RECEIVED);
+        }
+
+        op.transactionId = hash;
+        return o;
+    }
+
+    private TransactionOperation[] generateOp()
+    {
+        TransactionOperation[] o = new TransactionOperation[1];
+        TransactionOperation op = new TransactionOperation();
+        TransactionContract ct = new TransactionContract();
+        o[0] = op;
+        op.contract = ct;
+        return o;
+    }
+
+    private void setName(TransactionOperation[] o, TransactionType name)
+    {
+        if (o.length > 0 && o[0] != null)
+        {
+            TransactionOperation op = o[0];
+            TransactionContract ct = op.contract;
+            if (ct instanceof ERC875ContractTransaction)
+            {
+                ((ERC875ContractTransaction) ct).operation = name;
+            }
+            else
+            {
+                op.contract.name = "*" + String.valueOf(name.ordinal());
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -37,7 +37,15 @@ public class EtherscanTransaction
         Transaction tx = new Transaction(hash, isError, blockNumber, timeStamp, nonce, from, to, value, gas, gasPrice, input,
                                          gasUsed, chainId, contractAddress);
 
-        if (walletAddress != null) tx.completeSetup(walletAddress);
+        if (walletAddress != null)
+        {
+            tx.completeSetup(walletAddress);
+            if (!walletInvolvedInTransaction(tx, walletAddress))
+            {
+                tx = null;
+            }
+        }
+
         return tx;
     }
 
@@ -49,7 +57,7 @@ public class EtherscanTransaction
         if ((data != null && data.functionData != null) && data.containsAddress(walletAddr)) return true;
         if (trans.from.equalsIgnoreCase(walletAddr)) return true;
         if (trans.to.equalsIgnoreCase(walletAddr)) return true;
-        if (input != null && input.length() > 40 && input.contains(Numeric.cleanHexPrefix(walletAddr))) return true;
+        if (input != null && input.length() > 40 && input.contains(Numeric.cleanHexPrefix(walletAddr.toLowerCase()))) return true;
         if (trans.operations != null && trans.operations.length > 0 && trans.operations[0].walletInvolvedWithTransaction(walletAddr))
             involved = true;
         return involved;

--- a/app/src/main/java/com/alphawallet/app/entity/Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Transaction.java
@@ -60,6 +60,16 @@ public class Transaction implements Parcelable {
 		return TextUtils.isEmpty(blockNumber) || blockNumber.equals("0") || blockNumber.equals("-2");
 	}
 
+	public boolean hasError()
+	{
+		return TextUtils.isEmpty(error) && error.equals("1");
+	}
+
+	public boolean hasData()
+	{
+		return !TextUtils.isEmpty(input) && input.length() > 2;
+	}
+
     public Transaction(
             String hash,
             String error,
@@ -353,7 +363,7 @@ public class Transaction implements Parcelable {
 		else
 		{
 			if (to.equalsIgnoreCase(contractAddress)) return true;
-			else return operation != null && (operations[0].contract.address.equalsIgnoreCase(contractAddress));
+			else return operation != null && (operation.walletInvolvedWithTransaction(walletAddress) || operation.contract.address.equalsIgnoreCase(contractAddress));
 		}
 	}
 
@@ -458,7 +468,7 @@ public class Transaction implements Parcelable {
 	{
 		if (operations == null || operations.length == 0)
 			return token.getTransactionValue(this, precision);
-		if (error.equals("1")) return "";
+		if (hasError()) return "";
 
 		//TODO: Handle multiple operation transactions
 		TransactionOperation operation = operations[0];
@@ -583,7 +593,7 @@ public class Transaction implements Parcelable {
 
 	public StatusType getTransactionStatus()
 	{
-		if (error != null && error.equals("1"))
+		if (hasError())
 		{
 			return StatusType.FAILED;
 		}

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionLookup.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionLookup.java
@@ -1,9 +1,9 @@
 package com.alphawallet.app.entity;
 
+import com.alphawallet.app.R;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import com.alphawallet.app.R;
 
 public class TransactionLookup
 {
@@ -36,6 +36,7 @@ public class TransactionLookup
             typeMapping.put(TransactionType.TRANSFER_FROM, R.string.ticket_transfer_from);
             typeMapping.put(TransactionType.ALLOCATE_TO, R.string.allocate_to);
             typeMapping.put(TransactionType.APPROVE, R.string.approve);
+            typeMapping.put(TransactionType.RECEIVED, R.string.received);
             typeMapping.put(TransactionType.UNKNOWN_FUNCTION, R.string.ticket_invalid_op);
         }
     }

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionOperation.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionOperation.java
@@ -78,7 +78,8 @@ public class TransactionOperation implements Parcelable {
     {
         if (contract != null)
         {
-            return contract.checkAddress(address);
+            if ((from != null && from.equalsIgnoreCase(address)) || (to != null && to.equalsIgnoreCase(address))) return true;
+            else return contract.checkAddress(address);
         }
         else
         {

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionType.java
@@ -21,5 +21,6 @@ public enum TransactionType
     TRANSFER_FROM,
     ALLOCATE_TO,
     APPROVE,
+    RECEIVED,
     ILLEGAL_VALUE
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -3,6 +3,7 @@ package com.alphawallet.app.entity.tokens;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.format.DateUtils;
 
 import androidx.annotation.NonNull;
 
@@ -36,6 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static com.alphawallet.app.repository.EthereumNetworkBase.hasRealValue;
 
 public class Token implements Parcelable, Comparable<Token>
 {
@@ -638,7 +641,7 @@ public class Token implements Parcelable, Comparable<Token>
      */
     public String getTransactionValue(Transaction transaction, int precision)
     {
-        if (transaction.error.equals("1")) return "";
+        if (transaction.hasError()) return "";
         else if (transaction.value.equals("0")) return "0";
         return transaction.getPrefix(this) + BalanceUtils.getScaledValueFixed(new BigDecimal(transaction.value), tokenInfo.decimals, precision);
     }
@@ -923,5 +926,21 @@ public class Token implements Parcelable, Comparable<Token>
     public void setNameWeight(int weight)
     {
         nameWeight = weight;
+    }
+
+    public long getTransactionCheckInterval()
+    {
+        if (hasRealValue() && hasPositiveBalance())
+        {
+            return 1* DateUtils.MINUTE_IN_MILLIS;
+        }
+        else if (hasPositiveBalance())
+        {
+            return 150* DateUtils.SECOND_IN_MILLIS;
+        }
+        else
+        {
+            return 0;
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
@@ -10,31 +10,30 @@ public class TokenUpdateEntry
 {
     public final int chainId;
     public final String tokenAddress;
-    public ContractType type;
     public long lastUpdateTime;
     public long lastTxCheck;
     public float balanceUpdateWeight;
+    public boolean isEthereum;
 
     public TokenUpdateEntry(int chainId, String tokenAddress, ContractType type)
     {
         this.chainId = chainId;
         this.tokenAddress = tokenAddress;
-        this.type = type;
+        this.isEthereum = type == ContractType.ETHEREUM;
     }
 
     public boolean isEthereum()
     {
-        return type == ContractType.ETHEREUM;
+        return isEthereum;
     }
 
-    public boolean needsTransactionCheck()
+    public boolean needsTransactionCheck(ContractType type)
     {
         switch (type)
         {
             case ERC875_LEGACY:
             case ERC875:
             case ETHEREUM:
-            case ERC20:
             case ERC721_TICKET:
                 return true;
             case CURRENCY:
@@ -45,6 +44,7 @@ public class TokenUpdateEntry
             case ERC721_LEGACY:
             case ERC721_UNDETERMINED:
             case CREATION:
+            case ERC20:
             default:
                 return false;
         }

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenUpdateEntry.java
@@ -34,9 +34,9 @@ public class TokenUpdateEntry
             case ERC875_LEGACY:
             case ERC875:
             case ETHEREUM:
-                return true;
             case ERC20:
             case ERC721_TICKET:
+                return true;
             case CURRENCY:
             case DELETED_ACCOUNT:
             case OTHER:

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -1,12 +1,12 @@
 package com.alphawallet.app.repository;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
-import com.alphawallet.app.BuildConfig;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.alphawallet.app.entity.ContractLocator;
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.NetworkInfo;
@@ -25,7 +25,6 @@ import com.alphawallet.app.service.AWHttpService;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.TickerService;
 import com.alphawallet.app.service.TokensService;
-import com.alphawallet.app.service.TransactionsNetworkClientType;
 import com.alphawallet.app.util.AWEnsResolver;
 import com.alphawallet.app.util.Utils;
 import com.alphawallet.token.entity.MagicLinkData;
@@ -82,7 +81,6 @@ public class TokenRepository implements TokenRepositoryType {
     private final OkHttpClient okClient;
     private final Context context;
     private final TickerService tickerService;
-    private final TransactionsNetworkClientType transactionClient;
 
     public static final String INVALID_CONTRACT = "<invalid>";
 
@@ -102,15 +100,13 @@ public class TokenRepository implements TokenRepositoryType {
             TokenLocalSource localSource,
             OkHttpClient okClient,
             Context context,
-            TickerService tickerService,
-            TransactionsNetworkClientType networkClientType) {
+            TickerService tickerService) {
         this.ethereumNetworkRepository = ethereumNetworkRepository;
         this.localSource = localSource;
         this.ethereumNetworkRepository.addOnChangeDefaultNetwork(this::buildWeb3jClient);
         this.okClient = okClient;
         this.context = context;
         this.tickerService = tickerService;
-        this.transactionClient = networkClientType;
 
         web3jNodeServers = new ConcurrentHashMap<>();
     }

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -135,11 +135,11 @@ public class TokensRealmSource implements TokenLocalSource {
             }
             else
             {
-                realm.beginTransaction();
-                realmToken.setInterfaceSpec(type.ordinal());
-                realmToken.setName(token.tokenInfo.name);
-                realmToken.setSymbol(token.tokenInfo.symbol);
-                realm.commitTransaction();
+                realm.executeTransaction(instance -> {
+                    realmToken.setInterfaceSpec(type.ordinal());
+                    realmToken.setName(token.tokenInfo.name);
+                    realmToken.setSymbol(token.tokenInfo.symbol);
+                });
             }
 
             return fetchToken(token.tokenInfo.chainId, wallet, token.getAddress());
@@ -547,11 +547,9 @@ public class TokensRealmSource implements TokenLocalSource {
         if (!WalletUtils.isValidAddress(wallet.address)) return;
         try (Realm realm = realmManager.getRealmInstance(wallet))
         {
-            TransactionsRealmCache.addRealm();
-            realm.beginTransaction();
-            saveToken(realm, token);
-            realm.commitTransaction();
-            TransactionsRealmCache.subRealm();
+            realm.executeTransaction(instance -> {
+                saveToken(realm, token);
+            });
         }
         catch (Exception ex)
         {

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
@@ -397,7 +397,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
         return retrievedTransactions.toArray(new Transaction[0]);
     }
 
-    private void deleteOperations(RealmTransaction rawItem)
+    public static void deleteOperations(RealmTransaction rawItem)
     {
         int len = rawItem.getOperations().size();
         for (int i = 0; i < len; i++)

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
@@ -26,19 +26,15 @@ public class WalletRepository implements WalletRepositoryType
 	private final PreferenceRepositoryType preferenceRepositoryType;
 	private final AccountKeystoreService accountKeystoreService;
 	private final EthereumNetworkRepositoryType networkRepository;
-	private final TransactionsNetworkClientType blockExplorerClient;
 	private final WalletDataRealmSource walletDataRealmSource;
-	private final OkHttpClient httpClient;
 	private final KeyService keyService;
 
-	public WalletRepository(PreferenceRepositoryType preferenceRepositoryType, AccountKeystoreService accountKeystoreService, EthereumNetworkRepositoryType networkRepository, TransactionsNetworkClientType blockExplorerClient, WalletDataRealmSource walletDataRealmSource, OkHttpClient httpClient, KeyService keyService)
+	public WalletRepository(PreferenceRepositoryType preferenceRepositoryType, AccountKeystoreService accountKeystoreService, EthereumNetworkRepositoryType networkRepository, WalletDataRealmSource walletDataRealmSource, KeyService keyService)
 	{
 		this.preferenceRepositoryType = preferenceRepositoryType;
 		this.accountKeystoreService = accountKeystoreService;
 		this.networkRepository = networkRepository;
-		this.blockExplorerClient = blockExplorerClient;
 		this.walletDataRealmSource = walletDataRealmSource;
-		this.httpClient = httpClient;
 		this.keyService = keyService;
 	}
 

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -1,30 +1,30 @@
 package com.alphawallet.app.service;
 
-import android.content.Context;
 import android.text.TextUtils;
-import android.util.Log;
 
-import com.alphawallet.app.entity.ActivityMeta;
-import com.alphawallet.app.entity.TransactionMeta;
-import com.alphawallet.app.entity.Wallet;
-import com.alphawallet.app.entity.tokens.Token;
-import com.alphawallet.app.repository.TokensRealmSource;
-import com.alphawallet.app.repository.TransactionsRealmCache;
-import com.alphawallet.app.repository.entity.RealmToken;
-import com.alphawallet.app.repository.entity.RealmTransaction;
-import com.google.gson.Gson;
 import com.alphawallet.app.entity.ContractType;
+import com.alphawallet.app.entity.EtherscanEvent;
 import com.alphawallet.app.entity.EtherscanTransaction;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.Transaction;
-import com.alphawallet.app.entity.TransactionContract;
+import com.alphawallet.app.entity.TransactionMeta;
+import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.entity.tokens.ERC721Token;
+import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.entity.tokens.TokenInfo;
+import com.alphawallet.app.repository.TransactionsRealmCache;
+import com.alphawallet.app.repository.entity.RealmAuxData;
+import com.alphawallet.app.repository.entity.RealmToken;
+import com.alphawallet.app.repository.entity.RealmTransaction;
+import com.alphawallet.token.entity.ContractAddress;
+import com.google.gson.Gson;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.InterruptedIOException;
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,21 +44,21 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private final int SYNC_PAGECOUNT = 2; //how many pages to read when we first sync the account - means we store the first 1600 transactions only
     //Note: if user wants to view transactions older than this, we fetch from etherscan on demand.
     //Generally this would only happen when watching extremely active accounts for curiosity
+    private final String BLOCK_ENTRY = "-erc20blockCheck-";
+    private final String ERC20_QUERY = "tokentx";
+    private final String ERC721_QUERY = "tokennfttx";
 
     private final OkHttpClient httpClient;
     private final Gson gson;
     private final RealmManager realmManager;
-    private final Context context;
 
     public TransactionsNetworkClient(
             OkHttpClient httpClient,
             Gson gson,
-            RealmManager realmManager,
-            Context context) {
+            RealmManager realmManager) {
         this.httpClient = httpClient;
         this.gson = gson;
         this.realmManager = realmManager;
-        this.context = context;
     }
 
     /**
@@ -238,6 +238,13 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         return gson.fromJson(orders.toString(), EtherscanTransaction[].class);
     }
 
+    private EtherscanEvent[] getEtherscanEvents(String response) throws JSONException
+    {
+        JSONObject stateData = new JSONObject(response);
+        JSONArray orders = stateData.getJSONArray("result");
+        return gson.fromJson(orders.toString(), EtherscanEvent[].class);
+    }
+
     private boolean writeTransactions(Realm instance, List<Transaction> txList) throws Exception
     {
         if (txList.size() == 0) return false;
@@ -256,6 +263,8 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
             }
             else
             {
+                //remove all operations
+                TransactionsRealmCache.deleteOperations(realmTx);
                 startedReWriting = true;
             }
 
@@ -377,7 +386,270 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
             return txList.toArray(new TransactionMeta[0]);
         });
-        //see if we already have transactions older
+    }
+
+    @Override
+    public Single<Integer> readTransactions(String walletAddress, NetworkInfo networkInfo, TokensService svs, boolean nftCheck)
+    {
+        if (nftCheck)
+        {
+            return readNFTTransactions(walletAddress, networkInfo, svs);
+        }
+        else
+        {
+            return readERC20Transactions(walletAddress, networkInfo, svs);
+        }
+    }
+
+    /**
+     * Fetch the ERC20 transactions relevant to this wallet - ie deposits to and transfers from
+     * @param walletAddress
+     * @param networkInfo
+     * @param svs
+     * @return
+     */
+    public Single<Integer> readERC20Transactions(String walletAddress, NetworkInfo networkInfo, TokensService svs)
+    {
+        return Single.fromCallable(() -> {
+            //get latest block read
+            int eventCount = 0;
+            try (Realm instance = realmManager.getRealmInstance(new Wallet(walletAddress)))
+            {
+                //get last tokencheck
+                long lastBlockChecked = getTokenBlockRead(instance, networkInfo.chainId);
+                //fetch erc20 tx from Etherscan
+                String fetchTransactions = readNextTxBatch(walletAddress, networkInfo, lastBlockChecked, ERC20_QUERY);
+
+                if (fetchTransactions != null && fetchTransactions.length() > 100)
+                {
+                    //convert to gson
+                    EtherscanEvent[] events = getEtherscanEvents(fetchTransactions);
+                    //we know all these events are relevant to the wallet, and they are all ERC20 events
+                    //TODO: fetch transaction details from Infura to find base currency input. For now mark as zero
+                    writeTransactions(instance, convertToTxList(events, walletAddress, networkInfo));
+
+                    //Now update tokens if we don't already know this token
+                    writeERC20Tokens(instance, walletAddress, networkInfo, events, svs);
+
+                    lastBlockChecked = Long.parseLong(events[events.length - 1].blockNumber);
+
+                    //and update the top block read
+                    writeTokenBlockRead(instance, networkInfo.chainId, lastBlockChecked);
+                    eventCount = events.length;
+                }
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+            return eventCount;
+        }).observeOn(Schedulers.io());
+    }
+
+    public Single<Integer> readNFTTransactions(String walletAddress, NetworkInfo networkInfo, TokensService svs)
+    {
+        return Single.fromCallable(() -> {
+            //get latest block read
+            int eventCount = 0;
+            try (Realm instance = realmManager.getRealmInstance(new Wallet(walletAddress)))
+            {
+                //get last tokencheck
+                long lastBlockChecked = getNFTokenBlockRead(instance, networkInfo.chainId);
+                String fetchTransactions = readNextTxBatch(walletAddress, networkInfo, lastBlockChecked, ERC721_QUERY);
+
+                if (fetchTransactions != null && fetchTransactions.length() > 100)
+                {
+                    //convert to gson
+                    EtherscanEvent[] events = getEtherscanEvents(fetchTransactions);
+                    writeTransactions(instance, convertToTxList(events, walletAddress, networkInfo));
+
+                    //Now update tokens if we don't already know this token
+                    writeERC721Tokens(instance, walletAddress, networkInfo, events, svs);
+
+                    lastBlockChecked = Long.parseLong(events[events.length - 1].blockNumber);
+
+                    //and update the top block read
+                    writeNFTokenBlockRead(instance, networkInfo.chainId, lastBlockChecked);
+                    eventCount = events.length;
+                }
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+            }
+            return eventCount;
+        }).observeOn(Schedulers.io());
+    }
+
+    private void writeERC20Tokens(Realm instance, String walletAddress, NetworkInfo networkInfo, EtherscanEvent[] events, TokensService svs)
+    {
+        for (EtherscanEvent ev : events)
+        {
+            //have this token?
+            RealmToken realmItem = instance.where(RealmToken.class)
+                    .equalTo("address", databaseKey(networkInfo.chainId, ev.contractAddress.toLowerCase()))
+                    .equalTo("chainId", networkInfo.chainId)
+                    .findFirst();
+
+            if (realmItem == null || realmItem.getInterfaceSpec() != ContractType.ERC20.ordinal())
+            {
+                // write token to DB - note this also fetches the balance
+                int tokenDecimal = (!TextUtils.isEmpty(ev.tokenDecimal) && Character.isDigit(ev.tokenDecimal.charAt(0))) ? Integer.parseInt(ev.tokenDecimal) : -1;
+                if (tokenDecimal >= 0)
+                {
+                    TokenInfo info = new TokenInfo(ev.contractAddress, ev.tokenName, ev.tokenSymbol, tokenDecimal, true, networkInfo.chainId);
+                    Token newToken = new Token(info, BigDecimal.ZERO, 0, networkInfo.getShortName(), ContractType.ERC20);
+                    newToken.setTokenWallet(walletAddress);
+                    svs.storeToken(newToken);
+                }
+                else
+                {
+                    //unknown token
+                    svs.addUnknownTokenToCheck(new ContractAddress(networkInfo.chainId, ev.contractAddress));
+                }
+            }
+            else
+            {
+                //update token block read so we don't check events on this contract
+                storeLatestBlockRead(instance, networkInfo.chainId, ev.contractAddress, ev.blockNumber);
+            }
+        }
+    }
+
+    private void writeERC721Tokens(Realm instance, String walletAddress, NetworkInfo networkInfo, EtherscanEvent[] events, TokensService svs)
+    {
+        for (EtherscanEvent ev : events)
+        {
+            //have this token?
+            RealmToken realmItem = instance.where(RealmToken.class)
+                    .equalTo("address", databaseKey(networkInfo.chainId, ev.contractAddress.toLowerCase()))
+                    .equalTo("chainId", networkInfo.chainId)
+                    .findFirst();
+
+            if (realmItem == null ||
+                    ( realmItem.getInterfaceSpec() != ContractType.ERC721.ordinal() &&
+                            realmItem.getInterfaceSpec() != ContractType.ERC721_LEGACY.ordinal() &&
+                            realmItem.getInterfaceSpec() != ContractType.ERC721_TICKET.ordinal() &&
+                            realmItem.getInterfaceSpec() != ContractType.ERC721_UNDETERMINED.ordinal()))
+            {
+                // write token to DB - note this also fetches the balance
+                TokenInfo info = new TokenInfo(ev.contractAddress, ev.tokenName, ev.tokenSymbol, 0, true, networkInfo.chainId);
+                ERC721Token newToken = new ERC721Token(info, null, 0, networkInfo.getShortName(), ContractType.ERC721_UNDETERMINED);
+                newToken.setTokenWallet(walletAddress);
+                svs.storeToken(newToken);
+            }
+            else
+            {
+                //update token block read so we don't check events on this contract
+                storeLatestBlockRead(instance, networkInfo.chainId, ev.contractAddress, ev.blockNumber);
+            }
+        }
+    }
+
+    private List<Transaction> convertToTxList(EtherscanEvent[] events, String walletAddress, NetworkInfo info)
+    {
+        List<Transaction> txList = new ArrayList<>();
+        for (EtherscanEvent ev : events)
+        {
+            txList.add(ev.createTransaction(walletAddress, info));
+        }
+
+        return txList;
+    }
+
+    private String readNextTxBatch(String walletAddress, NetworkInfo networkInfo, long lastBlockChecked, String queryType)
+    {
+        okhttp3.Response response;
+        String result = null;
+        final String START_BLOCK = "[START_BLOCK]";
+        final String WALLET_ADDR = "[WALLET_ADDR]";
+        final String ETHERSCAN = "[ETHERSCAN]";
+        final String QUERY_TYPE = "[QUERY_TYPE]";
+        String fullUrl = ETHERSCAN + "api?module=account&action=" + QUERY_TYPE + "&startBlock=" + START_BLOCK + "&address=" + WALLET_ADDR + "&page=1&offset=100&sort=asc&apikey=6U31FTHW3YYHKW6CYHKKGDPHI9HEJ9PU5F";
+        fullUrl = fullUrl.replace(QUERY_TYPE, queryType).replace(ETHERSCAN, networkInfo.etherscanTxUrl).replace(START_BLOCK, String.valueOf(lastBlockChecked + 1)).replace(WALLET_ADDR, walletAddress);
+        //sb.append("&apikey=6U31FTHW3YYHKW6CYHKKGDPHI9HEJ9PU5F");
+
+        try
+        {
+            Request request = new Request.Builder()
+                    .url(fullUrl)
+                    .get()
+                    .build();
+
+            response = httpClient.newCall(request).execute();
+
+            result = response.body().string();
+            if (result != null && result.length() < 80 && result.contains("No transactions found"))
+            {
+                result = "0";
+            }
+        }
+        catch (InterruptedIOException e)
+        {
+            //If user switches account or network during a fetch
+            //this exception is going to be thrown because we're terminating the API call
+            //Don't display error
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+
+    private long getTokenBlockRead(Realm instance, int chainId)
+    {
+        RealmAuxData rd = instance.where(RealmAuxData.class)
+                .equalTo("instanceKey", BLOCK_ENTRY + chainId)
+                .findFirst();
+
+        if (rd == null)
+        {
+            return 1L;
+        }
+        else
+        {
+            return rd.getResultTime();
+        }
+    }
+
+    private long getNFTokenBlockRead(Realm instance, int chainId)
+    {
+        RealmAuxData rd = instance.where(RealmAuxData.class)
+                .equalTo("instanceKey", BLOCK_ENTRY + chainId)
+                .findFirst();
+
+        if (rd == null || rd.getResult() == null)
+        {
+            return 1L;
+        }
+        else
+        {
+            return Long.parseLong(rd.getResult());
+        }
+    }
+
+    private void writeTokenBlockRead(Realm instance, int chainId, long lastBlockChecked)
+    {
+        instance.executeTransaction(r -> {
+            RealmAuxData rd = instance.where(RealmAuxData.class)
+                    .equalTo("instanceKey", BLOCK_ENTRY + chainId)
+                    .findFirst();
+            if (rd == null) rd = instance.createObject(RealmAuxData.class, BLOCK_ENTRY + chainId);
+            rd.setResultTime(lastBlockChecked);
+        });
+    }
+
+    private void writeNFTokenBlockRead(Realm instance, int chainId, long lastBlockChecked)
+    {
+        instance.executeTransaction(r -> {
+            RealmAuxData rd = instance.where(RealmAuxData.class)
+                    .equalTo("instanceKey", BLOCK_ENTRY + chainId)
+                    .findFirst();
+            if (rd == null) rd = instance.createObject(RealmAuxData.class, BLOCK_ENTRY + chainId);
+            rd.setResult(String.valueOf(lastBlockChecked));
+        });
     }
 
     private long getOldestBlockRead(Realm instance, int chainId, long lastTxTime)

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
@@ -8,7 +8,6 @@ import com.alphawallet.app.entity.tokens.Token;
 import io.reactivex.Single;
 
 public interface TransactionsNetworkClientType {
-    Single<Transaction[]> storeNewTransactions(String walletAddress, NetworkInfo networkInfo, long lastBlock);
-    void storeBlockRead(Token token, String walletAddress);
+    Single<Transaction[]> storeNewTransactions(String walletAddress, NetworkInfo networkInfo, String tokenAddress, long lastBlock);
     Single<TransactionMeta[]> fetchMoreTransactions(String walletAddress, NetworkInfo network, long lastTxTime);
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
@@ -3,11 +3,11 @@ package com.alphawallet.app.service;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionMeta;
-import com.alphawallet.app.entity.tokens.Token;
 
 import io.reactivex.Single;
 
 public interface TransactionsNetworkClientType {
     Single<Transaction[]> storeNewTransactions(String walletAddress, NetworkInfo networkInfo, String tokenAddress, long lastBlock);
     Single<TransactionMeta[]> fetchMoreTransactions(String walletAddress, NetworkInfo network, long lastTxTime);
+    Single<Integer> readTransactions(String currentAddress, NetworkInfo networkByChain, TokensService tokensService, boolean nftCheck);
 }

--- a/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
@@ -128,9 +128,6 @@ public class ActivityFragment extends BaseFragment implements View.OnClickListen
                     adapter.updateActivityItems(metas.toArray(new TransactionMeta[0]));
                     systemView.hide();
                 }
-
-                //Check for new unknown tokens
-                viewModel.checkTokens(realmTransactions);
             });
 
             auxRealmUpdates = realm.where(RealmAuxData.class)

--- a/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransactionDetailActivity.java
@@ -300,7 +300,7 @@ public class TransactionDetailActivity extends BaseActivity implements StandardF
 
     private void checkFailed()
     {
-        if (transaction.error != null && transaction.error.equals("1"))
+        if (transaction.hasError())
         {
             TextView failed = findViewById(R.id.failed);
             TextView failedF = findViewById(R.id.failedFace);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TokenSortedItem.java
@@ -29,7 +29,7 @@ public class TokenSortedItem extends SortedItem<TokenCardMeta> {
             //if (!oldToken.tokenId.equalsIgnoreCase(newToken.tokenId)) return false;
             if (debugging) System.out.println("DEBUG: Contents: " + weight + " " + newItem.weight + " Balance: " + value.balance + " " + newToken.balance);
             if (weight != newItem.weight) return false;
-            else return value.balance.equals(newToken.balance);
+            else return value.balance.equals(newToken.balance) && value.type.ordinal() == newToken.type.ordinal();
         }
         else
         {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/ActivityViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/ActivityViewModel.java
@@ -132,23 +132,6 @@ public class ActivityViewModel extends BaseViewModel
         return fetchTransactionsInteract.getRealmInstance(wallet.getValue());
     }
 
-    /**
-     * Check new tokens for any unknowns, then find the unknowns
-     * @param rawTxList
-     */
-    public void checkTokens(RealmResults<RealmTransaction> rawTxList)
-    {
-        for (RealmTransaction tx : rawTxList)
-        {
-            if (tx.getError() != null && tx.getError().equals("0") &&
-                    tx.getInput() != null && tx.getInput().length() > 2) //is this a successful contract transaction?
-            {
-                Token token = tokensService.getToken(tx.getChainId(), tx.getTo());
-                if (token == null) tokensService.addUnknownTokenToCheck(new ContractAddress(tx.getChainId(), tx.getTo()));
-            }
-        }
-    }
-
     public AssetDefinitionService getAssetDefinitionService()
     {
         return assetDefinitionService;


### PR DESCRIPTION
Uses the Etherscan APIs to discover token transfers into and out of the wallet. Previously we discovered the transfers going out of the wallet, but with this API route when any token is transferred to the wallet, the receive event will appear and the token will always appear in the wallet.

NOTE: This PR builds on PR #1646 . PR #1646 needs to be pushed first.

