### PR TITLE
fix NPE in Web3Transaction

### DIFF
--- a/app/src/main/java/com/alphawallet/app/web3/entity/Web3Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/web3/entity/Web3Transaction.java
@@ -73,7 +73,7 @@ public class Web3Transaction implements Parcelable {
 
         this.recipient = TextUtils.isEmpty(wcTx.getTo()) ? Address.EMPTY : new Address(wcTx.getTo());
         this.contract = null;
-        this.value = wcTx.getValue() == null ? BigInteger.ZERO : Hex.hexToBigInteger(wcTx.getValue());;
+        this.value = wcTx.getValue() == null ? BigInteger.ZERO : Hex.hexToBigInteger(wcTx.getValue(), BigInteger.ZERO);;
         this.gasPrice = Hex.hexToBigInteger(gasPrice, BigInteger.ZERO);
         this.gasLimit = Hex.hexToBigInteger(gasLimit, BigInteger.ZERO);
         this.nonce = Hex.hexToLong(nonce, -1);


### PR DESCRIPTION
Reproducing the bug:
1. Connect with MyEtherWallet via WalletConnect
2. Try to send 0 ERC20 tokens

The app will go back to the main screen without any error displayed on the screen. The value of `wcTx.getValue()` is `0x` and `Hex.hexToBigInteger("0x")` returns `null`.