### PR TITLE
NFT transfer event handling improvements

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/ActivityMeta.java
+++ b/app/src/main/java/com/alphawallet/app/entity/ActivityMeta.java
@@ -9,7 +9,7 @@ import java.util.List;
  */
 public class ActivityMeta
 {
-    private final long timeStamp;
+    protected final long timeStamp;
     public final String hash;
 
     public ActivityMeta(long ts, String txHash)

--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 /**
  * Created by JB on 21/10/2020.
  */
+
 public class EtherscanEvent
 {
     public String blockNumber;
@@ -25,6 +26,7 @@ public class EtherscanEvent
     public String tokenName;
     public String tokenSymbol;
     public String tokenDecimal;
+    public String input;
     String gas;
     String gasPrice;
     String gasUsed;

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -223,7 +223,15 @@ public class ERC721Ticket extends Token implements Parcelable {
     @Override
     public String convertValue(String value, int precision)
     {
-        return value;
+        precision += 1;
+        if (value.length() > precision)
+        {
+            return "…" + value.substring(value.length() - precision);
+        }
+        else
+        {
+            return value;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -255,7 +255,15 @@ public class ERC721Token extends Token implements Parcelable
     @Override
     public String convertValue(String value, int precision)
     {
-        return value;
+        precision += 1;
+        if (value.length() > precision)
+        {
+            return "…" + value.substring(value.length() - precision);
+        }
+        else
+        {
+            return value;
+        }
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -264,6 +264,19 @@ public class Token implements Parcelable, Comparable<Token>
         else return tokenInfo.symbol.toUpperCase();
     }
 
+    public String getSymbolOrShortName()
+    {
+        String shortSymbol = getShortSymbol();
+        if (TextUtils.isEmpty(shortSymbol))
+        {
+            return Utils.getShortSymbol(tokenInfo.name);
+        }
+        else
+        {
+            return shortSymbol;
+        }
+    }
+
     public void clickReact(BaseViewModel viewModel, Activity context)
     {
         viewModel.showErc20TokenDetail(context, tokenInfo.address, tokenInfo.symbol, tokenInfo.decimals, this);

--- a/app/src/main/java/com/alphawallet/app/ui/TokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenActivity.java
@@ -28,6 +28,7 @@ import com.alphawallet.app.repository.EventResult;
 import com.alphawallet.app.repository.TransactionsRealmCache;
 import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.repository.entity.RealmTransaction;
+import com.alphawallet.app.ui.widget.entity.TokenTransferData;
 import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.util.KeyboardUtils;
 import com.alphawallet.app.util.Utils;
@@ -100,12 +101,14 @@ public class TokenActivity extends BaseActivity implements PageReadyCallback, St
     private final Handler handler = new Handler();
     private boolean isFromTokenHistory = false;
     private long pendingStart = 0;
+    private TokenTransferData transferData;
 
     @Nullable
     private Disposable pendingTxUpdate = null;
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
+    protected void onCreate(@Nullable Bundle savedInstanceState)
+    {
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_token_activity);
@@ -113,6 +116,8 @@ public class TokenActivity extends BaseActivity implements PageReadyCallback, St
         eventKey = getIntent().getStringExtra(C.EXTRA_ACTION_NAME);
         transactionHash = getIntent().getStringExtra(C.EXTRA_TXHASH);
         isFromTokenHistory = getIntent().getBooleanExtra(C.EXTRA_STATE, false);
+        transferData = getIntent().getParcelableExtra(C.EXTRA_TOKEN_ID);
+        //TODO: Send event details
         icon = findViewById(R.id.token_icon);
 
         SystemView systemView = findViewById(R.id.system_view);
@@ -263,6 +268,10 @@ public class TokenActivity extends BaseActivity implements PageReadyCallback, St
         {
             eventDetail.setupTransactionView(transaction, token, viewModel.getAssetDefinitionService(), supplementalTxt);
         }
+        else if (transferData != null)
+        {
+            eventDetail.setupTransferData(transaction, token, transferData);
+        }
 
         setChainName(transaction);
     }
@@ -321,6 +330,10 @@ public class TokenActivity extends BaseActivity implements PageReadyCallback, St
     {
         String operationAddress = tx.getOperationTokenAddress();
         Token operationToken = viewModel.getTokensService().getToken(tx.chainId, operationAddress);
+        if (operationToken == null && transferData != null)
+        {
+            operationToken = viewModel.getTokensService().getToken(tx.chainId, transferData.tokenAddress);
+        }
 
         if (operationToken == null)
         {

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/ActivityAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/ActivityAdapter.java
@@ -5,6 +5,7 @@ package com.alphawallet.app.ui.widget.adapter;
  */
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
@@ -48,9 +49,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-public class ActivityAdapter extends RecyclerView.Adapter<BinderViewHolder> implements AdapterCallback
+public class ActivityAdapter extends RecyclerView.Adapter<BinderViewHolder<?>> implements AdapterCallback
 {
-    private final ActivitySortedList<SortedItem> items = new ActivitySortedList<>(SortedItem.class, new ActivitySortedList.Callback<SortedItem>() {
+    private final ActivitySortedList<SortedItem<?>> items = new ActivitySortedList<>(SortedItem.class, new ActivitySortedList.Callback<SortedItem<?>>() {
         @Override
         public int compare(SortedItem left, SortedItem right)
         {
@@ -173,7 +174,7 @@ public class ActivityAdapter extends RecyclerView.Adapter<BinderViewHolder> impl
 
     private Runnable checkData = () -> {
         //get final position time
-        SortedItem item = items.get(items.size() - 1);
+        SortedItem<?> item = items.get(items.size() - 1);
         long earliestDate = 0;
         if (item instanceof TimestampSortedItem)
         {

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/ENSHandler.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/ENSHandler.java
@@ -300,9 +300,9 @@ public class ENSHandler implements Runnable
         }
     }
 
-    public static String displayAddressOrENS(Context ctx, String ethAddress)
+    public static String displayAddressOrENS(Context ctx, String ethAddress, boolean shrinkAddress)
     {
-        String returnAddress = Utils.formatAddress(ethAddress);
+        String returnAddress = shrinkAddress ? Utils.formatAddress(ethAddress) : ethAddress;
         if (!TextUtils.isEmpty(ethAddress) && Utils.isAddressValid(ethAddress))
         {
             HashMap<String, String> ensMap = getENSHistoryFromPrefs(ctx);
@@ -311,6 +311,11 @@ public class ENSHandler implements Runnable
         }
 
         return returnAddress;
+    }
+
+    public static String displayAddressOrENS(Context ctx, String ethAddress)
+    {
+        return displayAddressOrENS(ctx, ethAddress, true);
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransactionSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransactionSortedItem.java
@@ -4,6 +4,7 @@ import com.alphawallet.app.entity.ActivityMeta;
 import com.alphawallet.app.entity.TransactionMeta;
 import com.alphawallet.app.ui.widget.holder.EventHolder;
 import com.alphawallet.app.ui.widget.holder.TransactionHolder;
+import com.alphawallet.app.ui.widget.holder.TransferHolder;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -65,11 +66,7 @@ public class TransactionSortedItem extends TimestampSortedItem<TransactionMeta> 
                 TransactionMeta newTx = (TransactionMeta) other.value;
                 return value.isPending == newTx.isPending;
             }
-            else if (other.viewType == EventHolder.VIEW_TYPE)
-            {
-                return false;
-            }
-            else
+            else //allow other types to override the lowly Transaction item
             {
                 return false;
             }
@@ -90,7 +87,7 @@ public class TransactionSortedItem extends TimestampSortedItem<TransactionMeta> 
                 TransactionMeta oldTx = (TransactionMeta) other.value;
                 return value.hash.equals(oldTx.hash);
             }
-            else if (other.viewType == EventHolder.VIEW_TYPE)
+            else if (other.viewType == EventHolder.VIEW_TYPE || other.viewType == TransferHolder.VIEW_TYPE) //allow both Event and Transfer to override
             {
                 return true;
             }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransferSortedItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/TransferSortedItem.java
@@ -1,7 +1,10 @@
 package com.alphawallet.app.ui.widget.entity;
 
 import com.alphawallet.app.entity.ActivityMeta;
+import com.alphawallet.app.entity.Transaction;
+import com.alphawallet.app.entity.TransactionMeta;
 import com.alphawallet.app.ui.widget.holder.EventHolder;
+import com.alphawallet.app.ui.widget.holder.TransactionHolder;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -22,7 +25,7 @@ public class TransferSortedItem extends TimestampSortedItem<TokenTransferData> {
     {
         if (other.tags.contains(IS_TIMESTAMP_TAG))
         {
-            TimestampSortedItem otherTimestamp = (TimestampSortedItem) other;
+            TimestampSortedItem<?> otherTimestamp = (TimestampSortedItem<?>) other;
 
             if (other.value instanceof ActivityMeta)
             {
@@ -52,14 +55,15 @@ public class TransferSortedItem extends TimestampSortedItem<TokenTransferData> {
         }
     }
 
+    //Determine if we overwrite or add an extra element
     @Override
     public boolean areContentsTheSame(SortedItem other)
     {
         if (viewType == other.viewType)
         {
-            return true;
+            return true; //don't overwrite
         }
-        else if (other.viewType == EventHolder.VIEW_TYPE)
+        else if (other.viewType == EventHolder.VIEW_TYPE) //allow event type to overwrite, messaging the adapter
         {
             return false;
         }
@@ -69,15 +73,16 @@ public class TransferSortedItem extends TimestampSortedItem<TokenTransferData> {
         }
     }
 
+    //Checks if the type is the same, if same type then overwrite is possible
     @Override
     public boolean areItemsTheSame(SortedItem other)
     {
         if (viewType == other.viewType)
         {
             TokenTransferData newTx = (TokenTransferData) other.value;
-            return value.hash.equals(newTx.hash);
+            return value.hash.equals(newTx.hash); //if same type, only overwrite if hash is same
         }
-        else if (other.viewType == EventHolder.VIEW_TYPE)
+        else if (other.viewType == EventHolder.VIEW_TYPE) //allow Event type to overwrite
         {
             return true;
         }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TransactionHolder.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.ui.widget.holder;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -44,7 +45,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
     private final TextView value;
     private final ChainName chainName;
     private final TextView supplemental;
-    //private final TextView symbol;
     private final TokensService tokensService;
     private final LinearLayout transactionBackground;
     private final FetchTransactionsInteract transactionsInteract;
@@ -65,7 +65,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
         chainName = findViewById(R.id.chain_name);
         supplemental = findViewById(R.id.supplimental);
         transactionBackground = findViewById(R.id.layout_background);
-        //symbol = findViewById(R.id.symbol);
         tokensService = service;
         transactionsInteract = interact;
         assetService = svs;
@@ -198,7 +197,6 @@ public class TransactionHolder extends BinderViewHolder<TransactionMeta> impleme
             transactionBackground.setBackgroundResource(R.drawable.background_pending_transaction);
             long fetchTxCompletionTime = transactionsInteract.fetchTxCompletionTime(defaultAddress, transaction.hash);
             tokenIcon.startPendingSpinner(transaction.timeStamp, fetchTxCompletionTime/1000);
-            //symbol.setVisibility(View.GONE);
             chainName.setVisibility(View.GONE);
         }
         else if (transactionBackground != null)

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -141,13 +141,15 @@ public class Utils {
     }
 
     private static String getFirstWord(String text) {
+        if (TextUtils.isEmpty(text)) return "";
         text = text.trim();
-        int index = text.indexOf(' ');
-        if (index > -1) {
-            return text.substring(0, index).trim();
-        } else {
-            return text.trim();
+        int index;
+        for (index = 0; index < text.length(); index++)
+        {
+            if (!Character.isLetterOrDigit(text.charAt(index))) break;
         }
+
+        return text.substring(0, index).trim();
     }
 
     public static String getIconisedText(String text)
@@ -308,7 +310,7 @@ public class Utils {
 
     public static CharSequence createFormattedValue(Context ctx, String operationName, Token token)
     {
-        String symbol = token != null ? token.getShortSymbol() : "";
+        String symbol = token != null ? token.getSymbolOrShortName() : "";
         boolean needsBreak = false;
 
         if ((symbol.length() + operationName.length()) > 16 && symbol.length() > 0)

--- a/app/src/main/java/com/alphawallet/app/widget/EventDetailWidget.java
+++ b/app/src/main/java/com/alphawallet/app/widget/EventDetailWidget.java
@@ -9,8 +9,14 @@ import android.widget.TextView;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.repository.EventResult;
 import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.ui.widget.entity.TokenTransferData;
+
+import java.util.Map;
+
+import static com.alphawallet.app.ui.widget.holder.TransactionHolder.TRANSACTION_BALANCE_PRECISION;
 
 /**
  * Created by JB on 8/12/2020.
@@ -78,6 +84,39 @@ public class EventDetailWidget extends LinearLayout
         else
         {
             detail.setText(getContext().getString(R.string.default_from, supplimentalInfo.substring(2), "", token.getFullName()));
+        }
+    }
+
+    public void setupTransferData(Transaction transaction, Token token, TokenTransferData transferData)
+    {
+        holdingView.setVisibility(View.VISIBLE);
+        icon.setVisibility(View.GONE);
+        symbol.setText(token.getSymbolOrShortName());
+
+        title.setVisibility(View.GONE);
+
+        transaction.getDestination(token); //build decoded input
+        Map<String, EventResult> resultMap = transferData.getEventResultMap();
+        String value = "";
+        if (resultMap.get("amount") != null)
+        {
+            value = token.isNonFungible() ? "#" : (transferData.eventName.equals("sent") ? "- " : "+ "); //"#" for ERC721, "- " or "+ " for ERC20
+            value += token.convertValue(resultMap.get("amount").value, token.isNonFungible() ? 128 : TRANSACTION_BALANCE_PRECISION + 2);
+        }
+
+        //get 'from'
+        String addressDetail = transferData.getDetail(getContext(), transaction, "", false);
+
+        switch (transferData.eventName)
+        {
+            case "received":
+                detail.setText(getContext().getString(R.string.default_from, value, "", addressDetail));
+                break;
+            case "sent":
+                detail.setText(getContext().getString(R.string.default_to, value, "", addressDetail));
+                break;
+            default:
+                break;
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="no_transactions_yet">Activities will appear here</string>
     <string name="unknown_balance_without_symbol">--</string>
     <string name="dummy_transaction_value">&#45;&#45;</string>
-    <string name="title_dialog_sending">Sending...</string>
+    <string name="title_dialog_sending">Sending…</string>
     <string name="scan_qr">Get address from QR Code</string>
     <string name="info_gas_price">The higher the gas price, the more expensive your transaction fee will be, but the quicker your transaction will be processed by the Ethereum network.</string>
     <string name="info_gas_limit">The gas limit prevents smart contracts from consuming all your Ethereum. We will try to calculate the gas limit automatically for you, but some smart contracts may require a custom gas limit.</string>


### PR DESCRIPTION
- Handle Blockscout network NFT transfer events (covering networks: xDai, Eth Classic, POA, Sokol).
- Refactor transfer event pickup.
- Show more details for transfer events in Token Activity.