### PR TITLE
Add the chain icon into the TokenIcon widget

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectSessionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectSessionActivity.java
@@ -29,6 +29,7 @@ import com.alphawallet.app.C;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.walletconnect.WalletConnectSessionItem;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.ui.QRScanning.QRScanner;
 import com.alphawallet.app.ui.widget.divider.ListDivider;
 import com.alphawallet.app.viewmodel.WalletConnectViewModel;
@@ -169,7 +170,7 @@ public class WalletConnectSessionActivity extends BaseActivity
             final TextView peerName;
             final TextView peerUrl;
             final LinearLayout clickLayer;
-            final ChainName chainName;
+            final ImageView chainIcon;
 
             CustomViewHolder(View view)
             {
@@ -179,7 +180,9 @@ public class WalletConnectSessionActivity extends BaseActivity
                 peerName = view.findViewById(R.id.session_name);
                 peerUrl = view.findViewById(R.id.session_url);
                 clickLayer = view.findViewById(R.id.item_layout);
-                chainName = view.findViewById(R.id.chain_name);
+                chainIcon = view.findViewById(R.id.chain_icon);
+                chainIcon.setVisibility(View.VISIBLE);
+                view.findViewById(R.id.chain_icon_background).setVisibility(View.VISIBLE);
             }
         }
 
@@ -194,7 +197,7 @@ public class WalletConnectSessionActivity extends BaseActivity
                     .into(holder.icon);
             holder.peerName.setText(session.name);
             holder.peerUrl.setText(session.url);
