### PR TITLE
Add a CODEOWNERS file to have default reviewers for PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JamesSmartCell


### PR DESCRIPTION
Closes #2108 

When a new PR is created without explicitly assigning a reviewer, the users listed will be automatically added.