### PR TITLE
Ensure Polygon NFT transfers are picked up

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
+++ b/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
@@ -54,7 +54,7 @@ public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
 
     public boolean usesSeparateNFTTransferQuery()
     {
-        return (etherscanAPI != null && !etherscanAPI.contains(BLOCKSCOUT_API) && !etherscanAPI.contains(MATIC_API)
+        return (etherscanAPI != null && !etherscanAPI.contains(BLOCKSCOUT_API)
                 && !etherscanAPI.contains(COVALENT) && !etherscanAPI.contains(PALM_API));
     }
 

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -66,7 +66,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private final String BLOCK_ENTRY = "-erc20blockCheck-";
     private final String ERC20_QUERY = "tokentx";
     private final String ERC721_QUERY = "tokennfttx";
-    private final int AUX_DATABASE_ID = 23; //increment this to do a one off refresh the AUX database, in case of changed design etc
+    private final int AUX_DATABASE_ID = 25; //increment this to do a one off refresh the AUX database, in case of changed design etc
     private final String DB_RESET = BLOCK_ENTRY + AUX_DATABASE_ID;
     private final String ETHERSCAN_API_KEY;
     private final String BSC_EXPLORER_API_KEY;
@@ -850,7 +850,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     {
         try
         {
-            instance.executeTransactionAsync(r -> {
+            instance.executeTransaction(r -> {
                 RealmToken realmToken = r.where(RealmToken.class)
                         .equalTo("address", databaseKey(chainId, walletAddress))
                         .findFirst();


### PR DESCRIPTION
Overall fix for Polygon NFTs not showing up.

@hboon Polygonscan updated their API code, it now takes the `action=tokennfttx` switch same as Etherscan.