### PR TITLE
Add Cached data reset

### DIFF
--- a/app/src/main/java/com/alphawallet/app/di/AdvancedSettingsModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/AdvancedSettingsModule.java
@@ -6,6 +6,7 @@ import com.alphawallet.app.repository.LocaleRepository;
 import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.service.TransactionsService;
 import com.alphawallet.app.viewmodel.AdvancedSettingsViewModelFactory;
 
 import dagger.Module;
@@ -18,13 +19,15 @@ class AdvancedSettingsModule {
             LocaleRepositoryType localeRepository,
             CurrencyRepositoryType currencyRepository,
             AssetDefinitionService assetDefinitionService,
-            PreferenceRepositoryType preferenceRepository
+            PreferenceRepositoryType preferenceRepository,
+            TransactionsService transactionsService
     ) {
         return new AdvancedSettingsViewModelFactory(
                 localeRepository,
                 currencyRepository,
                 assetDefinitionService,
-                preferenceRepository);
+                preferenceRepository,
+                transactionsService);
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
@@ -30,4 +30,6 @@ public interface TransactionLocalSource {
 	Transaction storeRawTx(Wallet wallet, int chainId, EthTransaction object, long timeStamp, boolean isSuccessful);
 
     long fetchTxCompletionTime(Wallet wallet, String hash);
+
+    Single<Boolean> deleteAllForWallet(String currentAddress);
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
@@ -8,7 +8,9 @@ import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionMeta;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.repository.entity.RealmAuxData;
+import com.alphawallet.app.repository.entity.RealmToken;
 import com.alphawallet.app.repository.entity.RealmTransaction;
+import com.alphawallet.app.repository.entity.RealmTransfer;
 import com.alphawallet.app.service.RealmManager;
 
 import org.jetbrains.annotations.NotNull;
@@ -320,6 +322,40 @@ public class TransactionsRealmCache implements TransactionLocalSource {
             //do not record
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public Single<Boolean> deleteAllForWallet(String currentAddress)
+    {
+        return Single.fromCallable(() -> {
+            //delete all token and AUX data for this wallet
+            try (Realm instance = realmManager.getRealmInstance(new Wallet(currentAddress)))
+            {
+                instance.executeTransaction(r -> {
+                    RealmResults<RealmAuxData> data = r.where(RealmAuxData.class)
+                            .findAll();
+                    data.deleteAllFromRealm();
+
+                    RealmResults<RealmTransfer> realmTransfers = r.where(RealmTransfer.class)
+                            .findAll();
+                    realmTransfers.deleteAllFromRealm();
+
+                    RealmResults<RealmTransaction> realmTransactions = r.where(RealmTransaction.class)
+                            .findAll();
+                    realmTransactions.deleteAllFromRealm();
+
+                    RealmResults<RealmToken> realmTokens = r.where(RealmToken.class)
+                            .findAll();
+                    realmTokens.deleteAllFromRealm();
+                });
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     public static void fill(Realm realm, RealmTransaction item, Transaction transaction)

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -277,7 +277,7 @@ public class TokensService
                 .observeOn(Schedulers.newThread()).subscribe();
     }
 
-    private void stopUpdateCycle()
+    public void stopUpdateCycle()
     {
         if (eventTimer != null && !eventTimer.isDisposed())
         {

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
@@ -398,4 +398,13 @@ public class TransactionsService
             return null;
         }
     }
+
+    public Single<Boolean> wipeDataForWallet()
+    {
+        if (TextUtils.isEmpty(tokensService.getCurrentAddress())) return Single.fromCallable(() -> false);
+        tokensService.stopUpdateCycle();
+        stopAllChainUpdate();
+
+        return transactionsCache.deleteAllForWallet(tokensService.getCurrentAddress());
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
@@ -28,12 +28,16 @@ import com.alphawallet.app.widget.SettingsItemView;
 import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 
 import static com.alphawallet.app.C.CHANGED_LOCALE;
 import static com.alphawallet.app.C.CHANGE_CURRENCY;
 import static com.alphawallet.app.C.EXTRA_CURRENCY;
 import static com.alphawallet.app.C.EXTRA_LOCALE;
 import static com.alphawallet.app.C.EXTRA_STATE;
+import static com.alphawallet.app.C.RESET_WALLET;
 
 public class AdvancedSettingsActivity extends BaseActivity {
     @Inject
@@ -47,6 +51,10 @@ public class AdvancedSettingsActivity extends BaseActivity {
     private SettingsItemView tokenScriptManagement;
     private SettingsItemView changeCurrency;
     private SettingsItemView fullScreenSettings;
+    private SettingsItemView refreshTokenDatabase;
+
+    @Nullable
+    private Disposable clearTokenCache;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -64,6 +72,17 @@ public class AdvancedSettingsActivity extends BaseActivity {
         initializeSettings();
 
         addSettingsToLayout();
+    }
+
+    @Override
+    public void onDestroy()
+    {
+        super.onDestroy();
+        if (clearTokenCache != null && !clearTokenCache.isDisposed())
+        {
+            //terminate the thread
+            clearTokenCache.dispose();
+        }
     }
 
     private void initializeSettings() {
@@ -111,6 +130,12 @@ public class AdvancedSettingsActivity extends BaseActivity {
                         .withListener(this::onFullScreenClicked)
                         .build();
 
+        refreshTokenDatabase = new SettingsItemView.Builder(this)
+                .withIcon(R.drawable.ic_settings_reset_tokens)
+                .withTitle(R.string.title_reload_token_data)
+                .withListener(this::onReloadTokenDataClicked)
+                .build();
+
         changeLanguage.setSubtitle(LocaleUtils.getDisplayLanguage(viewModel.getActiveLocale(), viewModel.getActiveLocale()));
         fullScreenSettings.setToggleState(viewModel.getFullScreenState());
     }
@@ -132,6 +157,7 @@ public class AdvancedSettingsActivity extends BaseActivity {
         advancedSettingsLayout.addView(changeCurrency);
         advancedSettingsLayout.addView(tokenScriptManagement);
         advancedSettingsLayout.addView(fullScreenSettings);
+        advancedSettingsLayout.addView(refreshTokenDatabase);
     }
 
     private void onConsoleClicked() {
@@ -143,6 +169,25 @@ public class AdvancedSettingsActivity extends BaseActivity {
         webView.clearCache(true);
         Toast.makeText(this, getString(R.string.toast_browser_cache_cleared), Toast.LENGTH_SHORT).show();
         viewModel.blankFilterSettings();
+    }
+
+    private void onReloadTokenDataClicked() {
+        //delete all Token data for this wallet
+        clearTokenCache = viewModel.resetTokenData()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::showResetResult);
+
+        viewModel.blankFilterSettings();
+    }
+
+    private void showResetResult(Boolean resetResult)
+    {
+        if (resetResult)
+        {
+            Toast.makeText(this, getString(R.string.toast_token_data_cleared), Toast.LENGTH_SHORT).show();
+            sendBroadcast(new Intent(RESET_WALLET)); // refresh token and transaction lists
+        }
     }
 
     private void onTokenScriptClicked() {

--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -159,7 +159,6 @@ public class WalletFragment extends BaseFragment implements
         viewModel = new ViewModelProvider(this, walletViewModelFactory)
                 .get(WalletViewModel.class);
         viewModel.progress().observe(getViewLifecycleOwner(), systemView::showProgress);
-        //viewModel.error().observe(getViewLifecycleOwner(), this::onError);
         viewModel.tokens().observe(getViewLifecycleOwner(), this::onTokens);
         viewModel.backupEvent().observe(getViewLifecycleOwner(), this::backupEvent);
         viewModel.defaultWallet().observe(getViewLifecycleOwner(), this::onDefaultWallet);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
@@ -10,32 +10,34 @@ import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.service.TokensService;
+import com.alphawallet.app.service.TransactionsService;
 import com.alphawallet.app.ui.HomeActivity;
 import com.alphawallet.app.util.LocaleUtils;
 
 import java.io.File;
 import java.util.ArrayList;
 
+import io.reactivex.Single;
+
 public class AdvancedSettingsViewModel extends BaseViewModel {
     private final LocaleRepositoryType localeRepository;
     private final CurrencyRepositoryType currencyRepository;
     private final AssetDefinitionService assetDefinitionService;
     private final PreferenceRepositoryType preferenceRepository;
+    private final TransactionsService transactionsService;
 
     AdvancedSettingsViewModel(
             LocaleRepositoryType localeRepository,
             CurrencyRepositoryType currencyRepository,
             AssetDefinitionService assetDefinitionService,
-            PreferenceRepositoryType preferenceRepository) {
+            PreferenceRepositoryType preferenceRepository,
+            TransactionsService transactionsService) {
         this.localeRepository = localeRepository;
         this.currencyRepository = currencyRepository;
         this.assetDefinitionService = assetDefinitionService;
         this.preferenceRepository = preferenceRepository;
-    }
-
-    public String getUserPreferenceLocale()
-    {
-        return localeRepository.getUserPreferenceLocale();
+        this.transactionsService = transactionsService;
     }
 
     public ArrayList<LocaleItem> getLocaleList(Context context) {
@@ -105,5 +107,10 @@ public class AdvancedSettingsViewModel extends BaseViewModel {
     public void blankFilterSettings()
     {
         preferenceRepository.blankHasSetNetworkFilters();
+    }
+
+    public Single<Boolean> resetTokenData()
+    {
+        return transactionsService.wipeDataForWallet();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModelFactory.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModelFactory.java
@@ -8,22 +8,26 @@ import com.alphawallet.app.repository.CurrencyRepositoryType;
 import com.alphawallet.app.repository.LocaleRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
 import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.app.service.TransactionsService;
 
 public class AdvancedSettingsViewModelFactory implements ViewModelProvider.Factory {
     private final LocaleRepositoryType localeRepository;
     private final CurrencyRepositoryType currencyRepository;
     private final AssetDefinitionService assetDefinitionService;
     private final PreferenceRepositoryType preferenceRepository;
+    private final TransactionsService transactionsService;
 
     public AdvancedSettingsViewModelFactory(
             LocaleRepositoryType localeRepository,
             CurrencyRepositoryType currencyRepository,
             AssetDefinitionService assetDefinitionService,
-            PreferenceRepositoryType preferenceRepository) {
+            PreferenceRepositoryType preferenceRepository,
+            TransactionsService transactionsService) {
         this.localeRepository = localeRepository;
         this.currencyRepository = currencyRepository;
         this.assetDefinitionService = assetDefinitionService;
         this.preferenceRepository = preferenceRepository;
+        this.transactionsService = transactionsService;
     }
 
     @NonNull
@@ -33,7 +37,8 @@ public class AdvancedSettingsViewModelFactory implements ViewModelProvider.Facto
                 localeRepository,
                 currencyRepository,
                 assetDefinitionService,
-                preferenceRepository
+                preferenceRepository,
+                transactionsService
         );
     }
 }

--- a/app/src/main/res/drawable/ic_settings_reset_tokens.xml
+++ b/app/src/main/res/drawable/ic_settings_reset_tokens.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M20,20m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+      android:fillColor="#D8D8D8"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M20,40C8.954,40 0,31.046 0,20S8.954,0 20,0s20,8.954 20,20 -8.954,20 -20,20z"
+      android:fillColor="#FC3159"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M8,22.24c0,2.86 4.634,5.177 10.356,5.177h1.294c0,1.36 0.35,2.641 0.972,3.755l-2.266,0.13C12.634,31.301 8,28.982 8,26.122L8,22.24zM8,15.766c0,2.862 4.634,5.18 10.356,5.18 5.722,0 10.356,-2.318 10.356,-5.18v3.988l-1.295,-0.104c-3.352,0 -6.213,2.123 -7.3,5.101l-1.761,0.077C12.634,24.828 8,22.511 8,19.65v-3.884zM18.356,8c5.722,0 10.356,2.317 10.356,5.177 0,2.862 -4.634,5.18 -10.356,5.18C12.634,18.356 8,16.038 8,13.176 8,10.317 12.634,8 18.356,8zM22.835,24.673l1.838,-1.838 2.744,2.757 2.745,-2.745 1.825,1.826 -2.744,2.744L32,30.162 30.162,32l-2.745,-2.757 -2.744,2.744 -1.825,-1.825 2.744,-2.745 -2.757,-2.744z"
+      android:fillColor="#FFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -581,6 +581,7 @@
     <string name="title_faq">Preguntas frecuentes</string>
     <string name="title_console">Consola</string>
     <string name="title_clear_browser_cache">Borrar la caché del navegador</string>
+    <string name="title_reload_token_data">Recargar datos del Token</string>
     <string name="title_tokenscript">TokenScript</string>
     <string name="title_change_language">Cambiar idioma</string>
     <string name="add_hide_tokens">Añadir / Ocultar tokens</string>
@@ -589,6 +590,7 @@
     <string name="dialog_title_select_currency">Seleccionar moneda FÍAT</string>
     <string name="tokenscript_file_error">Error de archivo de TokenScript</string>
     <string name="toast_browser_cache_cleared">Caché del navegador borrada</string>
+    <string name="toast_token_data_cleared">Datos del Token borrados</string>
     <string name="your_wallets">Tus monederos</string>
     <string name="action_copy">Copiar</string>
     <string name="title_version_support_warning">Actualización importante</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -595,6 +595,7 @@
     <string name="title_faq">FAQ</string>
     <string name="title_console">Console</string>
     <string name="title_clear_browser_cache">Effacer le Cache du Navigateur</string>
+    <string name="title_reload_token_data">Recharger les données du Tokens</string>
     <string name="title_tokenscript">TokenScript</string>
     <string name="title_change_language">Changer Langue</string>
     <string name="add_hide_tokens">Ajouter / Cacher Tokens</string>
@@ -603,6 +604,7 @@
     <string name="dialog_title_select_currency">Selectionner Devise FIAT</string>
     <string name="tokenscript_file_error">TokenScript fichier erreur</string>
     <string name="toast_browser_cache_cleared">Cache Navigateur nettoyé</string>
+    <string name="toast_token_data_cleared">Données de Token effacées</string>
     <string name="your_wallets">Vos Portefeuilles</string>
     <string name="action_copy">Copier</string>
     <string name="title_version_support_warning">Mise à jour importante</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -581,6 +581,7 @@
     <string name="title_faq">常见问题</string>
     <string name="title_console">控制台</string>
     <string name="title_clear_browser_cache">清除浏览器缓存</string>
+    <string name="title_reload_token_data">重新加载通证数据</string>
     <string name="title_tokenscript">TokenScript</string>
     <string name="title_change_language">更换语言</string>
     <string name="add_hide_tokens">添加/隐藏通证</string>
@@ -589,6 +590,7 @@
     <string name="dialog_title_select_currency">选择法定货币</string>
     <string name="tokenscript_file_error">TokenScript 文件错误</string>
     <string name="toast_browser_cache_cleared">浏览器缓存已清除</string>
+    <string name="toast_token_data_cleared">通证数据已清除</string>
     <string name="your_wallets">您的钱包</string>
     <string name="action_copy">复制</string>
     <string name="title_version_support_warning">重要更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -598,6 +598,7 @@
     <string name="title_faq">FAQ</string>
     <string name="title_console">Console</string>
     <string name="title_clear_browser_cache">Clear Browser Cache</string>
+    <string name="title_reload_token_data">Reload Token Data</string>
     <string name="title_tokenscript">TokenScript</string>
     <string name="title_change_language">Change Language</string>
     <string name="add_hide_tokens">Add / Hide Tokens</string>
@@ -606,6 +607,7 @@
     <string name="dialog_title_select_currency">Select FIAT Currency</string>
     <string name="tokenscript_file_error">TokenScript file error</string>
     <string name="toast_browser_cache_cleared">Browser cache cleared</string>
+    <string name="toast_token_data_cleared">Token Data cleared</string>
     <string name="your_wallets">Your Wallets</string>
     <string name="action_copy">Copy</string>
     <string name="title_version_support_warning">Important Update</string>


### PR DESCRIPTION
Add ability to reset all cached token data. Very useful for testing and support - it's basically a 'switch it off and on again' for token visibility.