### PR TITLE
Fix to ensure all history items show correctly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
         //Put your Infura key here, NB with over 30 - 40 users this API key will rate limit, it's only here for bootstrapping a free build
         def DEFAULT_INFURA_API_KEY = "\"da3717f25f824cc1baa32d812386d93f\"";
 
-        buildConfigField 'int', 'DB_VERSION', '28'
+        buildConfigField 'int', 'DB_VERSION', '29'
         buildConfigField "String", XInfuraAPI, DEFAULT_INFURA_API_KEY
 
         ndk {

--- a/app/src/main/java/com/alphawallet/app/repository/AWRealmMigration.java
+++ b/app/src/main/java/com/alphawallet/app/repository/AWRealmMigration.java
@@ -302,6 +302,13 @@ public class AWRealmMigration implements RealmMigration
             }
             oldVersion++;
         }
+
+        if (oldVersion == 28)
+        {
+            RealmObjectSchema realmData = schema.get("RealmTransaction");
+            if (realmData != null && !realmData.hasField("contractAddress")) realmData.addField("contractAddress", String.class);
+            oldVersion++;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
@@ -265,7 +265,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
                     realmTx = r.createObject(RealmTransaction.class, tx.hash);
                 }
 
-                fill(r, realmTx, tx);
+                fill(realmTx, tx);
                 r.insertOrUpdate(realmTx);
             });
         }
@@ -289,7 +289,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
         {
             instance.executeTransactionAsync(r -> {
                 RealmTransaction item = r.createObject(RealmTransaction.class, ethTx.getHash());
-                fill(r, item, tx);
+                fill(item, tx);
                 r.insertOrUpdate(item);
             });
         }
@@ -359,7 +359,7 @@ public class TransactionsRealmCache implements TransactionLocalSource {
         });
     }
 
