### PR TITLE
BSC Token Logo's Fix

### DIFF
--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -864,7 +864,7 @@ public class Utils {
                 repoChain = "poa";
                 break;
             case BINANCE_MAIN_ID:
-                repoChain = "binance";
+                repoChain = "smartchain";
                 break;
             case AVALANCHE_ID:
                 repoChain = "avalanche";


### PR DESCRIPTION
BSC Token logos was not showing due to wrong ripo pointing, Fixed