### PR TITLE
Fix unreliable Token name/decimals override

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -419,12 +419,7 @@ public class TokensRealmSource implements TokenLocalSource {
                 TransactionsRealmCache.addRealm();
                 realm.beginTransaction();
                 token.setRealmBalance(realmToken);
-                if (token.tokenInfo.name.length() > 0)
-                {
-                    realmToken.setName(token.tokenInfo.name);
-                    realmToken.setSymbol(token.tokenInfo.symbol);
-                    realmToken.setDecimals(token.tokenInfo.decimals);
-                }
+                realmToken.updateTokenInfoIfRequired(token.tokenInfo);
                 token.setRealmInterfaceSpec(realmToken);
                 realm.commitTransaction();
                 TransactionsRealmCache.subRealm();
@@ -525,13 +520,12 @@ public class TokensRealmSource implements TokenLocalSource {
         else
         {
             Log.d(TAG, "Update Token: " + token.getFullName());
+            realmToken.updateTokenInfoIfRequired(token.tokenInfo);
+
             if (token.checkRealmBalanceChange(realmToken))
             {
                 //has token changed?
-                realmToken.setName(token.tokenInfo.name);
-                realmToken.setSymbol(token.tokenInfo.symbol);
                 realmToken.setUpdateTime(token.updateBlancaTime);
-                realmToken.setDecimals(token.tokenInfo.decimals);
                 token.setRealmInterfaceSpec(realmToken);
                 token.setRealmBalance(realmToken);
                 token.setRealmLastBlock(realmToken);

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
@@ -1,6 +1,7 @@
 package com.alphawallet.app.repository.entity;
 
 import com.alphawallet.app.entity.ContractType;
+import com.alphawallet.app.entity.tokens.TokenInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -183,5 +184,16 @@ public class RealmToken extends RealmObject {
     public void setVisibilityChanged(boolean visibilityChanged)
     {
         this.visibilityChanged = visibilityChanged;
+    }
+
+    public void updateTokenInfoIfRequired(TokenInfo tokenInfo)
+    {
+        //check decimal integrity, if received a non-18 decimals, this is most likely an update correction from etherscan
+        if (tokenInfo.decimals != decimals && (tokenInfo.decimals > 0 && (decimals == 0 || decimals == 18)))
+        {
+            setName(tokenInfo.name);
+            setSymbol(tokenInfo.symbol);
+            setDecimals(tokenInfo.decimals);
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -491,10 +491,14 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                     .equalTo("chainId", networkInfo.chainId)
                     .findFirst();
 
-            if (realmItem == null || realmItem.getInterfaceSpec() != ContractType.ERC20.ordinal())
+            int tokenDecimal = (!TextUtils.isEmpty(ev.tokenDecimal) && Character.isDigit(ev.tokenDecimal.charAt(0))) ? Integer.parseInt(ev.tokenDecimal) : -1;
+
+            if (realmItem == null || realmItem.getInterfaceSpec() != ContractType.ERC20.ordinal()
+                    || (tokenDecimal > 0 && tokenDecimal != realmItem.getDecimals())
+                    || !ev.tokenName.equals(realmItem.getName()) //trust etherscan's name
+            )
             {
                 // write token to DB - note this also fetches the balance
-                int tokenDecimal = (!TextUtils.isEmpty(ev.tokenDecimal) && Character.isDigit(ev.tokenDecimal.charAt(0))) ? Integer.parseInt(ev.tokenDecimal) : -1;
                 if (tokenDecimal >= 0)
                 {
                     TokenInfo info = new TokenInfo(ev.contractAddress, ev.tokenName, ev.tokenSymbol, tokenDecimal, true, networkInfo.chainId);


### PR DESCRIPTION
Fix for issue where token fetch from node is unreliable; if we have a result from Etherscan then use this.

Observe this token:

https://etherscan.io/token/0xe4c94d45f7aef7018a5d66f44af780ec6023378e

If you translate the 'name' from bytes:

0x70726f7879434300000000000000000000000000000000000000000000000000 bytes32

You'll see 'proxyCC', whereas the name of the token is CCRB as registered on Etherscan.

Also there's no decimals read, but the Etherscan info shows 6.

So, if we get a token return from Etherscan from a token transaction, the information from this should override the usual data.

This is a bad precedence, but not sure how else we can handle this.

To reproduce and check on iOS try watching this address:

```0x9c84EC90EF46e68530893cF3229A1Dd695b8b457```