### PR TITLE
Update DAS Dapp info

### DIFF
--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -76,6 +76,6 @@
   {"name": "Matic Testnet Faucet", "description": "Matic Faucet to access Mumbai and Goerli testnet tokens", "url": "https://faucet.matic.network/", "category": "Tool"},
   {"name": "NAOS Finance", "description": "A DeFi lending protocol allowing lenders and SME borrowers to facilitate permissionless and borderless loaning/borrowing transactions", "url": "https://naos.finance", "category": "Finance"},
   {"name": "DASLA", "description": "A DAS (Decentralized Account System) account registration tool.", "url": "https://das.la", "category": "Tool"},
-  {"name": "DAS", "description": "A cross-chain decentralized account system.", "url": "https://da.systems/", "category": "Tool"},
+  {"name": ".bit (Previously DAS)", "description": "Your decentralized identity for Web3.0 life", "url": "https://did.id/", "category": "Tool"},
   {"name": "NFTSCAN", "description": "NFT Explorer.", "url": "https://nftscan.com/", "category": "Tool"}
 ]


### PR DESCRIPTION
DAS has rebranded as .bit. And the new website is https://did.id