### PR TITLE
Refresh Ticker Database when switching currency.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionLocalSource.java
@@ -34,4 +34,6 @@ public interface TransactionLocalSource {
     long fetchTxCompletionTime(Wallet wallet, String hash);
 
     Single<Boolean> deleteAllForWallet(String currentAddress);
+
+    Single<Boolean> deleteAllTickers();
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionsRealmCache.java
@@ -31,6 +31,7 @@ import io.realm.RealmResults;
 import io.realm.Sort;
 
 import static com.alphawallet.app.repository.TokensRealmSource.EVENT_CARDS;
+import static com.alphawallet.app.repository.TokensRealmSource.TICKER_DB;
 
 public class TransactionsRealmCache implements TransactionLocalSource {
 
@@ -327,6 +328,24 @@ public class TransactionsRealmCache implements TransactionLocalSource {
             //do not record
             if (BuildConfig.DEBUG) e.printStackTrace();
         }
+    }
+
+    @Override
+    public Single<Boolean> deleteAllTickers()
+    {
+        return Single.fromCallable(() -> {
+            try (Realm instance = realmManager.getRealmInstance(TICKER_DB))
+            {
+                instance.executeTransaction(r -> instance.deleteAll());
+                instance.refresh();
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
@@ -411,4 +411,9 @@ public class TransactionsService
 
         return transactionsCache.deleteAllForWallet(tokensService.getCurrentAddress());
     }
+
+    public Single<Boolean> wipeTickerData()
+    {
+        return transactionsCache.deleteAllTickers();
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
@@ -5,6 +5,7 @@ import static com.alphawallet.app.C.CHANGE_CURRENCY;
 import static com.alphawallet.app.C.EXTRA_CURRENCY;
 import static com.alphawallet.app.C.EXTRA_LOCALE;
 import static com.alphawallet.app.C.EXTRA_STATE;
+import static com.alphawallet.app.C.PAGE_LOADED;
 import static com.alphawallet.app.C.RESET_WALLET;
 
 import android.Manifest;
@@ -302,10 +303,16 @@ public class AdvancedSettingsActivity extends BaseActivity {
         //Check if selected currency code is previous selected one then don't update
         if(viewModel.getDefaultCurrency().equals(currencyCode)) return;
 
-        viewModel.updateCurrency(currencyCode);
-
-        //send broadcast to HomeActivity about change
-        sendBroadcast(new Intent(CHANGE_CURRENCY));
+        viewModel.updateCurrency(currencyCode)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(res -> {
+                    Intent intent = new Intent();
+                    setResult(RESULT_OK, intent);
+                    intent.putExtra(CHANGE_CURRENCY, true);
+                    finish();
+                })
+        .isDisposed();
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -78,6 +78,7 @@ import dagger.android.AndroidInjection;
 
 import static androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE;
 import static com.alphawallet.app.C.CHANGED_LOCALE;
+import static com.alphawallet.app.C.CHANGE_CURRENCY;
 import static com.alphawallet.app.C.RESET_WALLET;
 import static com.alphawallet.app.entity.WalletPage.ACTIVITY;
 import static com.alphawallet.app.entity.WalletPage.DAPP_BROWSER;
@@ -318,6 +319,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
 
         getSupportFragmentManager()
                 .setFragmentResultListener(RESET_WALLET, this, (requestKey, b) -> showAndRefreshWallet());
+
+        getSupportFragmentManager()
+                .setFragmentResultListener(CHANGE_CURRENCY, this, (k, b) -> {
+                    viewModel.updateTickers();
+                    showAndRefreshWallet();
+                });
     }
 
     private void onBackup(String address)
@@ -833,11 +840,11 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         if (Utils.isAddressValid(keyAddress)) backupWalletSuccess(keyAddress);
     }
 
+    //Deprecated
     @Override
     public void changeCurrency()
     {
-        ((WalletFragment) walletFragment).indicateFetch();
-        viewModel.updateTickers();
+
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NewSettingsFragment.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.ui;
 
 
 import static android.app.Activity.RESULT_OK;
+import static com.alphawallet.app.C.CHANGE_CURRENCY;
 import static com.alphawallet.app.C.Key.WALLET;
 import static com.alphawallet.app.C.RESET_WALLET;
 import static com.alphawallet.app.entity.BackupOperationType.BACKUP_HD_KEY;
@@ -510,9 +511,14 @@ public class NewSettingsFragment extends BaseFragment {
     ActivityResultLauncher<Intent> advancedSettingsHandler = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
             result -> {
                 Intent data = result.getData();
-                if (data != null && data.getBooleanExtra(RESET_WALLET, false))
+                if (data == null) return;
+                if (data.getBooleanExtra(RESET_WALLET, false))
                 {
                     getParentFragmentManager().setFragmentResult(RESET_WALLET, new Bundle());
+                }
+                else if (data.getBooleanExtra(CHANGE_CURRENCY, false))
+                {
+                    getParentFragmentManager().setFragmentResult(CHANGE_CURRENCY, new Bundle());
                 }
             });
 

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AdvancedSettingsViewModel.java
@@ -65,8 +65,10 @@ public class AdvancedSettingsViewModel extends BaseViewModel {
         return currencyRepository.getCurrencyList();
     }
 
-    public void updateCurrency(String currencyCode){
+    public Single<Boolean> updateCurrency(String currencyCode){
         currencyRepository.setDefaultCurrency(currencyCode);
+        //delete tickers from realm
+        return transactionsService.wipeTickerData();
     }
 
     public boolean createDirectory() {


### PR DESCRIPTION
- Delete all tickers when we update the currency, restart ticker service.
- switch to correct fragment comms.