### PR TITLE
Fix for direct-supply contract metadata contracts

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -957,6 +957,9 @@ public class Token
     {
         if (TextUtils.isEmpty(tokenURI)) return "";
 
+        //check if this is direct metadata, some tokens do this
+        if (Utils.isJson(tokenURI)) return tokenURI;
+
         setupClient();
 
         Request request = new Request.Builder()

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -35,6 +35,7 @@ import com.alphawallet.token.entity.ProviderTypedData;
 import com.alphawallet.token.entity.Signable;
 
 import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
 import org.web3j.crypto.Hash;
 import org.web3j.crypto.Keys;
 import org.web3j.crypto.WalletUtils;
@@ -906,5 +907,18 @@ public class Utils {
         calculatedAddressAsBytes = Arrays.copyOfRange(calculatedAddressAsBytes,
                 12, calculatedAddressAsBytes.length);
         return Keys.toChecksumAddress(Numeric.toHexString(calculatedAddressAsBytes));
+    }
+
+    public static boolean isJson(String value)
+    {
+        try
+        {
+            JSONObject stateData = new JSONObject(value);
+            return true;
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/web3/Web3View.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3View.java
@@ -162,18 +162,6 @@ public class Web3View extends WebView {
         init();
     }
 
-    private static boolean isJson(String value)
-    {
-        try
-        {
-            JSONObject stateData = new JSONObject(value);
-            return true;
-        } catch (Exception e)
-        {
-            return false;
-        }
-    }
-
     @Override
     public void setWebChromeClient(WebChromeClient client)
     {


### PR DESCRIPTION
Ensure we load metadata correctly from contracts that supply metadata directly.

We are used to handling NFTs like this:

tokenURI(uint256 tokenId) -> "https://some_metadata_here/tokenId"

Then we go and fetch the metadata at that URL.

Some contracts provide the metadata directly:

tokenURI(uint256 tokenId) -> "{"name": "MachineFi NFT", "description": "The MachineFi NFT.", "image": "[https://machinefi.com/nft/image/3253"}](https://machinefi.com/nft/image/3253%22%7D)"