### PR TITLE
Don't re-sync all wallets unless explicitly refreshed

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsSummaryAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/WalletsSummaryAdapter.java
@@ -157,7 +157,14 @@ public class WalletsSummaryAdapter extends RecyclerView.Adapter<BinderViewHolder
         int index = getWalletIndex(wallet);
         if (index >= 0)
         {
-            valueMap.put(wallet.toLowerCase(), value);
+            if (value != null)
+            {
+                valueMap.put(wallet.toLowerCase(), value);
+            }
+            else
+            {
+                wallets.get(index).isSynced = false;
+            }
             notifyItemChanged(index);
             updateWalletSummary();
         }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletSummaryHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/WalletSummaryHolder.java
@@ -157,6 +157,11 @@ public class WalletSummaryHolder extends BinderViewHolder<Wallet> implements Vie
         }
     }
 
+    public void setWaiting()
+    {
+        walletIcon.setWaiting();
+    }
+
     private void setWalletChange(double percentChange24h)
     {
         //This sets the 24hr percentage change (rightmost value)


### PR DESCRIPTION
Fixes issue where user has lots of wallets; going to select a new wallet caused the app to freeze