### PR TITLE
Use Polygonscan API key for transaction checks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ android {
         //Put your Infura key here, NB with over 30 - 40 users this API key will rate limit, it's only here for bootstrapping a free build
         def DEFAULT_INFURA_API_KEY = "\"da3717f25f824cc1baa32d812386d93f\""
         def DEFAULT_OPENSEA_API_KEY = "\"...\""; //Put your OpenSea developer API key in here, otherwise you are reliant on the backup NFT fetch method
+        def DEFAULT_POLYGONSCAN_API_KEY = "\"\""; //Put your Polygonscan developer API key in here to get access to Polygon/Mumbai token discovery and transactions
 
         buildConfigField 'int', 'DB_VERSION', '40'
         buildConfigField "String", XInfuraAPI, DEFAULT_INFURA_API_KEY
@@ -61,6 +62,7 @@ android {
             cmake {
                 cFlags "-DIFKEY=\\\"" + DEFAULT_INFURA_API_KEY + "\\\""
                 cFlags "-DOSKEY=\\\"" + DEFAULT_OPENSEA_API_KEY + "\\\""
+                cFlags "-DPSKEY=\\\"" + DEFAULT_POLYGONSCAN_API_KEY + "\\\""
             }
         }
     }

--- a/app/src/main/cpp/keys.c
+++ b/app/src/main/cpp/keys.c
@@ -21,6 +21,12 @@
 #   define HAS_OS 0
 #endif
 
+#ifdef PSKEY
+#   define HAS_PS 1
+#else
+#   define HAS_PS 0
+#endif
+
 JNIEXPORT jstring JNICALL
 Java_com_alphawallet_app_repository_EthereumNetworkBase_getAmberDataKey( JNIEnv* env, jobject thiz )
 {
@@ -159,10 +165,18 @@ JNIEXPORT jstring JNICALL
 Java_com_alphawallet_app_service_GasService_getPolygonScanKey(JNIEnv *env, jobject thiz) {
 #if (HAS_KEYS == 1)
     return getDecryptedKey(env, polygonScanKey);
+#elif (HAS_PS == 1)
+    return (*env)->NewStringUTF(env, PSKEY);
 #else
     const jstring key = "";
     return (*env)->NewStringUTF(env, key);
 #endif
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_alphawallet_app_service_TransactionsNetworkClient_getPolygonScanKey( JNIEnv* env, jclass thiz )
+{
+    return Java_com_alphawallet_app_service_GasService_getPolygonScanKey(env, thiz);
 }
 
 JNIEXPORT jstring JNICALL

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -629,11 +629,6 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         String result = "0";
         if (currentBlock == 0) currentBlock = 1;
 
-        if (networkInfo.chainId == MATIC_ID)
-        {
-            System.out.println("YOLESS");
-        }
-
         String APIKEY_TOKEN = getNetworkAPIToken(networkInfo);
         String fullUrl = networkInfo.etherscanAPI + "module=account&action=" + queryType +
                 "&startblock=" + currentBlock + "&endblock=9999999999" +

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -629,12 +629,11 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         String result = "0";
         if (currentBlock == 0) currentBlock = 1;
 
-        String APIKEY_TOKEN = getNetworkAPIToken(networkInfo);
         String fullUrl = networkInfo.etherscanAPI + "module=account&action=" + queryType +
                 "&startblock=" + currentBlock + "&endblock=9999999999" +
                 "&address=" + walletAddress +
                 "&page=1&offset=" + TRANSFER_RESULT_MAX +
-                "&sort=asc" + APIKEY_TOKEN;
+                "&sort=asc" + getNetworkAPIToken(networkInfo);
 
         Request request = new Request.Builder()
                 .url(fullUrl)

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -54,6 +54,8 @@ import static com.alphawallet.app.repository.TokensRealmSource.databaseKey;
 import static com.alphawallet.ethereum.EthereumNetworkBase.ARTIS_TAU1_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.BINANCE_MAIN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.BINANCE_TEST_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MATIC_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MATIC_TEST_ID;
 
 public class TransactionsNetworkClient implements TransactionsNetworkClientType
 {
@@ -70,6 +72,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private final String DB_RESET = BLOCK_ENTRY + AUX_DATABASE_ID;
     private final String ETHERSCAN_API_KEY;
     private final String BSC_EXPLORER_API_KEY;
+    private final String POLYGONSCAN_API_KEY;
 
     private final OkHttpClient httpClient;
     private final Gson gson;
@@ -82,6 +85,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     public static native String getEtherscanKey();
     public static native String getBSCExplorerKey();
     public static native String getCovalentKey();
+    public static native String getPolygonScanKey();
 
     public TransactionsNetworkClient(
             OkHttpClient httpClient,
@@ -94,6 +98,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
         BSC_EXPLORER_API_KEY = getBSCExplorerKey().length() > 0 ? "&apikey=" + getBSCExplorerKey() : "";
         ETHERSCAN_API_KEY = "&apikey=" + getEtherscanKey();
+        POLYGONSCAN_API_KEY = getPolygonScanKey().length() > 3 ? "&apikey=" + getPolygonScanKey() : "";
     }
 
     @Override
@@ -385,14 +390,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                 sb.append(pageSize);
             }
 
-            if (networkInfo.etherscanAPI.contains("etherscan"))
-            {
-                sb.append(ETHERSCAN_API_KEY);
-            }
-            else if (networkInfo.chainId == BINANCE_TEST_ID || networkInfo.chainId == BINANCE_MAIN_ID)
-            {
-                sb.append(BSC_EXPLORER_API_KEY);
-            }
+            sb.append(getNetworkAPIToken(networkInfo));
 
             fullUrl = sb.toString();
 
@@ -631,7 +629,12 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         String result = "0";
         if (currentBlock == 0) currentBlock = 1;
 
-        String APIKEY_TOKEN = networkInfo.etherscanAPI.contains("etherscan") ? ETHERSCAN_API_KEY : "";
+        if (networkInfo.chainId == MATIC_ID)
+        {
+            System.out.println("YOLESS");
+        }
+
+        String APIKEY_TOKEN = getNetworkAPIToken(networkInfo);
         String fullUrl = networkInfo.etherscanAPI + "module=account&action=" + queryType +
                 "&startblock=" + currentBlock + "&endblock=9999999999" +
                 "&address=" + walletAddress +
@@ -665,6 +668,26 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         }
 
         return result;
+    }
+
+    private String getNetworkAPIToken(NetworkInfo networkInfo)
+    {
+        if (networkInfo.etherscanAPI.contains("etherscan"))
+        {
+            return ETHERSCAN_API_KEY;
+        }
+        else if (networkInfo.chainId == BINANCE_TEST_ID || networkInfo.chainId == BINANCE_MAIN_ID)
+        {
+            return BSC_EXPLORER_API_KEY;
+        }
+        else if (networkInfo.chainId == MATIC_ID || networkInfo.chainId == MATIC_TEST_ID)
+        {
+            return POLYGONSCAN_API_KEY;
+        }
+        else
+        {
+            return "";
+        }
     }
 
     //TODO: Instead of reading transfers we can read balances and track changes for ERC20 tokens


### PR DESCRIPTION
Ensure we're using Polygonscan API key for all calls to Polygonscan.