### PR TITLE
Add Matic Faucet for Testnet Tokens to dApp list

### DIFF
--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -70,7 +70,7 @@
   {"name": "DerivaDEX | Insurance Fund", "description": "DerivaDEX is the next generation of crypto derivatives. Begin earning DDX by bootstrapping the insurance fund.", "url": "https://insurance.derivadex.com", "category": "Finance"},
   {"name": "SCV.Finance", "description": "Get a big picture of all your digital assets locked inside various DeFi projects across multiple blockchains.", "url": "https://scv.finance", "category": "Tool"},
   {"name": "Mushrooms Finance", "description": "Sustainable crypto earning in DeFi", "url": "https://mushrooms.finance/", "category": "Finance"},
-  {"name": "Levinswap", "description": "Decentralized exchange for trading crypto and serurities tokens", "url": "https://app.levinswap.org/", "category": "Exchange"}
+  {"name": "Levinswap", "description": "Decentralized exchange for trading crypto and serurities tokens", "url": "https://app.levinswap.org/", "category": "Exchange"},
   {"name": "Matic Testnet Faucet", "description": "Matic Faucet to access Mumbai and Goerli testnet tokens", "url": "https://faucet.matic.network/", "category": "Tool"}
 
 ]

--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -71,5 +71,7 @@
   {"name": "SCV.Finance", "description": "Get a big picture of all your digital assets locked inside various DeFi projects across multiple blockchains.", "url": "https://scv.finance", "category": "Tool"},
   {"name": "Mushrooms Finance", "description": "Sustainable crypto earning in DeFi", "url": "https://mushrooms.finance/", "category": "Finance"},
   {"name": "Levinswap", "description": "Decentralized exchange for trading crypto and serurities tokens", "url": "https://app.levinswap.org/", "category": "Exchange"}
+  {"name": "Matic Testnet Faucet", "description": "Matic Faucet to access Mumbai and Goerli testnet tokens", "url": "https://faucet.matic.network/", "category": "Tool"}
+
 ]
 


### PR DESCRIPTION
Added Matic Faucet dApp after testing 3 Matic faucets: 

Tested 3 sites on Alphawallet browser: 
Works - https://faucet.matic.network/ ---> Matic Faucet for Testnet Tokens on Mumbai, Goerli, and DA Testnet (successful txns, ADDED ENTRY) 
Issues - https://wallet.matic.network/faucet/ ---> Matic Faucet for Ropsten Testnet Tokens (requires tweet, did not authenticate) 
Issues - https://matic.supply/ ---> Matic Faucet for 0.001 MATIC Tokens on Polygon Network (connected to Alphawallet, click receive, but threw error "undefined")