### PR TITLE
Allow request camera permission for dappbrowser

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -5,10 +5,12 @@ import android.animation.Animator;
 import android.animation.LayoutTransition;
 import android.animation.ValueAnimator;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -26,6 +28,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.webkit.GeolocationPermissions;
+import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
 import android.webkit.WebBackForwardList;
 import android.webkit.WebChromeClient;
@@ -811,6 +814,11 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
             }
 
             @Override
+            public void onPermissionRequest(final PermissionRequest request) {
+                requestCameraPermission(request);
+            }
+
+            @Override
             public void onGeolocationPermissionsShowPrompt(String origin,
                                                            GeolocationPermissions.Callback callback)
             {
@@ -1566,6 +1574,31 @@ public class DappBrowserFragment extends Fragment implements OnSignTransactionLi
         else
         {
             callback.invoke(origin, true, false);
+        }
+    }
+
+    // Handles the requesting of the camera permission.
+    private void requestCameraPermission(PermissionRequest request)
+    {
+        final String[] requestedResources = request.getResources();
+        for (String r : requestedResources)
+        {
+            if (r.equals(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+            {
+                AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
+                alertDialog.setMessage(String.format(getString(R.string.message_permission_request_webkit_camera), request.getOrigin().getAuthority()));
+                alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, getString(R.string.action_deny_webkit_camera),
+                        (dialog, which) -> {
+                            request.deny();
+                            dialog.dismiss();
+                        });
+                alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.action_allow_webkit_camera),
+                        (dialog, which) -> {
+                            request.grant(requestedResources);
+                            dialog.dismiss();
+                        });
+                alertDialog.show();
+            }
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -928,6 +928,9 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         switch (requestCode)
         {
+            case DappBrowserFragment.REQUEST_CAMERA_ACCESS:
+                ((DappBrowserFragment) dappBrowserFragment).gotCameraAccess(permissions, grantResults);
+                break;
             case DappBrowserFragment.REQUEST_FILE_ACCESS:
                 ((DappBrowserFragment) dappBrowserFragment).gotFileAccess(permissions, grantResults);
                 break;

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -733,4 +733,7 @@
     <string name="your_seed_phrase">Your seed phrase (do not share with anyone)</string>
     <string name="hide_seed_text">OK, Hide Seed Phrase</string>
     <string name="ens_not_match_wallet">ENS Name does not match wallet address</string>
+    <string name="action_allow_webkit_camera">Allow</string>
+    <string name="action_deny_webkit_camera">Deny</string>
+    <string name="message_permission_request_webkit_camera">%s wants to use your camera</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -733,4 +733,7 @@
     <string name="your_seed_phrase">Your seed phrase (do not share with anyone)</string>
     <string name="hide_seed_text">OK, Hide Seed Phrase</string>
     <string name="ens_not_match_wallet">ENS Name does not match wallet address</string>
+    <string name="action_allow_webkit_camera">Allow</string>
+    <string name="action_deny_webkit_camera">Deny</string>
+    <string name="message_permission_request_webkit_camera">%s wants to use your camera</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -759,4 +759,7 @@
     <string name="your_seed_phrase">Your seed phrase (do not share with anyone)</string>
     <string name="hide_seed_text">OK, Hide Seed Phrase</string>
     <string name="ens_not_match_wallet">ENS Name does not match wallet address</string>
+    <string name="action_allow_webkit_camera">Allow</string>
+    <string name="action_deny_webkit_camera">Deny</string>
+    <string name="message_permission_request_webkit_camera">%s wants to use your camera</string>
 </resources>


### PR DESCRIPTION
Potential fix for #1775

I cannot replicate the exact issue for Ramp, but what I noticed is that the Dapp Browser is auto-denying requests to use the camera on other websites.

This PR addresses this issue by displaying a simple dialog that prompts the user to Allow or Deny camera access on websites that require one.