### PR TITLE
Modified on-ramp intent generation

### DIFF
--- a/app/src/main/assets/onramp_contracts.json
+++ b/app/src/main/assets/onramp_contracts.json
@@ -1,17 +1,14 @@
-[
-  {
+{
+  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": {
     "symbol": "USDC",
-    "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-    "provider": "ramp"
+    "provider": "Ramp"
   },
-  {
-    "symbol": "DAI",
-    "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-    "provider": "ramp"
-  },
-  {
+  "0xdac17f958d2ee523a2206206994597c13d831ec7": {
     "symbol": "USDT",
-    "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-    "provider": "ramp"
+    "provider": "Ramp"
+  },
+  "0x6b175474e89094c44da98b954eedeac495271d0f": {
+    "symbol": "DAI",
+    "provider": "Ramp"
   }
-]
+}

--- a/app/src/main/assets/onramp_contracts.json
+++ b/app/src/main/assets/onramp_contracts.json
@@ -1,0 +1,17 @@
+[
+  {
+    "symbol": "USDC",
+    "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "provider": "ramp"
+  },
+  {
+    "symbol": "DAI",
+    "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+    "provider": "ramp"
+  },
+  {
+    "symbol": "USDT",
+    "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+    "provider": "ramp"
+  }
+]

--- a/app/src/main/cpp/keys.c
+++ b/app/src/main/cpp/keys.c
@@ -74,3 +74,14 @@ Java_com_alphawallet_app_viewmodel_Erc20DetailViewModel_getRampKey( JNIEnv* env,
     return (*env)->NewStringUTF(env, key);
 #endif
 }
+
+JNIEXPORT jstring JNICALL
+Java_com_alphawallet_app_repository_OnRampRepository_getRampKey( JNIEnv* env, jobject thiz )
+{
+#if (HAS_KEYS == 1)
+    return getDecryptedKey(env, rampKey);
+#else
+    const jstring key = "asfjkdhvcmbnekjfhskjdhfskjdhfskjdhfsdkjf"; // <-- replace with your Ramp key
+    return (*env)->NewStringUTF(env, key);
+#endif
+}

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -215,4 +215,6 @@ public abstract class C {
     public static final String AN_USE_GAS = "Gas Settings";
     public static final String AN_CALL_ACTIONSHEET = "Use ActionSheet";
     public static final String APP_NAME = "PACKAGE_NAME";
+
+    public static final String ALPHAWALLET_LOGO_URI = "https://alphawallet.com/wp-content/themes/alphawallet/img/alphawallet-logo.svg";
 }

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -214,6 +214,7 @@ public abstract class C {
     public static final String AN_PRIVATE_KEY = "Private Key";
     public static final String AN_USE_GAS = "Gas Settings";
     public static final String AN_CALL_ACTIONSHEET = "Use ActionSheet";
+    public static final String AN_USE_ONRAMP = "Use OnRamp";
     public static final String APP_NAME = "PACKAGE_NAME";
 
     public static final String ALPHAWALLET_LOGO_URI = "https://alphawallet.com/wp-content/themes/alphawallet/img/alphawallet-logo.svg";

--- a/app/src/main/java/com/alphawallet/app/di/Erc20DetailModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/Erc20DetailModule.java
@@ -1,6 +1,7 @@
 package com.alphawallet.app.di;
 
 import com.alphawallet.app.interact.FetchTransactionsInteract;
+import com.alphawallet.app.repository.OnRampRepositoryType;
 import com.alphawallet.app.repository.TokenRepositoryType;
 import com.alphawallet.app.repository.TransactionRepositoryType;
 import com.alphawallet.app.router.MyAddressRouter;
@@ -17,11 +18,13 @@ class Erc20DetailModule {
     Erc20DetailViewModelFactory provideErc20DetailViewModelFactory(MyAddressRouter myAddressRouter,
                                                                    FetchTransactionsInteract fetchTransactionsInteract,
                                                                    AssetDefinitionService assetDefinitionService,
-                                                                   TokensService tokensService) {
+                                                                   TokensService tokensService,
+                                                                   OnRampRepositoryType onRampRepository) {
         return new Erc20DetailViewModelFactory(myAddressRouter,
                 fetchTransactionsInteract,
                 assetDefinitionService,
-                tokensService);
+                tokensService,
+                onRampRepository);
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
+import com.alphawallet.app.repository.OnRampRepository;
+import com.alphawallet.app.repository.OnRampRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.repository.SharedPreferenceRepository;
 import com.alphawallet.app.repository.TokenLocalSource;
@@ -100,6 +102,12 @@ public class RepositoriesModule {
 				accountKeystoreService,
 				inDiskCache,
 				transactionsService);
+	}
+
+	@Singleton
+	@Provides
+	OnRampRepositoryType provideOnRampRepository(Context context) {
+		return new OnRampRepository(context);
 	}
 
 	@Singleton

--- a/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/RepositoriesModule.java
@@ -106,8 +106,8 @@ public class RepositoriesModule {
 
 	@Singleton
 	@Provides
-	OnRampRepositoryType provideOnRampRepository(Context context) {
-		return new OnRampRepository(context);
+	OnRampRepositoryType provideOnRampRepository(Context context, AnalyticsServiceType analyticsServiceType) {
+		return new OnRampRepository(context, analyticsServiceType);
 	}
 
 	@Singleton

--- a/app/src/main/java/com/alphawallet/app/entity/BuyCryptoInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/BuyCryptoInterface.java
@@ -1,0 +1,7 @@
+package com.alphawallet.app.entity;
+
+import com.alphawallet.app.entity.tokens.Token;
+
+public interface BuyCryptoInterface {
+    void handleBuyFunction(Token token);
+}

--- a/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
+++ b/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
@@ -6,6 +6,12 @@ public class OnRampContract {
     private String symbol;
     private String provider;
 
+    public OnRampContract(String symbol)
+    {
+        this.symbol = symbol;
+        this.provider = OnRampRepository.DEFAULT_PROVIDER;
+    }
+
     public OnRampContract()
     {
         this.symbol = "";

--- a/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
+++ b/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
@@ -1,0 +1,37 @@
+package com.alphawallet.app.entity;
+
+public class OnRampContract {
+    private String symbol;
+    private String address;
+    private String provider;
+
+    public OnRampContract(String symbol) {
+        this.symbol = symbol;
+        this.address = "";
+        this.provider = "";
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
+++ b/app/src/main/java/com/alphawallet/app/entity/OnRampContract.java
@@ -1,37 +1,34 @@
 package com.alphawallet.app.entity;
 
+import com.alphawallet.app.repository.OnRampRepository;
+
 public class OnRampContract {
     private String symbol;
-    private String address;
     private String provider;
 
-    public OnRampContract(String symbol) {
-        this.symbol = symbol;
-        this.address = "";
-        this.provider = "";
+    public OnRampContract()
+    {
+        this.symbol = "";
+        this.provider = OnRampRepository.DEFAULT_PROVIDER;
     }
 
-    public String getSymbol() {
+    public String getSymbol()
+    {
         return symbol;
     }
 
-    public void setSymbol(String symbol) {
+    public void setSymbol(String symbol)
+    {
         this.symbol = symbol;
     }
 
-    public String getAddress() {
-        return address;
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    public String getProvider() {
+    public String getProvider()
+    {
         return provider;
     }
 
-    public void setProvider(String provider) {
+    public void setProvider(String provider)
+    {
         this.provider = provider;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/StandardFunctionInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/StandardFunctionInterface.java
@@ -13,7 +13,6 @@ public interface StandardFunctionInterface
     default void showSend() { };
     default void showReceive() { };
     default void updateAmount() { };
-    default void buy(OnRampContract data) { };
     default void displayTokenSelectionError(TSAction action) { };
     default void handleClick(String action, int actionId) { };
     default void handleTokenScriptFunction(String function, List<BigInteger> selection) { };

--- a/app/src/main/java/com/alphawallet/app/entity/StandardFunctionInterface.java
+++ b/app/src/main/java/com/alphawallet/app/entity/StandardFunctionInterface.java
@@ -13,6 +13,7 @@ public interface StandardFunctionInterface
     default void showSend() { };
     default void showReceive() { };
     default void updateAmount() { };
+    default void buy(OnRampContract data) { };
     default void displayTokenSelectionError(TSAction action) { };
     default void handleClick(String action, int actionId) { };
     default void handleTokenScriptFunction(String function, List<BigInteger> selection) { };

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
@@ -63,7 +63,7 @@ public class OnRampRepository implements OnRampRepositoryType {
                 }.getType());
     }
 
-    private static Uri buildRampUri(String address, String symbol)
+    private Uri buildRampUri(String address, String symbol)
     {
         Uri.Builder builder = new Uri.Builder();
         builder.scheme("https")

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
@@ -1,0 +1,93 @@
+package com.alphawallet.app.repository;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.alphawallet.app.C;
+import com.alphawallet.app.entity.OnRampContract;
+import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.util.Utils;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.util.Map;
+
+public class OnRampRepository implements OnRampRepositoryType {
+    public static final String DEFAULT_PROVIDER = "Ramp";
+    private static final String RAMP = "ramp";
+    private static final String ONRAMP_CONTRACTS_FILE_NAME = "onramp_contracts.json";
+
+    static
+    {
+        System.loadLibrary("keys");
+    }
+
+    private final Context context;
+
+    public OnRampRepository(Context context)
+    {
+        this.context = context;
+    }
+
+    public static native String getRampKey();
+
+    @Override
+    public String getDefaultProvider()
+    {
+        return DEFAULT_PROVIDER;
+    }
+
+    @Override
+    public String getUri(String address, Token token)
+    {
+        OnRampContract contract = getContract(token);
+        switch (contract.getProvider().toLowerCase())
+        {
+            case RAMP:
+            default:
+                return buildRampUri(address, contract.getSymbol()).toString();
+        }
+    }
+
+    @Override
+    public OnRampContract getContract(Token token)
+    {
+        Map<String, OnRampContract> contractMap = getKnownContracts();
+        OnRampContract contract = contractMap.get(token.getAddress().toLowerCase());
+        if (contract != null) return contract;
+        else return new OnRampContract();
+    }
+
+    @Override
+    public boolean isInKnownContractsList(Token token)
+    {
+        Map<String, OnRampContract> contractMap = getKnownContracts();
+        OnRampContract contract = contractMap.get(token.getAddress().toLowerCase());
+        return contract != null;
+    }
+
+    private Map<String, OnRampContract> getKnownContracts()
+    {
+        return new Gson().fromJson(Utils.loadJSONFromAsset(context, ONRAMP_CONTRACTS_FILE_NAME),
+                new TypeToken<Map<String, OnRampContract>>() {
+                }.getType());
+    }
+
+    private static Uri buildRampUri(String address, String symbol)
+    {
+        Uri.Builder builder = new Uri.Builder();
+        builder.scheme("https")
+                .authority("buy.ramp.network")
+                .appendQueryParameter("hostApiKey", getRampKey())
+                .appendQueryParameter("hostLogoUrl", C.ALPHAWALLET_LOGO_URI)
+                .appendQueryParameter("hostAppName", "AlphaWallet")
+                .appendQueryParameter("userAddress", address);
+
+        if (!symbol.isEmpty())
+        {
+            builder.appendQueryParameter("swapAsset", symbol);
+        }
+
+        return builder.build();
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.net.Uri;
 
 import com.alphawallet.app.C;
+import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.OnRampContract;
 import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.service.AnalyticsServiceType;
 import com.alphawallet.app.util.Utils;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -23,10 +25,12 @@ public class OnRampRepository implements OnRampRepositoryType {
     }
 
     private final Context context;
+    private final AnalyticsServiceType analyticsService;
 
-    public OnRampRepository(Context context)
+    public OnRampRepository(Context context, AnalyticsServiceType analyticsService)
     {
         this.context = context;
+        this.analyticsService = analyticsService;
     }
 
     public static native String getRampKey();
@@ -35,6 +39,11 @@ public class OnRampRepository implements OnRampRepositoryType {
     public String getUri(String address, Token token)
     {
         OnRampContract contract = getContract(token);
+
+        AnalyticsProperties analyticsProperties = new AnalyticsProperties();
+        analyticsProperties.setData(contract.getSymbol());
+        analyticsService.track(C.AN_USE_ONRAMP, analyticsProperties);
+
         switch (contract.getProvider().toLowerCase())
         {
             case RAMP:

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepository.java
@@ -32,12 +32,6 @@ public class OnRampRepository implements OnRampRepositoryType {
     public static native String getRampKey();
 
     @Override
-    public String getDefaultProvider()
-    {
-        return DEFAULT_PROVIDER;
-    }
-
-    @Override
     public String getUri(String address, Token token)
     {
         OnRampContract contract = getContract(token);
@@ -55,15 +49,11 @@ public class OnRampRepository implements OnRampRepositoryType {
         Map<String, OnRampContract> contractMap = getKnownContracts();
         OnRampContract contract = contractMap.get(token.getAddress().toLowerCase());
         if (contract != null) return contract;
-        else return new OnRampContract();
-    }
-
-    @Override
-    public boolean isInKnownContractsList(Token token)
-    {
-        Map<String, OnRampContract> contractMap = getKnownContracts();
-        OnRampContract contract = contractMap.get(token.getAddress().toLowerCase());
-        return contract != null;
+        else
+        {
+            if (token.isEthereum()) return new OnRampContract(token.tokenInfo.symbol);
+            else return new OnRampContract();
+        }
     }
 
     private Map<String, OnRampContract> getKnownContracts()

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepositoryType.java
@@ -1,0 +1,14 @@
+package com.alphawallet.app.repository;
+
+import com.alphawallet.app.entity.OnRampContract;
+import com.alphawallet.app.entity.tokens.Token;
+
+public interface OnRampRepositoryType {
+    String getUri(String address, Token token);
+
+    boolean isInKnownContractsList(Token token);
+
+    OnRampContract getContract(Token token);
+
+    String getDefaultProvider();
+}

--- a/app/src/main/java/com/alphawallet/app/repository/OnRampRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/OnRampRepositoryType.java
@@ -6,9 +6,5 @@ import com.alphawallet.app.entity.tokens.Token;
 public interface OnRampRepositoryType {
     String getUri(String address, Token token);
 
-    boolean isInKnownContractsList(Token token);
-
     OnRampContract getContract(Token token);
-
-    String getDefaultProvider();
 }

--- a/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
@@ -1,5 +1,6 @@
 package com.alphawallet.app.ui;
 
+import android.content.Context;
 import android.content.Intent;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
@@ -18,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
+import com.alphawallet.app.entity.BuyCryptoInterface;
 import com.alphawallet.app.entity.OnRampContract;
 import com.alphawallet.app.entity.StandardFunctionInterface;
 import com.alphawallet.app.entity.Wallet;
@@ -46,7 +48,7 @@ import static com.alphawallet.app.C.Key.TICKET;
 import static com.alphawallet.app.C.Key.WALLET;
 import static com.alphawallet.app.repository.TokensRealmSource.databaseKey;
 
-public class Erc20DetailActivity extends BaseActivity implements StandardFunctionInterface
+public class Erc20DetailActivity extends BaseActivity implements StandardFunctionInterface, BuyCryptoInterface
 {
     @Inject
     Erc20DetailViewModelFactory erc20DetailViewModelFactory;
@@ -139,6 +141,7 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
         if (BuildConfig.DEBUG || wallet.type != WalletType.WATCH)
         {
             functionBar = findViewById(R.id.layoutButtons);
+            functionBar.setupBuyFunction(this, viewModel.getOnRampRepository());
             functionBar.setupFunctions(this, viewModel.getAssetDefinitionService(), token, null, null);
             functionBar.revealButtons();
             functionBar.setWalletType(wallet.type);
@@ -296,24 +299,19 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
         }
     }
 
-    @Override
-    public void buy(OnRampContract data)
-    {
-        buyCrypto(data);
-    }
-
-    private void buyCrypto(OnRampContract data)
-    {
-        Intent intent = viewModel.getBuyIntent(wallet.address, data);
-        setResult(RESULT_OK, intent);
-        finish();
-    }
-
     private void openDapp(String dappURL)
     {
         //switch to dappbrowser and open at dappURL
         Intent intent = new Intent();
         intent.putExtra(C.DAPP_URL_LOAD, dappURL);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+
+    @Override
+    public void handleBuyFunction(Token token)
+    {
+        Intent intent = viewModel.getBuyIntent(wallet.address, token);
         setResult(RESULT_OK, intent);
         finish();
     }

--- a/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
+import com.alphawallet.app.entity.OnRampContract;
 import com.alphawallet.app.entity.StandardFunctionInterface;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.WalletType;
@@ -293,19 +294,17 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
         {
             openDapp(C.XDAI_BRIDGE_DAPP);
         }
-        else if (actionId == R.string.action_buy_eth)
-        {
-            startRamp(C.ETH_SYMBOL);
-        }
-        else if (actionId == R.string.action_buy_xdai)
-        {
-            startRamp(C.xDAI_SYMBOL);
-        }
     }
 
-    private void startRamp(String symbol)
+    @Override
+    public void buy(OnRampContract data)
     {
-        Intent intent = viewModel.startRamp(wallet.address, symbol);
+        buyCrypto(data);
+    }
+
+    private void buyCrypto(OnRampContract data)
+    {
+        Intent intent = viewModel.getBuyIntent(wallet.address, data);
         setResult(RESULT_OK, intent);
         finish();
     }

--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
@@ -451,7 +451,7 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
         String name = getString(R.string.app_name);
         String url = "https://www.alphawallet.com";
         String description = viewModel.getWallet().address;
-        String[] icons = {"https://alphawallet.com/wp-content/themes/alphawallet/img/alphawallet-logo.svg"};
+        String[] icons = {C.ALPHAWALLET_LOGO_URI};
 
         peerMeta = new WCPeerMeta(
                 name,

--- a/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
@@ -11,6 +11,7 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.ActivityMeta;
+import com.alphawallet.app.entity.OnRampContract;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.interact.FetchTransactionsInteract;
@@ -128,20 +129,35 @@ public class Erc20DetailViewModel extends BaseViewModel {
         fetchTransactionsInteract.restartTransactionService();
     }
 
-    public Intent startRamp(String address, String symbol)
+    public Intent getBuyIntent(String address, OnRampContract contract)
+    {
+        switch (contract.getProvider())
+        {
+            case "ramp":
+                return getRampIntent(address, contract.getSymbol());
+
+            default: // Default to Ramp if provider is not specified
+                return getRampIntent(address, contract.getSymbol());
+        }
+    }
+
+    private Intent getRampIntent(String address, String symbol)
     {
         Uri.Builder builder = new Uri.Builder();
-        Uri uri = builder.scheme("https")
+        builder.scheme("https")
                 .authority("buy.ramp.network")
                 .appendQueryParameter("hostApiKey", getRampKey())
                 .appendQueryParameter("hostLogoUrl", "https://alphawallet.com/wp-content/themes/alphawallet/img/alphawallet-logo.svg")
                 .appendQueryParameter("hostAppName", "AlphaWallet")
-                .appendQueryParameter("swapAsset", symbol)
-                .appendQueryParameter("userAddress", address)
-                .build();
+                .appendQueryParameter("userAddress", address);
+
+        if (!symbol.isEmpty())
+        {
+            builder.appendQueryParameter("swapAsset", symbol);
+        }
 
         Intent intent = new Intent();
-        intent.putExtra(C.DAPP_URL_LOAD, uri.toString());
+        intent.putExtra(C.DAPP_URL_LOAD, builder.build().toString());
         return intent;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModel.java
@@ -3,7 +3,6 @@ package com.alphawallet.app.viewmodel;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.text.TextUtils;
 
 import androidx.lifecycle.LiveData;
@@ -15,6 +14,8 @@ import com.alphawallet.app.entity.OnRampContract;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.interact.FetchTransactionsInteract;
+import com.alphawallet.app.repository.OnRampRepository;
+import com.alphawallet.app.repository.OnRampRepositoryType;
 import com.alphawallet.app.router.MyAddressRouter;
 import com.alphawallet.app.router.SendTokenRouter;
 import com.alphawallet.app.service.AssetDefinitionService;
@@ -28,53 +29,60 @@ import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
 
 public class Erc20DetailViewModel extends BaseViewModel {
-
     private final MutableLiveData<ActivityMeta[]> transactions = new MutableLiveData<>();
     private final MutableLiveData<XMLDsigDescriptor> sig = new MutableLiveData<>();
     private final MutableLiveData<Boolean> newScriptFound = new MutableLiveData<>();
-
     private final MyAddressRouter myAddressRouter;
     private final FetchTransactionsInteract fetchTransactionsInteract;
     private final AssetDefinitionService assetDefinitionService;
     private final TokensService tokensService;
-
-    static {
-        System.loadLibrary("keys");
-    }
-
-    public static native String getRampKey();
+    private final OnRampRepositoryType onRampRepository;
 
     public Erc20DetailViewModel(MyAddressRouter myAddressRouter,
                                 FetchTransactionsInteract fetchTransactionsInteract,
                                 AssetDefinitionService assetDefinitionService,
-                                TokensService tokensService) {
+                                TokensService tokensService,
+                                OnRampRepositoryType onRampRepository)
+    {
         this.myAddressRouter = myAddressRouter;
         this.fetchTransactionsInteract = fetchTransactionsInteract;
         this.assetDefinitionService = assetDefinitionService;
         this.tokensService = tokensService;
+        this.onRampRepository = onRampRepository;
     }
 
-    public LiveData<XMLDsigDescriptor> sig() { return sig; }
+    public LiveData<XMLDsigDescriptor> sig()
+    {
+        return sig;
+    }
 
-    public LiveData<Boolean> newScriptFound() { return newScriptFound; }
+    public LiveData<Boolean> newScriptFound()
+    {
+        return newScriptFound;
+    }
 
-    public void showMyAddress(Context context, Wallet wallet, Token token) {
+    public void showMyAddress(Context context, Wallet wallet, Token token)
+    {
         myAddressRouter.open(context, wallet, token);
     }
 
-    public void showContractInfo(Context ctx, Wallet wallet, Token token) {
+    public void showContractInfo(Context ctx, Wallet wallet, Token token)
+    {
         myAddressRouter.open(ctx, wallet, token);
     }
 
-    public TokensService getTokensService() {
+    public TokensService getTokensService()
+    {
         return tokensService;
     }
 
-    public FetchTransactionsInteract getTransactionsInteract() {
+    public FetchTransactionsInteract getTransactionsInteract()
+    {
         return fetchTransactionsInteract;
     }
 
-    public AssetDefinitionService getAssetDefinitionService() {
+    public AssetDefinitionService getAssetDefinitionService()
+    {
         return this.assetDefinitionService;
     }
 
@@ -129,35 +137,14 @@ public class Erc20DetailViewModel extends BaseViewModel {
         fetchTransactionsInteract.restartTransactionService();
     }
 
-    public Intent getBuyIntent(String address, OnRampContract contract)
+    public Intent getBuyIntent(String address, Token token)
     {
-        switch (contract.getProvider())
-        {
-            case "ramp":
-                return getRampIntent(address, contract.getSymbol());
-
-            default: // Default to Ramp if provider is not specified
-                return getRampIntent(address, contract.getSymbol());
-        }
+        Intent intent = new Intent();
+        intent.putExtra(C.DAPP_URL_LOAD, onRampRepository.getUri(address, token));
+        return intent;
     }
 
-    private Intent getRampIntent(String address, String symbol)
-    {
-        Uri.Builder builder = new Uri.Builder();
-        builder.scheme("https")
-                .authority("buy.ramp.network")
-                .appendQueryParameter("hostApiKey", getRampKey())
-                .appendQueryParameter("hostLogoUrl", "https://alphawallet.com/wp-content/themes/alphawallet/img/alphawallet-logo.svg")
-                .appendQueryParameter("hostAppName", "AlphaWallet")
-                .appendQueryParameter("userAddress", address);
-
-        if (!symbol.isEmpty())
-        {
-            builder.appendQueryParameter("swapAsset", symbol);
-        }
-
-        Intent intent = new Intent();
-        intent.putExtra(C.DAPP_URL_LOAD, builder.build().toString());
-        return intent;
+    public OnRampRepositoryType getOnRampRepository() {
+        return onRampRepository;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModelFactory.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/Erc20DetailViewModelFactory.java
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.alphawallet.app.interact.FetchTransactionsInteract;
+import com.alphawallet.app.repository.OnRampRepositoryType;
 import com.alphawallet.app.router.MyAddressRouter;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.TokensService;
@@ -16,20 +17,23 @@ public class Erc20DetailViewModelFactory implements ViewModelProvider.Factory {
     private final FetchTransactionsInteract fetchTransactionsInteract;
     private final AssetDefinitionService assetDefinitionService;
     private final TokensService tokensService;
+    private final OnRampRepositoryType onRampRepository;
 
     public Erc20DetailViewModelFactory(MyAddressRouter myAddressRouter,
                                        FetchTransactionsInteract fetchTransactionsInteract,
                                        AssetDefinitionService assetDefinitionService,
-                                       TokensService tokensService) {
+                                       TokensService tokensService,
+                                       OnRampRepositoryType onRampRepository) {
         this.myAddressRouter = myAddressRouter;
         this.fetchTransactionsInteract = fetchTransactionsInteract;
         this.assetDefinitionService = assetDefinitionService;
         this.tokensService = tokensService;
+        this.onRampRepository = onRampRepository;
     }
 
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-        return (T) new Erc20DetailViewModel(myAddressRouter, fetchTransactionsInteract, assetDefinitionService, tokensService);
+        return (T) new Erc20DetailViewModel(myAddressRouter, fetchTransactionsInteract, assetDefinitionService, tokensService, onRampRepository);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -709,6 +709,6 @@ public class FunctionButtonBar extends LinearLayout implements AdapterView.OnIte
     {
         OnRampContract contract = onRampRepository.getContract(token);
         String symbol = contract.getSymbol().isEmpty()? context.getString(R.string.crypto) : token.tokenInfo.symbol;
-        addFunction(new ItemClick(context.getString(R.string.action_buy_crypto, symbol, contract.getProvider()), R.string.action_buy_crypto));
+        addFunction(new ItemClick(context.getString(R.string.action_buy_crypto, symbol), R.string.action_buy_crypto));
     }
 }

--- a/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
+++ b/app/src/main/java/com/alphawallet/app/widget/FunctionButtonBar.java
@@ -708,13 +708,7 @@ public class FunctionButtonBar extends LinearLayout implements AdapterView.OnIte
     private void addPurchaseVerb(Token token, OnRampRepositoryType onRampRepository)
     {
         OnRampContract contract = onRampRepository.getContract(token);
-        if (token.isEthereum() || onRampRepository.isInKnownContractsList(token))
-        {
-            addFunction(new ItemClick(context.getString(R.string.action_buy_crypto, token.tokenInfo.symbol, contract.getProvider()), R.string.action_buy_crypto));
-        }
-        else
-        {
-            addFunction(new ItemClick(context.getString(R.string.action_buy_crypto, context.getString(R.string.crypto), onRampRepository.getDefaultProvider()), R.string.action_buy_crypto));
-        }
+        String symbol = contract.getSymbol().isEmpty()? context.getString(R.string.crypto) : token.tokenInfo.symbol;
+        addFunction(new ItemClick(context.getString(R.string.action_buy_crypto, symbol, contract.getProvider()), R.string.action_buy_crypto));
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -714,6 +714,5 @@
     <string name="action_withdraw">Withdraw</string>
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
-    <string name="action_buy_xdai">Buy xDAI</string>
-    <string name="action_buy_eth">Buy ETH</string>
+    <string name="crypto">Crypto</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -715,5 +715,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
-    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
+    <string name="action_buy_crypto">Buy %1$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -715,4 +715,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
+    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -714,6 +714,5 @@
     <string name="action_withdraw">Withdraw</string>
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
-    <string name="action_buy_xdai">Buy xDAI</string>
-    <string name="action_buy_eth">Buy ETH</string>
+    <string name="crypto">Crypto</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -715,5 +715,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
-    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
+    <string name="action_buy_crypto">Buy %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -715,4 +715,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
+    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,6 +740,5 @@
     <string name="action_withdraw">Withdraw</string>
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
-    <string name="action_buy_xdai">Buy xDAI</string>
-    <string name="action_buy_eth">Buy ETH</string>
+    <string name="crypto">Crypto</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,4 +741,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
+    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,5 +741,5 @@
     <string name="deposit">Deposit</string>
     <string name="convert_to_xdai">Convert to xDAI</string>
     <string name="crypto">Crypto</string>
-    <string name="action_buy_crypto">Buy %1$s from %2$s</string>
+    <string name="action_buy_crypto">Buy %1$s</string>
 </resources>


### PR DESCRIPTION
This PR addresses #1738 
- All fiat on-ramp provider data will now be maintained in a file named '**onramp_contracts.json**'. Each item will contain the token symbol, contract address, and on-ramp provider (ie Ramp, Wyre, etc)
- FunctionBar button for '**Buy XXX**' now automatically generates label depending on token symbol. This is to prevent bloating the code with multiple if/else statements and corresponding string resources for each kind of token. If a token is not in the known contracts file, it will display '**Buy Crypto**'.