### PR TITLE
Ensure Wallet data updated correctly

### DIFF
--- a/app/src/main/java/com/alphawallet/app/interact/FetchWalletsInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/FetchWalletsInteract.java
@@ -2,6 +2,7 @@ package com.alphawallet.app.interact;
 
 import android.text.TextUtils;
 
+import com.alphawallet.app.repository.WalletItem;
 import com.alphawallet.app.repository.WalletRepositoryType;
 
 import io.reactivex.Single;
@@ -40,6 +41,10 @@ public class FetchWalletsInteract {
 
     public void updateWalletData(Wallet wallet, Realm.Transaction.OnSuccess onSuccess) {
         accountRepository.updateWalletData(wallet, onSuccess);
+    }
+
+    public void updateWalletItem(Wallet wallet, WalletItem item, Realm.Transaction.OnSuccess onSuccess) {
+        accountRepository.updateWalletItem(wallet, item, onSuccess);
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/interact/GenericWalletInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/GenericWalletInteract.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.repository.WalletItem;
 import com.alphawallet.app.repository.WalletRepositoryType;
 import com.alphawallet.app.util.BalanceUtils;
 
@@ -74,16 +75,8 @@ public class GenericWalletInteract
 		return walletRepository.getWalletBackupWarning(walletAddr);
 	}
 
-	public void updateWalletInfo(Wallet wallet, String name, Realm.Transaction.OnSuccess onSuccess)
-	{
-		wallet.name = name;
-		walletRepository.updateWalletData(wallet, onSuccess);
-	}
-
-	public void updateWalletENS(Wallet wallet, String newENSName, Realm.Transaction.OnSuccess onSuccess)
-	{
-		wallet.ENSname = newENSName;
-		walletRepository.updateWalletData(wallet, onSuccess);
+	public void updateWalletItem(Wallet wallet, WalletItem item, Realm.Transaction.OnSuccess onSuccess) {
+		walletRepository.updateWalletItem(wallet, item, onSuccess);
 	}
 
 	public void updateBalanceIfRequired(Wallet wallet, BigDecimal newBalance)
@@ -92,7 +85,7 @@ public class GenericWalletInteract
 		if (!newBalance.equals(BigDecimal.valueOf(-1)) && !wallet.balance.equals(newBalanceStr))
 		{
 			wallet.balance = newBalanceStr;
-			walletRepository.updateWalletData(wallet, () -> {
+			walletRepository.updateWalletItem(wallet, WalletItem.BALANCE, () -> {
 				Timber.tag(getClass().getCanonicalName()).d("Updated balance");
 			});
 		}

--- a/app/src/main/java/com/alphawallet/app/repository/WalletDataRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletDataRealmSource.java
@@ -175,8 +175,49 @@ public class WalletDataRealmSource {
         {
             realm.executeTransactionAsync(r -> {
                 storeKeyData(wallet, r);
-                Timber.tag("RealmDebug").d("storedwalletdata " + wallet.address);
+                storeWalletData(wallet, r);
+                Timber.tag("RealmDebug").d("storedKeydata " + wallet.address);
             }, onSuccess);
+        }
+        catch (Exception e)
+        {
+            Timber.e(e);
+            onSuccess.onSuccess();
+        }
+    }
+
+    public void updateWalletItem(Wallet wallet, WalletItem item, Realm.Transaction.OnSuccess onSuccess)
+    {
+        try (Realm realm = realmManager.getWalletDataRealmInstance())
+        {
+            realm.executeTransactionAsync(r -> {
+                RealmWalletData walletData = r.where(RealmWalletData.class)
+                        .equalTo("address", wallet.address, Case.INSENSITIVE)
+                        .findFirst();
+
+                if (walletData != null)
+                {
+                    switch (item)
+                    {
+                        case NAME:
+                            walletData.setName(wallet.name);
+                            break;
+                        case ENS_NAME:
+                            walletData.setENSName(wallet.ENSname);
+                            break;
+                        case BALANCE:
+                            walletData.setBalance(wallet.balance);
+                            break;
+                        case ENS_AVATAR:
+                            walletData.setENSAvatar(wallet.ENSAvatar);
+                            break;
+                    }
+
+                    r.insertOrUpdate(walletData);
+                }
+                Timber.tag("RealmDebug").d("storedKeydata " + wallet.address);
+            }, onSuccess);
+
         }
         catch (Exception e)
         {

--- a/app/src/main/java/com/alphawallet/app/repository/WalletItem.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletItem.java
@@ -1,0 +1,13 @@
+package com.alphawallet.app.repository;
+
+/**
+ * Created by JB on 29/03/2022.
+ */
+
+public enum WalletItem
+{
+    NAME,
+    ENS_NAME,
+    BALANCE,
+    ENS_AVATAR
+}

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepository.java
@@ -166,6 +166,12 @@ public class WalletRepository implements WalletRepositoryType
 	}
 
 	@Override
+	public void updateWalletItem(Wallet wallet, WalletItem item, Realm.Transaction.OnSuccess onSuccess)
+	{
+		walletDataRealmSource.updateWalletItem(wallet, item, onSuccess);
+	}
+
+	@Override
 	public Single<String> getName(String address)
 	{
 		return walletDataRealmSource.getName(address);

--- a/app/src/main/java/com/alphawallet/app/repository/WalletRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/WalletRepositoryType.java
@@ -1,13 +1,10 @@
 package com.alphawallet.app.repository;
 
-import java.math.BigDecimal;
+import com.alphawallet.app.entity.Wallet;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
-import io.reactivex.disposables.Disposable;
 import io.realm.Realm;
-
-import com.alphawallet.app.entity.Wallet;
 
 public interface WalletRepositoryType {
     Single<Wallet[]> fetchWallets();
@@ -33,6 +30,7 @@ public interface WalletRepositoryType {
 
     Single<Wallet> storeWallet(Wallet wallet);
     void updateWalletData(Wallet wallet, Realm.Transaction.OnSuccess onSuccess);
+    void updateWalletItem(Wallet wallet, WalletItem item, Realm.Transaction.OnSuccess onSuccess);
 
     Single<String> getName(String address);
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsSummaryAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsSummaryAdapter.java
@@ -15,6 +15,7 @@ import com.alphawallet.app.R;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.WalletType;
 import com.alphawallet.app.interact.GenericWalletInteract;
+import com.alphawallet.app.repository.WalletItem;
 import com.alphawallet.app.ui.widget.entity.WalletClickCallback;
 import com.alphawallet.app.ui.widget.holder.BinderViewHolder;
 import com.alphawallet.app.ui.widget.holder.TextHolder;
@@ -40,6 +41,7 @@ public class WalletsSummaryAdapter extends RecyclerView.Adapter<BinderViewHolder
     private final Wallet summaryWallet = new Wallet(ZERO_ADDRESS);
     private final Context context;
     private final Realm realm;
+    private final GenericWalletInteract walletInteract;
 
     public WalletsSummaryAdapter(Context ctx,
                                  OnSetWalletDefaultListener onSetWalletDefaultListener, GenericWalletInteract genericWalletInteract) {
@@ -47,6 +49,7 @@ public class WalletsSummaryAdapter extends RecyclerView.Adapter<BinderViewHolder
         this.wallets = new ArrayList<>();
         this.context = ctx;
         this.realm = genericWalletInteract.getWalletRealm();
+        this.walletInteract = genericWalletInteract;
     }
 
     @NotNull
@@ -289,8 +292,8 @@ public class WalletsSummaryAdapter extends RecyclerView.Adapter<BinderViewHolder
     @Override
     public void ensAvatar(Wallet wallet)
     {
-        // we received a wallet avatar URL (wallet.ENSAvatar)
-        //TODO: Michael - does the view need to be updated?
+        //update the ENS avatar in the database
+        walletInteract.updateWalletItem(wallet, WalletItem.ENS_AVATAR, () -> { });
     }
 
     public void onDestroy()

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletSummaryHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletSummaryHolder.java
@@ -22,6 +22,7 @@ import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.repository.entity.RealmWalletData;
 import com.alphawallet.app.service.TickerService;
 import com.alphawallet.app.ui.WalletActionsActivity;
+import com.alphawallet.app.ui.widget.entity.AvatarWriteCallback;
 import com.alphawallet.app.ui.widget.entity.WalletClickCallback;
 import com.alphawallet.app.util.Utils;
 import com.alphawallet.app.widget.UserAvatar;
@@ -32,7 +33,7 @@ import java.math.RoundingMode;
 import io.realm.Realm;
 import io.realm.RealmResults;
 
-public class WalletSummaryHolder extends BinderViewHolder<Wallet> implements View.OnClickListener
+public class WalletSummaryHolder extends BinderViewHolder<Wallet> implements View.OnClickListener, AvatarWriteCallback
 {
 
     public static final int VIEW_TYPE = 1001;
@@ -115,7 +116,7 @@ public class WalletSummaryHolder extends BinderViewHolder<Wallet> implements Vie
                 walletNameText.setVisibility(View.GONE);
             }
 
-            walletIcon.bind(wallet);
+            walletIcon.bind(wallet, this);
 
             String walletBalance = wallet.balance;
             if (!TextUtils.isEmpty(walletBalance) && walletBalance.startsWith("*"))
@@ -271,5 +272,11 @@ public class WalletSummaryHolder extends BinderViewHolder<Wallet> implements Vie
                 getContext().startActivity(intent);
                 break;
         }
+    }
+
+    @Override
+    public void avatarFound(Wallet wallet)
+    {
+        if (clickCallback != null) clickCallback.ensAvatar(wallet);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/NameThisWalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/NameThisWalletViewModel.java
@@ -10,6 +10,7 @@ import androidx.lifecycle.MutableLiveData;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.TokenRepository;
+import com.alphawallet.app.repository.WalletItem;
 import com.alphawallet.app.util.AWEnsResolver;
 import com.alphawallet.app.util.EnsResolver;
 
@@ -96,7 +97,9 @@ public class NameThisWalletViewModel extends BaseViewModel
 
     public void setWalletName(String name, Realm.Transaction.OnSuccess onSuccess)
     {
-        genericWalletInteract.updateWalletInfo(defaultWallet.getValue(), name, onSuccess);
+        Wallet wallet = defaultWallet().getValue();
+        wallet.name = name;
+        genericWalletInteract.updateWalletItem(wallet, WalletItem.NAME, onSuccess);
     }
 
     public boolean checkEnsName(String newName, Realm.Transaction.OnSuccess onSuccess)
@@ -123,7 +126,9 @@ public class NameThisWalletViewModel extends BaseViewModel
     {
         if (defaultWallet.getValue() != null && !TextUtils.isEmpty(address) && address.equalsIgnoreCase(defaultWallet.getValue().address))
         {
-            genericWalletInteract.updateWalletENS(defaultWallet.getValue(), ensName, onSuccess);
+            Wallet wallet = defaultWallet().getValue();
+            wallet.ENSname = ensName;
+            genericWalletInteract.updateWalletItem(wallet, WalletItem.ENS_NAME, onSuccess);
         }
         else
         {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -30,6 +30,7 @@ import com.alphawallet.app.interact.FetchTokensInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
 import com.alphawallet.app.repository.OnRampRepositoryType;
 import com.alphawallet.app.repository.PreferenceRepositoryType;
+import com.alphawallet.app.repository.WalletItem;
 import com.alphawallet.app.router.ManageWalletsRouter;
 import com.alphawallet.app.router.MyAddressRouter;
 import com.alphawallet.app.router.TokenDetailRouter;
@@ -377,7 +378,7 @@ public class WalletViewModel extends BaseViewModel
 
     public void saveAvatar(Wallet wallet)
     {
-        genericWalletInteract.updateWalletInfo(wallet, wallet.name, () -> { });
+        genericWalletInteract.updateWalletItem(wallet, WalletItem.ENS_AVATAR, () -> { });
     }
 
     public Intent getBuyIntent(String address) {


### PR DESCRIPTION
Fix to update individual items in wallet database, and store ENS avatars when found.

1. Some wallet data was getting overwritten when the whole wallet was being clobbered.
2. When found, the ENS avatars weren't getting stored for later use
