### PR TITLE
Add SCV.finance as an dApp

### DIFF
--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -65,6 +65,7 @@
   {"name": "DeFi Money Market (DMM)", "description": "Earn interest on your crypto through tokenized real world assets", "url": "https://app.defimoneymarket.com", "category": "Finance"},
   {"name": "Idle Finance", "description": "DeFi Yield Aggregator and Rebalancing Protocol", "url": "https://idle.finance", "category": "Finance"},
   {"name": "GG Copyright EX", "description": "GeekGit Copyright Exchange for Music & Web Literature", "url": "https://crex.geekgit.com", "category": "Exchange"},
-  {"name": "DerivaDEX | Insurance Fund", "description": "DerivaDEX is the next generation of crypto derivatives. Begin earning DDX by bootstrapping the insurance fund.", "url": "https://insurance.derivadex.com", "category": "Finance"}
+  {"name": "DerivaDEX | Insurance Fund", "description": "DerivaDEX is the next generation of crypto derivatives. Begin earning DDX by bootstrapping the insurance fund.", "url": "https://insurance.derivadex.com", "category": "Finance"},
+  {"name": "SCV.Finance", "description": "Get a big picture of all your digital assets locked inside various DeFi projects across multiple blockchains.", "url": "https://scv.finance", "category": "Tool"}
 ]
 


### PR DESCRIPTION
Hi there! I've added [SCV.finance](https://scv.finance), a tool to manage DeFi portfolio on multiple chains.

currently with BSC, ETH support and the following products

- Compound
- Venus
- PancakeSwap
- Uniswap
- SushiSwap