### PR TITLE
Fix - network duplicated, hide `remove` menu for built-in network

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -486,8 +486,10 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
 
                 for (NetworkInfo info : list) {
                     networkMap.put(info.chainId, info);
-                    if (mapToTestNet.containsKey(info.chainId) && !mapToTestNet.get(info.chainId)) {
-                       hasValue.add(info.chainId);
+                    Boolean value = mapToTestNet.get(info.chainId);
+                    boolean isTestnet = value != null && value;
+                    if (!isTestnet && !hasValue.contains(info.chainId)) {
+                        hasValue.add(info.chainId);
                     }
                 }
             }
@@ -498,7 +500,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                 List<NetworkInfo> copyList = new ArrayList<>(list);
                 list.clear();
                 for (NetworkInfo n : copyList) {
-                    NetworkInfo newInfo = new NetworkInfo(n.name, n.symbol, n.rpcServerUrl, n.etherscanUrl, n.chainId, n.backupNodeUrl, n.etherscanAPI, true);
+                    boolean isCustom = builtinNetworkMap.indexOfKey(n.chainId) == -1;
+                    NetworkInfo newInfo = new NetworkInfo(n.name, n.symbol, n.rpcServerUrl, n.etherscanUrl, n.chainId, n.backupNodeUrl, n.etherscanAPI, isCustom);
                     list.add(newInfo);
                 }
                 //record back


### PR DESCRIPTION
Fix two bugs introduced in PR #2495 .

### Network duplicated after editing any built-in network
Edit built-in network creates a custom network actually. 
So if edit Ethereum, restart the app it shows 2 Ethereum in the `Select Active Network` list.

### Should not remove built-in network
After restarting and restoring custom networks, `checkCustomNetworkSetting()` marks it as `custom` so the user can remove it from the list. This PR checks the chain id to determine is it a custom network.