-            holder.chainName.setChainID(session.chainId);
+            holder.chainIcon.setImageResource(EthereumNetworkRepository.getChainLogo(session.chainId));
             holder.clickLayer.setOnClickListener(v -> {
                 //go to wallet connect session page
                 Intent intent = new Intent(getApplication(), WalletConnectActivity.class);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -1,16 +1,12 @@
 package com.alphawallet.app.ui.widget.holder;
 
-import android.app.Activity;
-import android.graphics.Color;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
+
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -24,8 +20,6 @@ import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenCardMeta;
 import com.alphawallet.app.entity.tokens.TokenTicker;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
-import com.alphawallet.app.repository.TokensRealmSource;
-import com.alphawallet.app.repository.entity.RealmTokenTicker;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.service.TickerService;
 import com.alphawallet.app.service.TokensService;
@@ -35,11 +29,6 @@ import com.alphawallet.app.widget.TokenIcon;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-
-import io.realm.Realm;
-import io.realm.RealmResults;
-
-import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 
 public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View.OnClickListener, View.OnLongClickListener {
 
@@ -121,6 +110,7 @@ public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View
             primaryElement = false;
 
             tokenIcon.bindData(token, assetDefinition);
+            //if (!token.isEthereum()) tokenIcon.setChainIcon(token.tokenInfo.chainId); //Add in when we upgrade the design
             tokenIcon.setOnTokenClickListener(onTokenClickListener);
 
 

--- a/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
@@ -49,6 +49,8 @@ public class TokenIcon extends ConstraintLayout
     private final ImageView statusIcon;
     private final ProgressBar pendingProgress;
     private final ImageView statusBackground;
+    private final ImageView chainIcon;
+    private final ImageView chainIconBackground;
 
     private OnTokenClickListener onTokenClickListener;
     private Token token;
@@ -72,6 +74,8 @@ public class TokenIcon extends ConstraintLayout
         statusBackground = findViewById(R.id.status_icon_background);
         statusIcon.setVisibility(isInEditMode() ? View.VISIBLE : View.GONE);
         currentStatus = StatusType.NONE;
+        chainIcon = findViewById(R.id.chain_icon);
+        chainIconBackground = findViewById(R.id.chain_icon_background);
 
         bindViews();
 
@@ -136,8 +140,17 @@ public class TokenIcon extends ConstraintLayout
         this.token = token;
 
         statusBackground.setVisibility(View.GONE);
+        chainIconBackground.setVisibility(View.GONE);
+        chainIcon.setVisibility(View.GONE);
 
         displayTokenIcon(iconItem);
+    }
+
+    public void setChainIcon(long chainId)
+    {
+        chainIconBackground.setVisibility(View.VISIBLE);
+        chainIcon.setVisibility(View.VISIBLE);
+        chainIcon.setImageResource(EthereumNetworkRepository.getChainLogo(chainId));
     }
 
     private void setupDefaultIcon(boolean loadFailed)

--- a/app/src/main/res/layout/item_token_icon.xml
+++ b/app/src/main/res/layout/item_token_icon.xml
@@ -16,6 +16,13 @@
         app:layout_constraintGuide_percent="0.98" />
 
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineLeft"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.00" />
+
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineBottom"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -55,14 +62,28 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.59" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineRightMid"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.55" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineLeftMid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.45" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineBottom2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.965" />
 
     <ImageView
         android:id="@+id/circle"
@@ -71,6 +92,7 @@
         android:contentDescription="@string/empty"
         android:src="@drawable/grey_circle"
         android:visibility="gone"
+        tools:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/guidelineInnerBottom"
         app:layout_constraintEnd_toStartOf="@id/guidelineInnerRight"
         app:layout_constraintStart_toEndOf="@id/guidelineInnerLeft"
@@ -125,7 +147,7 @@
         app:layout_constraintEnd_toStartOf="@id/guidelineRight"
         app:layout_constraintTop_toTopOf="@id/guidelineBottomMid"
         app:layout_constraintStart_toEndOf="@id/guidelineRightMid"
-        app:layout_constraintBottom_toTopOf="@id/guidelineBottom" />
+        app:layout_constraintBottom_toTopOf="@id/guidelineBottom2" />
 
     <ImageView
         android:id="@+id/status_icon"
@@ -137,7 +159,33 @@
         app:layout_constraintEnd_toStartOf="@id/guidelineRight"
         app:layout_constraintTop_toTopOf="@id/guidelineBottomMid"
         app:layout_constraintStart_toEndOf="@id/guidelineRightMid"
-        app:layout_constraintBottom_toTopOf="@id/guidelineBottom" />
+        app:layout_constraintBottom_toTopOf="@id/guidelineBottom2" />
+
+    <ImageView
+        android:id="@+id/chain_icon_background"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:contentDescription="@string/empty"
+        android:src="@drawable/grey_circle"
+        app:layout_constraintEnd_toStartOf="@id/guidelineLeftMid"
+        app:layout_constraintTop_toTopOf="@id/guidelineBottomMid"
+        app:layout_constraintStart_toEndOf="@id/guidelineLeft"
+        app:layout_constraintBottom_toTopOf="@id/guidelineBottom2" />
+
+    <ImageView
+        android:id="@+id/chain_icon"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/empty"
+        android:src="@drawable/ic_kovan"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/guidelineBottom2"
+        app:layout_constraintEnd_toStartOf="@id/guidelineLeftMid"
+        app:layout_constraintStart_toEndOf="@id/guidelineLeft"
+        app:layout_constraintTop_toTopOf="@id/guidelineBottomMid"
+        tools:visibility="visible" />
 
     <ProgressBar
         android:id="@+id/pending_progress"

--- a/app/src/main/res/layout/item_wc_session.xml
+++ b/app/src/main/res/layout/item_wc_session.xml
@@ -50,13 +50,4 @@
 
     </LinearLayout>
 
-
-    <com.alphawallet.app.widget.ChainName
-        android:id="@+id/chain_name"
-        android:layout_gravity="center_vertical|end"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="visible"
-        custom:font_size="12" />
-
 </LinearLayout>


### PR DESCRIPTION
Closes #2213, includes the functionality to add the chainIcons in the bottom corner to all instances of TokenIcon widget, eg in the Wallet page and Activity page.

Note - this is currently switched off, but can be switched on by uncommenting a line in TokenHolder