### PR TITLE
Fix walletconnect from remote browser

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
@@ -2,22 +2,17 @@ package com.alphawallet.app.ui;
 
 import static com.alphawallet.app.C.DEFAULT_GAS_LIMIT_FOR_NONFUNGIBLE_TOKENS;
 
-import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
-import android.hardware.SensorManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.MenuItem;
-import android.view.OrientationEventListener;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -632,7 +627,6 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
         }
     }
 
-
     ActivityResultLauncher<Intent> getNetwork = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
             result -> {
                 chainIdOverride = result.getData().getIntExtra(C.EXTRA_CHAIN_ID, 1);
@@ -647,7 +641,7 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
         String[] accounts = {viewModel.getWallet().address};
         String displayIcon = (peer.getIcons().size() > 0) ? peer.getIcons().get(0) : DEFAULT_IDON;
 
-        chainIdOverride = chainIdOverride > 0 ? chainIdOverride : chainId;
+        chainIdOverride = chainIdOverride > 0 ? chainIdOverride : (chainId > 0 ? chainId : com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID);
 
         Glide.with(this)
                 .load(displayIcon)


### PR DESCRIPTION
Fixes issue reported from dev forum:

- Open Wallet connect powered dapp in app browser eg Opera, Brave etc
- Start Wallet Connect session.
- Open session in AlphaWallet (First issue)
- Go back to app browser and issue request (sign/send transaction)
- Request will be invalid due to incorrect chain (Second issue)