### PR TITLE
Sufficient gas check now done in gas widget

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SendActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SendActivity.java
@@ -501,8 +501,7 @@ public class SendActivity extends BaseActivity implements AmountReadyCallback, S
         Token base = viewModel.getToken(token.tokenInfo.chainId, wallet.address);
         //validate that we have sufficient balance
         if ((token.isEthereum() && token.balance.subtract(value).compareTo(BigDecimal.ZERO) > 0) // if sending base ethereum then check we have more than just the value
-             || (hasGasOverride(token.tokenInfo.chainId) && token.getBalanceRaw().subtract(value).compareTo(BigDecimal.ZERO) >= 0) //allow for chains with no gas requirement
-             || (base.balance.compareTo(BigDecimal.ZERO) > 0 && token.getBalanceRaw().subtract(value).compareTo(BigDecimal.ZERO) >= 0)) // contract token, check gas and sufficient token balance
+             || (token.getBalanceRaw().subtract(value).compareTo(BigDecimal.ZERO) >= 0)) // contract token, check sufficient token balance (gas widget will check sufficient gas)
         {
             sendAmount = value;
             sendGasPrice = gasPrice;


### PR DESCRIPTION
Fixes issue reported by @hieronymus4826 where incorrect error was shown when user attempting to move tokens with no eth to cover gas fee.

Insufficient gas will be reported from the gas widget in the Action Sheet. Also the node warns that the transaction will probably fail as usual (because it obviously will).