-    public static void fill(Realm realm, RealmTransaction item, Transaction transaction)
+    public static void fill(RealmTransaction item, Transaction transaction)
     {
         item.setError(transaction.error);
         item.setBlockNumber(transaction.blockNumber);

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransaction.java
@@ -19,7 +19,11 @@ public class RealmTransaction extends RealmObject {
     private String error;
     private int chainId;
     private long expectedCompletion;
-    //private RealmList<RealmTransactionOperation> operations;
+    private String contractAddress; // this is so we can efficiently lookup transactions relating to contracts,
+                                    // if we discovered them using the Etherscan 'Transfers' API.
+                                    // NB: only transactions discovered by the Transfers API will have this field.
+                                    // It allows us to lookup eg AirDrop tx's or Internal tx's that otherwise wouldn't
+                                    // be indexable via RealmDB.
 
     public String getHash() {
         return hash;
@@ -117,10 +121,6 @@ public class RealmTransaction extends RealmObject {
         this.error = error;
     }
 
-    /*public RealmList<RealmTransactionOperation> getOperations() {
-        return operations;
-    }*/
-
     public int getChainId()
     {
         return chainId;
@@ -144,5 +144,15 @@ public class RealmTransaction extends RealmObject {
     public void setExpectedCompletion(long expectedCompletion)
     {
         this.expectedCompletion = expectedCompletion;
+    }
+
+    public String getContractAddress()
+    {
+        return contractAddress;
+    }
+
+    public void setContractAddress(String contractAddress)
+    {
+        this.contractAddress = contractAddress;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -22,6 +22,7 @@ import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.repository.entity.RealmToken;
 import com.alphawallet.app.repository.entity.RealmTransaction;
 import com.alphawallet.app.repository.entity.RealmTransfer;
+import com.alphawallet.app.util.Utils;
 import com.alphawallet.token.entity.ContractAddress;
 import com.google.gson.Gson;
 
@@ -64,7 +65,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private final String BLOCK_ENTRY = "-erc20blockCheck-";
     private final String ERC20_QUERY = "tokentx";
     private final String ERC721_QUERY = "tokennfttx";
-    private final int AUX_DATABASE_ID = 22; //increment this to do a one off refresh the AUX database, in case of changed design etc
+    private final int AUX_DATABASE_ID = 23; //increment this to do a one off refresh the AUX database, in case of changed design etc
     private final String DB_RESET = BLOCK_ENTRY + AUX_DATABASE_ID;
     private final String ETHERSCAN_API_KEY = "&apikey=6U31FTHW3YYHKW6CYHKKGDPHI9HEJ9PU5F";
     private final String BSC_EXPLORER_API_KEY = getBSCExplorerKey().length() > 0 ? "&apikey=" + getBSCExplorerKey() : "";
@@ -195,16 +196,13 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         while (continueReading) // only SYNC_PAGECOUNT pages at a time for each check, to avoid congestion
         {
             EtherscanTransaction[] myTxs = readTransactions(networkInfo, walletAddress, tokenAddress, String.valueOf(startingBlockNumber), false, page++, PAGESIZE);
-            if (myTxs == null) break;
+            if (myTxs.length == 0) break;
             getRelatedTransactionList(txList, myTxs, walletAddress, networkInfo.chainId);
-            if (myTxs.length > 0 && firstTransaction == null)
+            if (firstTransaction == null)
             {
                 firstTransaction = myTxs[0];
             }
-            if (myTxs.length > 0)
-            {
-                lastTransaction = myTxs[myTxs.length - 1];
-            }
+            lastTransaction = myTxs[myTxs.length - 1];
 
             writeTransactions(instance, txList); //record transactions here
             writeUpdates(updates, txList);
@@ -241,7 +239,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
         //only sync upwards by 1 page. If not sufficient then reset; delete DB and start again
         EtherscanTransaction[] myTxs = readTransactions(networkInfo, walletAddress, tokenAddress, String.valueOf(lastBlockNumber), true, page, PAGESIZE);
-        if (myTxs == null || myTxs.length == 0) { return null; }
+        if (myTxs.length == 0) { return null; }
         else if (myTxs.length == PAGESIZE)
         {
             //too big, erase transaction list and start from top
@@ -329,7 +327,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                     realmTx = r.createObject(RealmTransaction.class, tx.hash);
                 }
 
-                TransactionsRealmCache.fill(r, realmTx, tx);
+                TransactionsRealmCache.fill(realmTx, tx);
                 r.insertOrUpdate(realmTx);
             }
         });
@@ -395,10 +393,12 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
                 response = httpClient.newCall(request).execute();
 
+                if (response.body() == null) return new EtherscanTransaction[0];
+
                 result = response.body().string();
                 if (result.length() < 80 && result.contains("No transactions found"))
                 {
-                    result = "0";
+                    return new EtherscanTransaction[0];
                 }
                 else
                 {
@@ -413,7 +413,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
             }
             catch (Exception e)
             {
-                e.printStackTrace();
+                if (BuildConfig.DEBUG) e.printStackTrace();
             }
         }
 
@@ -672,10 +672,12 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
             response = httpClient.newCall(request).execute();
 
+            if (response.body() == null) return new EtherscanTransaction[0];
+
             result = response.body().string();
-            if (result != null && result.length() < 80 && result.contains("No transactions found"))
+            if (result.length() < 80 && result.contains("No transactions found"))
             {
-                result = "0";
+                return new EtherscanTransaction[0];
             }
         }
         catch (InterruptedIOException e)
@@ -686,7 +688,8 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            if (BuildConfig.DEBUG) e.printStackTrace();
+            return new EtherscanTransaction[0];
         }
 
         return getEtherscanTransactionsFromCovalent(result, walletAddress, networkInfo);
@@ -908,16 +911,16 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                 //find tx name
                 String activityName = tx.getEventName(walletAddress);
                 String valueList = VALUES.replace(TO_TOKEN, ev.to).replace(FROM_TOKEN, ev.from).replace(AMOUNT_TOKEN, scanAsNFT ? ev.tokenID : ev.value); //Etherscan sometimes interprets NFT transfers as FT's
-                storeTransferData(r, tx.hash, valueList, activityName, ev.contractAddress, ev.timeStamp);
+                storeTransferData(r, tx.hash, valueList, activityName, ev.contractAddress);
                 //ensure we have fetched the transaction for each hash
-                writeTransaction(r, tx, txFetches);
+                writeTransaction(r, tx, ev.contractAddress, txFetches);
             }
         });
 
         fetchRequiredTransactions(instance, networkInfo.chainId, txFetches);
     }
 
