### PR TITLE
Use AW icon repo across all chains

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -157,8 +157,6 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
     @Nullable
     private Disposable checkEventDisposable;
 
-    private final Map<String, Boolean> iconCheck = new ConcurrentHashMap<>();
-
     /* Designed with the assmuption that only a single instance of this class at any given time
     *  ^^ The "service" part of AssetDefinitionService is the keyword here.
     *  This is shorthand in the project to indicate this is a singleton that other classes inject.
@@ -2569,10 +2567,7 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
             tURL = Utils.getTokenImageUrl(token.tokenInfo.chainId, correctedAddr);
         }
 
-        boolean onlyTryCache = iconCheck.containsKey(correctedAddr);
-        iconCheck.put(correctedAddr, true);
-
-        return new IconItem(tURL, onlyTryCache, correctedAddr, token.tokenInfo.chainId);
+        return new IconItem(tURL, correctedAddr, token.tokenInfo.chainId);
     }
 
     public Single<Integer> fetchViewHeight(int chainId, String address)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/IconItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/IconItem.java
@@ -2,17 +2,24 @@ package com.alphawallet.app.ui.widget.entity;
 
 import com.bumptech.glide.signature.ObjectKey;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class IconItem {
     private final String url;
     private final boolean fetchFromCache;
     private final String correctedAddress;
     private final int chainId;
 
-    public IconItem(String url, boolean fetchFromCache, String correctedAddress, int chainId) {
+    private final static Map<String, Boolean> iconCheck = new ConcurrentHashMap<>();
+
+    public IconItem(String url, String correctedAddress, int chainId) {
         this.url = url;
-        this.fetchFromCache = fetchFromCache;
+        this.fetchFromCache = iconCheck.containsKey(correctedAddress);
         this.correctedAddress = correctedAddress;
         this.chainId = chainId;
+
+        iconCheck.put(correctedAddress, true);
     }
 
     public String getUrl() {

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -46,8 +46,9 @@ public class Utils {
     private static final String ISOLATE_NUMERIC = "(0?x?[0-9a-fA-F]+)";
     private static final String ICON_REPO_ADDRESS_TOKEN = "[TOKEN]";
     private static final String CHAIN_REPO_ADDRESS_TOKEN = "[CHAIN]";
+    public  static final String ALPHAWALLET_REPO_NAME = "alphawallet/iconassets";
     private static final String TRUST_ICON_REPO = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/" + CHAIN_REPO_ADDRESS_TOKEN + "/assets/" + ICON_REPO_ADDRESS_TOKEN + "/logo.png";
-    private static final String ALPHAWALLET_ICON_REPO = "https://raw.githubusercontent.com/alphawallet/iconassets/master/" + ICON_REPO_ADDRESS_TOKEN + "/logo.png";
+    private static final String ALPHAWALLET_ICON_REPO = "https://raw.githubusercontent.com/" + ALPHAWALLET_REPO_NAME + "/master/" + ICON_REPO_ADDRESS_TOKEN + "/logo.png";
 
     public static int dp2px(Context context, int dp) {
         Resources r = context.getResources();
@@ -767,6 +768,11 @@ public class Utils {
         tURL = tURL.replace(ICON_REPO_ADDRESS_TOKEN, address).replace(CHAIN_REPO_ADDRESS_TOKEN, repoChain);
 
         return tURL;
+    }
+
+    public static String getAWIconRepo(String address)
+    {
+        return ALPHAWALLET_ICON_REPO.replace(ICON_REPO_ADDRESS_TOKEN, Keys.toChecksumAddress(address));
     }
 
     public static boolean isContractCall(Context context, String operationName)


### PR DESCRIPTION
Tidy up icon loading (handle exceptions correctly) and add pass-through to check AW icon repo if not found in the Trust repo.

This gives us the ability to add icon graphics for tokens without waiting for entry to go into the Trust repo.