### PR TITLE
Rename element to avoid duplication names in 3 layout files, it may c…

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
@@ -74,7 +74,7 @@ public class TokenIcon extends ConstraintLayout
         statusBackground = findViewById(R.id.status_icon_background);
         statusIcon.setVisibility(isInEditMode() ? View.VISIBLE : View.GONE);
         currentStatus = StatusType.NONE;
-        chainIcon = findViewById(R.id.chain_icon);
+        chainIcon = findViewById(R.id.iv_chain_icon);
         chainIconBackground = findViewById(R.id.chain_icon_background);
 
         bindViews();

--- a/app/src/main/res/layout/item_token_icon.xml
+++ b/app/src/main/res/layout/item_token_icon.xml
@@ -175,7 +175,7 @@
         app:layout_constraintBottom_toTopOf="@id/guidelineBottom2" />
 
     <ImageView
-        android:id="@+id/chain_icon"
+        android:id="@+id/iv_chain_icon"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/empty"


### PR DESCRIPTION
…ause

ClassCastException

Different types have the same name.
<img width="457" alt="image" src="https://user-images.githubusercontent.com/735708/142754964-8f05b0b2-93aa-4f1a-b041-c8ad013689e0.png">

<img width="455" alt="image" src="https://user-images.githubusercontent.com/735708/142754868-0e69f2a5-0904-4e7d-beb5-ea3428ea4c3d.png">

I think have a type prefix is good name convention, like the `text_` below .
<img width="462" alt="image" src="https://user-images.githubusercontent.com/735708/142754905-9c3ec2f8-aa18-4c49-b389-cead4abcdb20.png">