-    private void storeTransferData(Realm instance, String hash, String valueList, String activityName, String tokenAddress, long timeStamp)
+    private void storeTransferData(Realm instance, String hash, String valueList, String activityName, String tokenAddress)
     {
         RealmTransfer matchingEntry = instance.where(RealmTransfer.class)
                 .equalTo("hash", hash)
@@ -928,11 +931,11 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
         if (matchingEntry == null) //prevent duplicates
         {
-            RealmTransfer realmToken = instance.createObject(RealmTransfer.class);
-            realmToken.setHash(hash);
-            realmToken.setTokenAddress(tokenAddress);
-            realmToken.setEventName(activityName);
-            realmToken.setTransferDetail(valueList);
+            RealmTransfer realmTransfer = instance.createObject(RealmTransfer.class);
+            realmTransfer.setHash(hash);
+            realmTransfer.setTokenAddress(tokenAddress);
+            realmTransfer.setEventName(activityName);
+            realmTransfer.setTransferDetail(valueList);
         }
         else
         {
@@ -947,7 +950,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
      * @param tx Transaction formed initially procedurally from the event, then from Ethereum node if we didn't already have it
      * @param txFetches build list of transactions that need fetching
      */
-    private void writeTransaction(Realm instance, Transaction tx, Map<String, Transaction> txFetches)
+    private void writeTransaction(Realm instance, Transaction tx, String contractAddress, Map<String, Transaction> txFetches)
     {
         RealmTransaction realmTx = instance.where(RealmTransaction.class)
                 .equalTo("hash", tx.hash)
@@ -960,10 +963,15 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
             //fetch the actual transaction here
             if (txFetches != null) txFetches.put(tx.hash, tx);
         }
+        else if (realmTx.getContractAddress() == null || !realmTx.getContractAddress().equalsIgnoreCase(contractAddress))
+        {
+            realmTx.setContractAddress(contractAddress);
+        }
 
         if (realmTx.getInput() == null || realmTx.getInput().length() <= 10 || txFetches == null)
         {
-            TransactionsRealmCache.fill(instance, realmTx, tx);
+            TransactionsRealmCache.fill(realmTx, tx);
+            realmTx.setContractAddress(contractAddress); //for indexing by contract (eg Token Activity)
         }
     }
 
@@ -985,9 +993,10 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                 {
                     EthTransaction etx = EventUtils.getTransactionDetails(tx.hash, web3j).blockingGet();
                     Transaction newTx = new Transaction(etx.getResult(), tx.chainId, true, tx.timeStamp);
+                    //when we create placeholder tx, we put token contract address in the 'to' member - tx.to holds contract address
                     if (!TextUtils.isEmpty(newTx.input) && newTx.input.length() > 2)
                     {
-                        writeTransaction(r, newTx, null);
+                        writeTransaction(r, newTx, tx.to, null);
                     }
                 }
                 catch (Exception e)

--- a/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ActivityFragment.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.ui;
 
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
@@ -57,7 +58,7 @@ public class ActivityFragment extends BaseFragment implements View.OnClickListen
     private RecyclerView listView;
     private Realm realm;
     private RealmResults<RealmTransaction> realmUpdates;
-    private final Handler handler = new Handler();
+    private final Handler handler = new Handler(Looper.getMainLooper());
     private boolean checkTimer;
     private long lastUpdateTime = 0;
 
@@ -181,7 +182,7 @@ public class ActivityFragment extends BaseFragment implements View.OnClickListen
         listView.setLayoutManager(new LinearLayoutManager(getContext()));
         listView.setAdapter(adapter);
         listView.addItemDecoration(new RecycleViewDivider(getContext()));
-        listView.setRecyclerListener(holder -> adapter.onRViewRecycled(holder));
+        listView.addRecyclerListener(holder -> adapter.onRViewRecycled(holder));
 
         systemView.attachRecyclerView(listView);
         systemView.attachSwipeRefreshLayout(refreshLayout);

--- a/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/Erc20DetailActivity.java
@@ -61,8 +61,6 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
     private Wallet wallet;
     private Token token;
     private TokenCardMeta tokenMeta;
-
-    private FunctionButtonBar functionBar;
     private RecyclerView tokenView;
     private CertifiedToolbarView toolbarView;
 
@@ -156,7 +154,7 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
     {
         if (BuildConfig.DEBUG || wallet.type != WalletType.WATCH)
         {
-            functionBar = findViewById(R.id.layoutButtons);
+            FunctionButtonBar functionBar = findViewById(R.id.layoutButtons);
             functionBar.setupBuyFunction(this, viewModel.getOnRampRepository());
             functionBar.setupFunctions(this, viewModel.getAssetDefinitionService(), token, null, null);
             functionBar.revealButtons();
@@ -275,6 +273,7 @@ public class Erc20DetailActivity extends BaseActivity implements StandardFunctio
             if (activityHistoryList != null)
             {
                 //reset the transaction history
+                activityHistoryList.resetAdapter();
                 activityHistoryList.startActivityListeners(viewModel.getRealmInstance(wallet), wallet,
                         token, viewModel.getTokensService(), BigInteger.ZERO, HISTORY_LENGTH);
             }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
@@ -246,7 +246,7 @@ public class TransactionDetailViewModel extends BaseViewModel {
                     .findFirst();
 
             if (realmTx == null) realmTx = instance.createObject(RealmTransaction.class, tx.hash);
-            TransactionsRealmCache.fill(instance, realmTx, tx);
+            TransactionsRealmCache.fill(realmTx, tx);
             instance.commitTransaction();
         }
         catch (Exception e)

--- a/app/src/main/java/com/alphawallet/app/widget/ActivityHistoryList.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActivityHistoryList.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.widget;
 
 import android.content.Context;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -20,8 +21,10 @@ import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.repository.entity.RealmTransaction;
+import com.alphawallet.app.repository.entity.RealmTransfer;
 import com.alphawallet.app.service.TokensService;
 import com.alphawallet.app.ui.widget.adapter.ActivityAdapter;
+import com.alphawallet.app.ui.widget.entity.TokenTransferData;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -45,12 +48,11 @@ public class ActivityHistoryList extends LinearLayout
     private Realm realm;
     private RealmResults<RealmTransaction> realmTransactionUpdates;
     private RealmQuery<RealmTransaction> realmUpdateQuery;
-    private RealmResults<RealmAuxData> auxRealmUpdates;
     @Nullable private Disposable updateCheck; //performs a background check to ensure we get completion
     private final RecyclerView recentTransactionsView;
     private final LinearLayout noTxNotice;
     private final ProgressBar loadingTransactions;
-    private final Handler handler = new Handler();
+    private final Handler handler = new Handler(Looper.getMainLooper());
     private final Context context;
 
     public ActivityHistoryList(Context context, @Nullable AttributeSet attrs)
@@ -79,7 +81,6 @@ public class ActivityHistoryList extends LinearLayout
 
         //stop any existing listeners (could be view refresh)
         if (realmTransactionUpdates != null) realmTransactionUpdates.removeAllChangeListeners();
-        if (auxRealmUpdates != null) auxRealmUpdates.removeAllChangeListeners();
 
         if (!token.isEthereum() || svs.isChainToken(token.tokenInfo.chainId, token.getAddress()))
         {
@@ -95,19 +96,7 @@ public class ActivityHistoryList extends LinearLayout
         realmTransactionUpdates = realmUpdateQuery.findAllAsync();
 
         //handle updated realm transactions
-        realmTransactionUpdates.addChangeListener(this::handleRealmTransactions);
-
-        auxRealmUpdates = RealmAuxData.getEventListener(realm, token, tokenId, historyCount, 0);
-        auxRealmUpdates.addChangeListener(realmEvents -> {
-            List<ActivityMeta> metas = new ArrayList<>();
-            for (RealmAuxData item : realmEvents)
-            {
-                EventMeta newMeta = new EventMeta(item.getTransactionHash(), item.getEventName(), item.getFunctionId(), item.getResultTime(), item.getChainId());
-                metas.add(newMeta);
-            }
-
-            addItems(metas);
-        });
+        realmTransactionUpdates.addChangeListener(result -> handleRealmTransactions(result, wallet));
     }
 
     public boolean resetAdapter()
@@ -123,7 +112,7 @@ public class ActivityHistoryList extends LinearLayout
         }
     }
 
-    private void handleRealmTransactions(RealmResults<RealmTransaction> realmTransactions)
+    private void handleRealmTransactions(RealmResults<RealmTransaction> realmTransactions, Wallet wallet)
     {
         boolean hasPending = false;
         List<ActivityMeta> metas = new ArrayList<>();
@@ -131,6 +120,7 @@ public class ActivityHistoryList extends LinearLayout
         {
             TransactionMeta tm = new TransactionMeta(item.getHash(), item.getTimeStamp(), item.getTo(), item.getChainId(), item.getBlockNumber());
             metas.add(tm);
+            metas.addAll(getRelevantTransfersForHash(tm, wallet));
             if (tm.isPending) hasPending = true;
         }
 
@@ -138,12 +128,48 @@ public class ActivityHistoryList extends LinearLayout
 
         if (hasPending)
         {
-            startUpdateCheck();
+            startUpdateCheck(wallet);
         }
         else
         {
             stopUpdateCheck();
         }
+    }
+
+    private List<TokenTransferData> getRelevantTransfersForHash(TransactionMeta tm, Wallet wallet)
+    {
+        List<TokenTransferData> transferData = new ArrayList<>();
+        //summon realm items
+        //get matching entries for this transaction
+        RealmResults<RealmTransfer> transfers = realm.where(RealmTransfer.class)
+                .equalTo("hash", tm.hash)
+                .findAll();
+
+        if (transfers != null && transfers.size() > 0)
+        {
+            //list of transfers, descending in time to give ordered list
+            long nextTransferTime = transfers.size() == 1 ? tm.getTimeStamp() : tm.getTimeStamp() - 1; // if there's only 1 transfer, keep the transaction timestamp
+            for (RealmTransfer rt : transfers)
+            {
+                if (rt.getTransferDetail().contains(wallet.address))
+                {
+                    TokenTransferData ttd = new TokenTransferData(rt.getHash(), tm.chainId,
+                            rt.getTokenAddress(), rt.getEventName(), rt.getTransferDetail(), nextTransferTime);
+                    transferData.add(ttd);
+                    nextTransferTime--;
+                }
+            }
+
+            //For clarity, show only 1 item if it was part of a chain; ie don't show raw transaction
+            if (transfers.size() > 1 && transferData.size() == 1)
+            {
+                TokenTransferData oldTf = transferData.get(0);
+                transferData.clear();
+                transferData.add(new TokenTransferData(oldTf.hash, tm.chainId, oldTf.tokenAddress, oldTf.eventName, oldTf.transferDetail, tm.getTimeStamp()));
+            }
+        }
+
+        return transferData;
     }
 
     private void initViews(boolean isEth)
@@ -166,7 +192,8 @@ public class ActivityHistoryList extends LinearLayout
     {
         return realm.where(RealmTransaction.class)
                 .sort("timeStamp", Sort.DESCENDING)
-                .beginGroup().not().equalTo("input", "0x").and().equalTo("to", tokenAddress, Case.INSENSITIVE).endGroup()
+                .beginGroup().not().equalTo("input", "0x").and().equalTo("to", tokenAddress, Case.INSENSITIVE)
+                             .or().equalTo("contractAddress", tokenAddress).endGroup()
                 .equalTo("chainId", chainId)
                 .limit(count);
     }
@@ -205,7 +232,6 @@ public class ActivityHistoryList extends LinearLayout
     public void onDestroy()
     {
         if (realmTransactionUpdates != null) realmTransactionUpdates.removeAllChangeListeners();
-        if (auxRealmUpdates != null) auxRealmUpdates.removeAllChangeListeners();
         if (realm != null && !realm.isClosed()) realm.close();
         handler.removeCallbacksAndMessages(null);
         stopUpdateCheck();
@@ -213,12 +239,12 @@ public class ActivityHistoryList extends LinearLayout
     }
 
     //Start update check on the database if anything is pending. Sometimes the listener doesn't pick up the change.
-    private void startUpdateCheck()
+    private void startUpdateCheck(final Wallet wallet)
     {
         if (updateCheck == null || updateCheck.isDisposed())
         {
             updateCheck = Observable.interval(0, 10, TimeUnit.SECONDS)
-                    .doOnNext(l -> checkTransactions()).subscribe();
+                    .doOnNext(l -> checkTransactions(wallet)).subscribe();
         }
     }
 
@@ -228,13 +254,13 @@ public class ActivityHistoryList extends LinearLayout
         updateCheck = null;
     }
 
-    private void checkTransactions()
+    private void checkTransactions(final Wallet wallet)
     {
         if (realmUpdateQuery != null)
         {
             handler.post(() -> {
                 RealmResults<RealmTransaction> rTx = realmUpdateQuery.findAll();
-                handleRealmTransactions(rTx);
+                handleRealmTransactions(rTx, wallet);
             });
         }
     }


### PR DESCRIPTION
Small refactor and add indexable item to transaction DB to allow finding internal transactions for contracts.

The fixes the old issue of internal transactions which occur as part of a transaction chain not appearing in the Activity history list for tokens (Clicking on an ERC20 token).