### PR TITLE
updated the link to discord in readme - invite had expired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can submit feedback and report bugs as Github issues. Please be sure to incl
 
 ### Request or submit a feature :postbox:
 
-Would you like to request a feature? Please get in touch with us [Telegram](https://t.me/AlphaWalletGroup), [Discord](https://discord.gg/d8Tqvx9e74), [Twitter](https://twitter.com/AlphaWallet) or through our [community forums](https://community.tokenscript.org/).
+Would you like to request a feature? Please get in touch with us [Telegram](https://t.me/AlphaWalletGroup), [Discord](https://discord.gg/mx23YWRTYf), [Twitter](https://twitter.com/AlphaWallet) or through our [community forums](https://community.tokenscript.org/).
 
 If you’d like to contribute code with a Pull Request, please make sure to follow code submission guidelines.
 


### PR DESCRIPTION
Updated the Discord link inside the readme. The previous url appeared to have expired. 