### PR TITLE
Fix cosmetic issue with 'Approve' values

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/TransactionContract.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionContract.java
@@ -176,8 +176,10 @@ public class TransactionContract implements Parcelable {
             if (!token.isNonFungible() && (operation.value == null || operation.value.length() > 0 && Character.isDigit(operation.value.charAt(0))))
             {
                 BigDecimal value = new BigDecimal(operation.value);
+                String balanceValue = BalanceUtils.getScaledValueFixed(value, token.tokenInfo.decimals, TransactionHolder.TRANSACTION_BALANCE_PRECISION);
+                if (getOperationId() == TransactionType.APPROVE.ordinal() && balanceValue.length() > 10) return "All";
                 //appears to be a number; try to produce number with prefix
-                return tx.getPrefix(token) + BalanceUtils.getScaledValueFixed(value, token.tokenInfo.decimals, TransactionHolder.TRANSACTION_BALANCE_PRECISION);
+                else return tx.getPrefix(token) + balanceValue;
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionContract.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionContract.java
@@ -176,10 +176,8 @@ public class TransactionContract implements Parcelable {
             if (!token.isNonFungible() && (operation.value == null || operation.value.length() > 0 && Character.isDigit(operation.value.charAt(0))))
             {
                 BigDecimal value = new BigDecimal(operation.value);
-                String balanceValue = BalanceUtils.getScaledValueFixed(value, token.tokenInfo.decimals, TransactionHolder.TRANSACTION_BALANCE_PRECISION);
-                if (getOperationId() == TransactionType.APPROVE.ordinal() && balanceValue.length() > 10) return "All";
-                //appears to be a number; try to produce number with prefix
-                else return tx.getPrefix(token) + balanceValue;
+                if (getOperationId() == TransactionType.APPROVE.ordinal() && value.abs().compareTo(token.balance.multiply(BigDecimal.TEN)) > 0) return "All";
+                else return tx.getPrefix(token) + BalanceUtils.getScaledValueFixed(value, token.tokenInfo.decimals, TransactionHolder.TRANSACTION_BALANCE_PRECISION); //appears to be a number; try to produce number with prefix
             }
             else
             {

--- a/app/src/main/java/com/alphawallet/app/entity/TransactionLookup.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionLookup.java
@@ -12,7 +12,8 @@ public class TransactionLookup
     public static int typeToName(TransactionType type)
     {
         setupTypes();
-        return typeMapping.get(type);
+        if (type.ordinal() > typeMapping.size()) return typeMapping.get(TransactionType.UNKNOWN);
+        else return typeMapping.get(type);
     }
 
     private static void setupTypes()

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -850,29 +850,7 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     private List<BigInteger> getBalanceArray721Ticket(Wallet wallet, TokenInfo tokenInfo) {
-        List<BigInteger> result = new ArrayList<>();
-        result.add(BigInteger.valueOf(NODE_COMMS_ERROR));
-        try
-        {
-            Function function = erc721TicketBalanceArray(wallet.address);
-            NetworkInfo network = ethereumNetworkRepository.getNetworkByChain(tokenInfo.chainId);
-            List<Type> tokenIds = callSmartContractFunctionArray(function, tokenInfo.address, network, wallet);
-            if (tokenIds != null)
-            {
-                result.clear();
-                for (Type val : tokenIds)
-                {
-                    result.add((BigInteger)val.getValue());
-                }
-            }
-        }
-        catch (StringIndexOutOfBoundsException e)
-        {
-            //contract call error
-            result.clear();
-            result.add(BigInteger.valueOf(NODE_COMMS_ERROR));
-        }
-        return result;
+        return getBalanceArray721Ticket(wallet, tokenInfo.chainId, tokenInfo.address);
     }
 
     public Observable<TransferFromEventResponse> burnListenerObservable(String contractAddr)
@@ -907,6 +885,11 @@ public class TokenRepository implements TokenRepositoryType {
             }
         }
 
+        //Check for raw bytes return value; need to do this before we try to parse the function return
+        //as raw bytes returns now cause a throw from the encoder
+        String rawBytesValue = checkRawBytesValue(responseValue, type);
+        if (rawBytesValue != null) return (T)rawBytesValue;
+
         List<Type> response = FunctionReturnDecoder.decode(
                 responseValue, function.getOutputParameters());
         if (response.size() == 1)
@@ -934,6 +917,36 @@ public class TokenRepository implements TokenRepositoryType {
                 return null;
             }
         }
+    }
+
+    //some token contracts break the ERC20 guidance and directly return bytes for strings
+    //These returns break the web3j ABI decoder
+    //Note that for a correct 'String' return type, it will be encoded like this:
+    //0000000000000000000000000000000000000000000000000000000000000020 : offset to dynamic type
+    //0000000000000000000000000000000000000000000000000000000000000003 : length 3
+    //4449500000000000000000000000000000000000000000000000000000000000 : 'DIP'
+    // However some contracts - presumably to save bandwidth - would encode this a bytes32:
+    //4449500000000000000000000000000000000000000000000000000000000000
+    //This routine will find the string in a bytes32 if the return type was expecting a string.
+    private <T> String checkRawBytesValue(String responseValue, T type) throws Exception
+    {
+        String value = null;
+        if ((type instanceof String))
+        {
+            responseValue = Numeric.cleanHexPrefix(responseValue);
+            int firstValueEndIndex = Math.min(responseValue.length(), 64);
+            if (firstValueEndIndex > 0)
+            {
+                BigInteger firstValue = new BigInteger(responseValue.substring(0, firstValueEndIndex), 16);
+
+                if (firstValue.compareTo(BigInteger.valueOf(0x20)) != 0)
+                {
+                    value = checkBytesString(responseValue);
+                }
+            }
+        }
+
+        return value;
     }
 
     private String checkBytesString(String responseValue) throws Exception
@@ -968,34 +981,16 @@ public class TokenRepository implements TokenRepositoryType {
         StringBuilder sb = new StringBuilder();
         for (char ch : name.toCharArray())
         {
-            if (ch >= 0x20 && ch <= 0x7E) //valid ASCII character
+            if (Character.isIdeographic(ch) ||
+                    Character.isLetterOrDigit(ch) ||
+                    Character.isWhitespace(ch) ||
+                    (ch >= 0x20 && ch <= 0x7E)) //some other common ASCII
             {
                 sb.append(ch);
             }
         }
 
         return sb.toString();
-    }
-
-    private String getName(String address, NetworkInfo network) throws Exception {
-        Function function = nameOf();
-        Wallet temp = new Wallet(null);
-        String responseValue = callSmartContractFunction(function, address, network ,temp);
-
-        if (TextUtils.isEmpty(responseValue)) return null;
-
-        List<Type> response = FunctionReturnDecoder.decode(
-                responseValue, function.getOutputParameters());
-        if (response.size() == 1) {
-            String name = (String)response.get(0).getValue();
-            if (responseValue.length() > 2 && name.length() == 0)
-            {
-                name = checkBytesString(responseValue);
-            }
-            return name;
-        } else {
-            return null;
-        }
     }
 
     private int getDecimals(String address, NetworkInfo network) throws Exception {
@@ -1128,16 +1123,15 @@ public class TokenRepository implements TokenRepositoryType {
             Object o;
             if (values.isEmpty())
             {
-                values = new ArrayList<Type>();
-                values.add((Type)new Int256(CONTRACT_BALANCE_NULL));
-                o = (List)values;
+                values = new ArrayList<>();
+                values.add(new Int256(CONTRACT_BALANCE_NULL));
+                o = values;
             }
             else
             {
-                Type T = values.get(0);
-                o = T.getValue();
+                o = values.get(0).getValue();
             }
-            return (List) o;
+            return (List)o;
         }
         catch (IOException e) //this call is expected to be interrupted when user switches network or wallet
         {
@@ -1285,8 +1279,8 @@ public class TokenRepository implements TokenRepositoryType {
             NetworkInfo network = ethereumNetworkRepository.getNetworkByChain(chainId);
             return new TokenInfo(
                     address,
-                    getName(address, network),
-                    getContractData(network, address, stringParam("symbol"), ""),
+                    getContractData(network, address, nameOf(), ""),
+                    getContractData(network, address, symbolOf(), ""),
                     getDecimals(address, network),
                     true, chainId);
         });

--- a/app/src/main/res/layout/activity_token_activity.xml
+++ b/app/src/main/res/layout/activity_token_activity.xml
@@ -62,6 +62,8 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/font_semibold"
                 tools:text="+ 1.234 ETH"
+				android:layout_gravity="center_horizontal"
+                android:gravity="center_horizontal"
                 android:textColor="@color/black"
                 android:layout_marginTop="@dimen/dp16"
                 android:layout_marginBottom="10dp"

--- a/app/src/main/res/layout/activity_token_activity.xml
+++ b/app/src/main/res/layout/activity_token_activity.xml
@@ -20,81 +20,81 @@
             android:gravity="center"
             android:layout_above="@id/layoutButtons">
 
-        <LinearLayout
-            android:id="@id/token_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/event_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/font_light"
-                tools:text="10:57 PM | July 22, 2020"
-                android:textColor="@color/black"
-                android:layout_marginTop="4dp"
-                android:layout_marginBottom="@dimen/dp18"
-                android:textSize="@dimen/sp14" />
-
-            <com.alphawallet.app.widget.TokenIcon
-                android:id="@+id/token_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:showStatus="true"
-                app:largeIcon="true" />
-
-            <TextView
-                android:id="@+id/event_action"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/font_semibold"
-                tools:text="Sent ETH"
-                android:textColor="@color/black"
-                android:layout_marginTop="@dimen/dp6"
-                android:layout_marginBottom="10dp"
-                android:textSize="@dimen/sp17" />
-
-            <TextView
-                android:id="@+id/event_amount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/font_semibold"
-                tools:text="+ 1.234 ETH"
-				android:layout_gravity="center_horizontal"
-                android:gravity="center_horizontal"
-                android:textColor="@color/black"
-                android:layout_marginTop="@dimen/dp16"
-                android:layout_marginBottom="10dp"
-                android:textSize="@dimen/sp24" />
-
             <LinearLayout
-                android:id="@+id/pending_time_layout"
-                android:layout_width="wrap_content"
+                android:id="@id/token_view"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:visibility="gone">
-
-                <ProgressBar
-                    android:layout_width="@dimen/dp14"
-                    android:layout_gravity="center_vertical"
-                    android:layout_height="@dimen/dp14"
-                    android:layout_marginEnd="6dp"
-                    android:contentDescription="@string/empty"/>
+                android:gravity="center"
+                android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/pending_time"
-                    style="@style/TransactionDetailsStyle"
+                    android:id="@+id/event_time"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    tools:text="@string/transaction_pending_for" />
+                    android:fontFamily="@font/font_light"
+                    tools:text="10:57 PM | July 22, 2020"
+                    android:textColor="@color/black"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginBottom="@dimen/dp18"
+                    android:textSize="@dimen/sp14" />
+
+                <com.alphawallet.app.widget.TokenIcon
+                    android:id="@+id/token_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:showStatus="true"
+                    app:largeIcon="true" />
+
+                <TextView
+                    android:id="@+id/event_action"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/font_semibold"
+                    tools:text="Sent ETH"
+                    android:textColor="@color/black"
+                    android:layout_marginTop="@dimen/dp6"
+                    android:layout_marginBottom="10dp"
+                    android:textSize="@dimen/sp17" />
+
+                <TextView
+                    android:id="@+id/event_amount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/font_semibold"
+                    tools:text="+ 1.234 ETH"
+                    android:layout_gravity="center_horizontal"
+                    android:gravity="center_horizontal"
+                    android:textColor="@color/black"
+                    android:layout_marginTop="@dimen/dp16"
+                    android:layout_marginBottom="10dp"
+                    android:textSize="@dimen/sp24" />
+
+                <LinearLayout
+                    android:id="@+id/pending_time_layout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:visibility="gone">
+
+                    <ProgressBar
+                        android:layout_width="@dimen/dp14"
+                        android:layout_gravity="center_vertical"
+                        android:layout_height="@dimen/dp14"
+                        android:layout_marginEnd="6dp"
+                        android:contentDescription="@string/empty"/>
+
+                    <TextView
+                        android:id="@+id/pending_time"
+                        style="@style/TransactionDetailsStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="@string/transaction_pending_for" />
+
+                </LinearLayout>
+
+                <include layout="@layout/item_ticket" />
 
             </LinearLayout>
-
-            <include layout="@layout/item_ticket" />
-
-        </LinearLayout>
         </ScrollView>
 
         <com.alphawallet.app.widget.FunctionButtonBar

--- a/app/src/main/res/layout/activity_token_activity.xml
+++ b/app/src/main/res/layout/activity_token_activity.xml
@@ -66,13 +66,28 @@
                     android:gravity="center_horizontal"
                     android:textColor="@color/black"
                     android:layout_marginTop="@dimen/dp16"
-                    android:layout_marginBottom="10dp"
                     android:textSize="@dimen/sp24" />
+
+                <TextView
+                    android:id="@+id/text_chain_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/dp5"
+                    android:layout_marginEnd="@dimen/dp8"
+                    android:layout_marginStart="@dimen/dp5"
+                    android:background="@drawable/background_status_pending"
+                    android:fontFamily="@font/font_bold"
+                    android:padding="2dp"
+                    android:text="@string/action_clear"
+                    android:textColor="@color/white"
+                    android:textSize="10sp"
+                    android:visibility="gone" />
 
                 <LinearLayout
                     android:id="@+id/pending_time_layout"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/dp5"
                     android:orientation="horizontal"
                     android:visibility="gone">
 
@@ -91,6 +106,11 @@
                         tools:text="@string/transaction_pending_for" />
 
                 </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/dp5"
+                    android:orientation="horizontal"/>
 
                 <include layout="@layout/item_ticket" />
 


### PR DESCRIPTION
App was displaying the actual approve value, like 99999999999999.9999 etc. Replace with heuristic that if the (abs) Approve value is more than 10x the token balance then show the approve as 'All' to make the display neater.

Also, fix issue in case there is a very long number displaying that number properly centred in the 'Token Activity' page (and tidy up the formatting in the file - the actual change is very small).

This fixes one of the issues seen in the image chain in issue #1647.