### PR TITLE
Fix raw bytes returns from contracts for names

### DIFF
--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -68,7 +68,7 @@ public class Utils {
             for (int i = 0; i < testStr.length(); i++)
             {
                 char c = testStr.charAt(i);
-                if (!Character.isLetterOrDigit(c) && !Character.isWhitespace(c) && !(c == '+') && !(c == ',') && !(c == ';'))
+                if (!Character.isIdeographic(c) && !Character.isLetterOrDigit(c) && !Character.isWhitespace(c) && (c < 32 || c > 126))
                 {
                     result = false;
                     break;


### PR DESCRIPTION
Fixes issue with reading raw byte returns from contracts which don't quite follow the ERC20 standards.

Returning the name or symbol as raw bytes causes web3j to throw an unexpected index out of bounds exception (previously it handled this passively).

Also, ensure that if raw bytes are returned we allow ideographic characters in the name.