### PR TITLE
Ensure url from intent is always URL-decoded

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -1643,12 +1643,12 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
         if (web3 == null)
         {
             if (getActivity() != null) ((HomeActivity)getActivity()).resetFragment(WalletPage.DAPP_BROWSER);
+            loadOnInit = urlText;
         }
         else
         {
             // reset initial url, to avoid issues with initial load
             loadOnInit = null;
-
             cancelSearchSession();
             addToBackStack(DAPP_BROWSER);
             setUrlText(Utils.formatUrl(urlText));

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -777,7 +777,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     public void loadingComplete()
     {
         int lastId = viewModel.getLastFragmentId();
-        if (!TextUtils.isEmpty(openLink))
+        if (!TextUtils.isEmpty(openLink)) //delayed open link from intent - safe now that all fragments have been initialised
         {
             showPage(DAPP_BROWSER);
             DappBrowserFragment dappFrag = (DappBrowserFragment) getFragment(DAPP_BROWSER);
@@ -1239,6 +1239,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
     {
         try
         {
+            if (importData != null) importData = URLDecoder.decode(importData, "UTF-8");
             DappBrowserFragment dappFrag = (DappBrowserFragment) getFragment(DAPP_BROWSER);
             if (importData != null && importData.startsWith(NotificationService.AWSTARTUP))
             {
@@ -1261,13 +1262,12 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                     String link = importData.substring(directLinkIndex + AW_MAGICLINK_DIRECT.length());
                     if (getSupportFragmentManager().getFragments().size() >= DAPP_BROWSER.ordinal())
                     {
-                        link = URLDecoder.decode(link, "UTF-8");
                         showPage(DAPP_BROWSER);
                         if (!dappFrag.isDetached()) dappFrag.loadDirect(link);
                     }
                     else
                     {
-                        openLink = link;
+                        openLink = link; //open link once fragments are initialised
                     }
                 }
                 else


### PR DESCRIPTION
Related to #2411.

If AW is not in memory and requires startup, the URL doesn't get url-decoded hence the wallet assumed it's a search string.