### PR TITLE
fix for browser url bar resizing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -133,6 +133,7 @@ import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
 import static com.alphawallet.app.entity.Operation.SIGN_DATA;
 import static com.alphawallet.app.entity.tokens.Token.TOKEN_BALANCE_PRECISION;
 import static com.alphawallet.app.ui.MyAddressActivity.KEY_ADDRESS;
+import static com.alphawallet.app.util.KeyboardUtils.showKeyboard;
 import static com.alphawallet.app.widget.AWalletAlertDialog.ERROR;
 
 public class DappBrowserFragment extends Fragment implements OnSignTransactionListener, OnSignPersonalMessageListener, OnSignTypedMessageListener, OnSignMessageListener,
@@ -542,7 +543,8 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
             cancelSearchSession();
         } else {
             urlTv.getText().clear();
-            beginSearchSession();
+            openURLInputView();
+            KeyboardUtils.showKeyboard(urlTv); //ensure keyboard shows here so we can listen for it being cancelled
         }
     }
 
@@ -568,11 +570,11 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
 
         // Both these are required, the onFocus listener is required to respond to the first click.
         urlTv.setOnFocusChangeListener((v, hasFocus) -> {
-            if (hasFocus && getActivity() != null) beginSearchSession();
+            if (hasFocus && getActivity() != null) openURLInputView();
         });
 
         urlTv.setOnClickListener(v -> {
-            beginSearchSession();
+            openURLInputView();
         });
 
         urlTv.setShowSoftInputOnFocus(true);
@@ -600,7 +602,8 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         });
     }
 
-    private void beginSearchSession() {
+    // TODO: Move all nav stuff to widget
+    private void openURLInputView() {
         urlTv.setAdapter(null);
         expandCollapseView(currentNetwork, false);
         expandCollapseView(layoutNavigation, false);
@@ -620,7 +623,7 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         if (item.getVisibility() == View.GONE)
         {
             expandCollapseView(item, true);
-            KeyboardUtils.showKeyboard(urlTv);
+            showKeyboard(urlTv);
         }
     }
 
@@ -703,6 +706,12 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
 
     private void cancelSearchSession() {
         detachFragment(SEARCH);
+        KeyboardUtils.hideKeyboard(urlTv);
+        setBackForwardButtons();
+    }
+
+    private void shrinkSearchBar()
+    {
         if (toolbar != null)
         {
             toolbar.getMenu().setGroupVisible(R.id.dapp_browser_menu, true);
@@ -711,8 +720,6 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
             clear.setVisibility(View.GONE);
             urlTv.dismissDropDown();
         }
-        KeyboardUtils.hideKeyboard(urlTv);
-        setBackForwardButtons();
     }
 
     private void detachFragment(String tag) {
@@ -1649,14 +1656,15 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         if (getActivity() != null) ((HomeActivity)getActivity()).useActionSheet(mode);
     }
 
-    public void removeBottomMargin()
+    public void softKeyboardVisible()
     {
         handler.postDelayed(() -> setMargin(0), 10);
     }
 
-    public void restoreBottomMargin(int bottomMarginHeight)
+    public void softKeyboardGone(int bottomMarginHeight)
     {
         handler.postDelayed(() -> setMargin(bottomMarginHeight), 10);
+        shrinkSearchBar();
     }
 
     private void setMargin(int height)

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -3,7 +3,6 @@ package com.alphawallet.app.ui;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.Application;
 import android.app.Dialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;
@@ -11,9 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.content.res.Configuration;
 import android.graphics.Color;
-import android.hardware.SensorManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -23,14 +20,12 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Menu;
-import android.view.OrientationEventListener;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -261,7 +256,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             //remove navbar if running as pure browser. clicking back will send you back to the Action/click that took you there
             hideNavBar();
             //now remove the bottom margin
-            ((DappBrowserFragment)dappBrowserFragment).removeBottomMargin();
+            ((DappBrowserFragment)dappBrowserFragment).softKeyboardVisible();
         }
 
         if (bundle != null)
@@ -284,12 +279,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                     {
                         navBarHeight = getNavBarHeight();
                         setNavBarVisibility(View.GONE);
-                        ((DappBrowserFragment)dappBrowserFragment).removeBottomMargin();
+                        ((DappBrowserFragment)dappBrowserFragment).softKeyboardVisible();
                     }
                     else
                     {
                         setNavBarVisibility(View.VISIBLE);
-                        ((DappBrowserFragment)dappBrowserFragment).restoreBottomMargin(navBarHeight);
+                        ((DappBrowserFragment)dappBrowserFragment).softKeyboardGone(navBarHeight);
                     }
                 });
     }


### PR DESCRIPTION
We were seeing an issue where even after user dismisses the soft keyboard, the URL bar wouldn't collapse back into the default state.

This mod keeps the URL bar expand (where the URL bar is expanded to fill the whole screen width while user typing in it, similar to most browser apps) hooks to where the URL bar gains focus which is 100% reliable.

The URL bar collapse is now hooked to the softkeyboard being dismissed, which is the desired behaviour. Previously it was hooked in different places to where we'd expect the user is doing a different activity.

Closes #1516 