### PR TITLE
Fix avatar resolve

### DIFF
--- a/app/src/main/java/com/alphawallet/app/interact/GenericWalletInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/GenericWalletInteract.java
@@ -80,6 +80,12 @@ public class GenericWalletInteract
 		walletRepository.updateWalletData(wallet, onSuccess);
 	}
 
+	public void updateWalletENS(Wallet wallet, String newENSName, Realm.Transaction.OnSuccess onSuccess)
+	{
+		wallet.ENSname = newENSName;
+		walletRepository.updateWalletData(wallet, onSuccess);
+	}
+
 	public void updateBalanceIfRequired(Wallet wallet, BigDecimal newBalance)
 	{
 		String newBalanceStr = BalanceUtils.getScaledValueFixed(newBalance, ETHER_DECIMALS, TOKEN_BALANCE_PRECISION);

--- a/app/src/main/java/com/alphawallet/app/ui/NameThisWalletActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NameThisWalletActivity.java
@@ -2,8 +2,6 @@ package com.alphawallet.app.ui;
 
 
 import android.os.Bundle;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 
@@ -13,29 +11,19 @@ import androidx.lifecycle.ViewModelProvider;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.StandardFunctionInterface;
 import com.alphawallet.app.entity.Wallet;
-import com.alphawallet.app.repository.TokenRepository;
-import com.alphawallet.app.util.AWEnsResolver;
 import com.alphawallet.app.viewmodel.NameThisWalletViewModel;
-import com.alphawallet.app.viewmodel.NewSettingsViewModel;
 import com.alphawallet.app.widget.FunctionButtonBar;
 import com.alphawallet.app.widget.InputView;
 
 import java.util.ArrayList;
 import java.util.Collections;
 
-import javax.inject.Inject;
-
 import dagger.hilt.android.AndroidEntryPoint;
-import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.schedulers.Schedulers;
-
-import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 
 @AndroidEntryPoint
-public class NameThisWalletActivity extends BaseActivity implements StandardFunctionInterface {
-
-
+public class NameThisWalletActivity extends BaseActivity implements StandardFunctionInterface
+{
     private NameThisWalletViewModel viewModel;
 
     private FunctionButtonBar functionBar;
@@ -45,7 +33,8 @@ public class NameThisWalletActivity extends BaseActivity implements StandardFunc
     private Disposable disposable;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_name_this_wallet);
 
@@ -59,15 +48,13 @@ public class NameThisWalletActivity extends BaseActivity implements StandardFunc
 
         inputName = findViewById(R.id.input_name);
 
-        inputName.getEditText().setOnKeyListener(new View.OnKeyListener() {
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (event.getAction() == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                    updateNameAndExit();
-                    return true;
-                }
-                return false;
+        inputName.getEditText().setOnKeyListener((v, keyCode, event) -> {
+            if (event.getAction() == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER)
+            {
+                updateNameAndExit();
+                return true;
             }
+            return false;
         });
 
         viewModel = new ViewModelProvider(this)
@@ -76,30 +63,48 @@ public class NameThisWalletActivity extends BaseActivity implements StandardFunc
         viewModel.ensName().observe(this, this::onENSSuccess);
     }
 
-    public void onENSSuccess(String resolvedAddress) {
+    public void onENSSuccess(String resolvedAddress)
+    {
         inputName.getEditText().setHint(resolvedAddress);
     }
 
-    private void onDefaultWallet(Wallet wallet) {
-       inputName.setText(wallet.name);
+    private void onDefaultWallet(Wallet wallet)
+    {
+        inputName.setText(wallet.name);
     }
 
-    public void handleClick(String action, int actionId) {
+    public void handleClick(String action, int actionId)
+    {
         updateNameAndExit();
     }
 
-    private void updateNameAndExit() {
-        viewModel.setWalletName(inputName.getText().toString(), this::finish);
+    private void updateNameAndExit()
+    {
+        viewModel.setWalletName(inputName.getText().toString(), this::checkENSName);
+    }
+
+    private void checkENSName()
+    {
+        if (viewModel.checkEnsName(inputName.getText().toString(), this::finish))
+        {
+            findViewById(R.id.store_spinner).setVisibility(View.VISIBLE);
+        }
+        else
+        {
+            finish();
+        }
     }
 
     @Override
-    protected void onResume() {
+    protected void onResume()
+    {
         super.onResume();
         viewModel.prepare();
     }
 
     @Override
-    public void onDestroy() {
+    public void onDestroy()
+    {
         super.onDestroy();
 
         if (disposable != null && !disposable.isDisposed())

--- a/app/src/main/java/com/alphawallet/app/util/AWEnsResolver.java
+++ b/app/src/main/java/com/alphawallet/app/util/AWEnsResolver.java
@@ -2,11 +2,9 @@ package com.alphawallet.app.util;
 
 import android.content.Context;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
-import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.UnableToResolveENS;
 import com.alphawallet.app.service.OpenSeaService;
@@ -45,6 +43,7 @@ public class AWEnsResolver extends EnsResolver
     private static final String DAS_NAME = "[DAS_NAME]";
     private static final String DAS_PAYLOAD = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"das_searchAccount\",\"params\":[\"" + DAS_NAME + "\"]}";
     private static final String OPENSEA_IMAGE_PREVIEW = "image_preview_url";
+    private static final String OPENSEA_IMAGE_ORIGINAL = "image_original_url"; //in case of SVG; Opensea breaks SVG compression
     private final Context context;
     private final OkHttpClient client;
 
@@ -161,9 +160,16 @@ public class AWEnsResolver extends EnsResolver
 
                 JSONObject asset = fetchOpenseaAsset(chainId, tokenAddress, tokenId);
 
-                if (asset != null && asset.has(OPENSEA_IMAGE_PREVIEW))
+                if (asset != null)
                 {
-                    return asset.getString(OPENSEA_IMAGE_PREVIEW);
+                    String url = asset.getString(OPENSEA_IMAGE_PREVIEW);
+                    if (!TextUtils.isEmpty(url) && url.endsWith(".svg"))
+                    {
+                        String original = asset.getString(OPENSEA_IMAGE_ORIGINAL);
+                        if (!TextUtils.isEmpty(original)) url = original;
+                    }
+
+                    return url;
                 }
                 else
                 {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/NameThisWalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/NameThisWalletViewModel.java
@@ -11,6 +11,7 @@ import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.TokenRepository;
 import com.alphawallet.app.util.AWEnsResolver;
+import com.alphawallet.app.util.EnsResolver;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -49,41 +50,85 @@ public class NameThisWalletViewModel extends BaseViewModel
     protected void onCleared()
     {
         super.onCleared();
-        if (ensResolveDisposable != null && !ensResolveDisposable.isDisposed()) ensResolveDisposable.dispose();
+        if (ensResolveDisposable != null && !ensResolveDisposable.isDisposed())
+            ensResolveDisposable.dispose();
     }
 
-    public LiveData<Wallet> defaultWallet() { return defaultWallet; }
-    public LiveData<String> ensName() { return ensName; }
+    public LiveData<Wallet> defaultWallet()
+    {
+        return defaultWallet;
+    }
 
-    public void prepare() {
+    public LiveData<String> ensName()
+    {
+        return ensName;
+    }
+
+    public void prepare()
+    {
         disposable = genericWalletInteract
                 .find()
                 .subscribe(this::onDefaultWallet, this::onError);
     }
 
-    private void onDefaultWallet(Wallet wallet) {
+    private void onDefaultWallet(Wallet wallet)
+    {
         defaultWallet.setValue(wallet);
 
         // skip resolve if wallet already has an ENSName
-        if (!TextUtils.isEmpty(wallet.ENSname)) {
+        if (!TextUtils.isEmpty(wallet.ENSname))
+        {
             onENSSuccess(wallet.ENSname);
-            return ;
+            return;
         }
 
         ensResolveDisposable = ensResolver.reverseResolveEns(wallet.address)
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(this::onENSSuccess);
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::onENSSuccess);
 
     }
 
-    private void onENSSuccess(String address) {
+    private void onENSSuccess(String address)
+    {
         ensName.setValue(address);
     }
 
     public void setWalletName(String name, Realm.Transaction.OnSuccess onSuccess)
     {
         genericWalletInteract.updateWalletInfo(defaultWallet.getValue(), name, onSuccess);
+    }
+
+    public boolean checkEnsName(String newName, Realm.Transaction.OnSuccess onSuccess)
+    {
+        if (!TextUtils.isEmpty(newName) && EnsResolver.isValidEnsName(newName))
+        {
+            //does this new name correspond to ENS?
+            ensResolver.resolveENSAddress(newName)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(addr -> checkAddress(addr, newName, onSuccess))
+                    .isDisposed();
+
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    //check if this is a valid ENS name, if so then replace the ENS name
+    private void checkAddress(String address, String ensName, Realm.Transaction.OnSuccess onSuccess)
+    {
+        if (defaultWallet.getValue() != null && !TextUtils.isEmpty(address) && address.equalsIgnoreCase(defaultWallet.getValue().address))
+        {
+            genericWalletInteract.updateWalletENS(defaultWallet.getValue(), ensName, onSuccess);
+        }
+        else
+        {
+            onSuccess.onSuccess();
+        }
     }
 }
 

--- a/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
@@ -199,9 +199,12 @@ public class TokenIcon extends ConstraintLayout
 
         if (iconItem.usePrimary())
         {
+            final RequestOptions optionalCircleCrop = squareToken || iconItem.getUrl().startsWith(Utils.ALPHAWALLET_REPO_NAME) ? new RequestOptions() : new RequestOptions().circleCrop();
+
             currentRq = Glide.with(getContext())
                     .load(iconItem.getUrl())
                     .placeholder(R.drawable.ic_token_eth)
+                    .apply(optionalCircleCrop)
                     .listener(requestListener)
                     .into(new DrawableImageViewTarget(icon)).getRequest();
         }

--- a/app/src/main/res/drawable/masking_circle.xml
+++ b/app/src/main/res/drawable/masking_circle.xml
@@ -7,6 +7,6 @@
     <gradient
         android:type="radial"
         android:gradientRadius="8dp"
-        android:endColor="@color/white"
+        android:endColor="@color/background"
         />
 </shape>

--- a/app/src/main/res/layout/activity_name_this_wallet.xml
+++ b/app/src/main/res/layout/activity_name_this_wallet.xml
@@ -31,4 +31,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <ProgressBar
+        android:id="@+id/store_spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:layout_constraintTop_toBottomOf="@id/input_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/layoutButtons"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_asset_image.xml
+++ b/app/src/main/res/layout/item_asset_image.xml
@@ -43,7 +43,7 @@
             android:id="@+id/overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:src="@drawable/white_circle"
+            android:src="@drawable/masking_circle"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/item_token_icon_square.xml
+++ b/app/src/main/res/layout/item_token_icon_square.xml
@@ -158,6 +158,7 @@
         android:contentDescription="@string/empty"
         android:src="@drawable/grey_circle"
         android:visibility="gone"
+        tools:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/guidelineBottom2"
         app:layout_constraintEnd_toStartOf="@id/guidelineRight"
         app:layout_constraintStart_toEndOf="@id/guidelineRightMid"

--- a/app/src/main/res/layout/item_token_icon_square.xml
+++ b/app/src/main/res/layout/item_token_icon_square.xml
@@ -158,7 +158,6 @@
         android:contentDescription="@string/empty"
         android:src="@drawable/grey_circle"
         android:visibility="gone"
-        tools:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/guidelineBottom2"
         app:layout_constraintEnd_toStartOf="@id/guidelineRight"
         app:layout_constraintStart_toEndOf="@id/guidelineRightMid"


### PR DESCRIPTION
This PR contains icon display fixes noticed when applying darkmode:

- Fix for displaying SVG from Opensea (OpenSea incorrectly renders the thumbnail SVG, so we need to use original image).
- Fix for masking surrounding the webview used to display the SVG in dark mode.
- Fix for masking of TokenIcon in dark mode when icon may be badly formatted (from outside source).
- Allow user to override the ENS name used when using the 'Name This Wallet' feature. This is useful if an account has many ENS names and one of those ENS names has an icon associated with it, but the wallet picked a different ENS name.