### PR TITLE
Refactor Transaction sending

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
@@ -1,6 +1,9 @@
 package com.alphawallet.app.repository;
 
-import com.alphawallet.app.C;
+import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
+import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
+import static com.alphawallet.app.service.KeyService.FAILED_SIGNATURE;
+
 import com.alphawallet.app.entity.ActivityMeta;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionData;
@@ -10,7 +13,6 @@ import com.alphawallet.app.entity.cryptokeys.SignatureReturnType;
 import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.service.AccountKeystoreService;
 import com.alphawallet.app.service.TransactionsService;
-import com.alphawallet.app.web3.entity.Web3Transaction;
 import com.alphawallet.token.entity.Signable;
 
 import org.web3j.crypto.RawTransaction;
@@ -31,10 +33,6 @@ import java.util.List;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
-
-import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
-import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
-import static com.alphawallet.app.service.KeyService.FAILED_SIGNATURE;
 
 public class TransactionRepository implements TransactionRepositoryType {
 
@@ -91,39 +89,6 @@ public class TransactionRepository implements TransactionRepositoryType {
 					return raw.getTransactionHash();
 				}))
 				.flatMap(txHash -> storeUnconfirmedTransaction(from, txHash, to, subunitAmount, nonce, useGasPrice, gasLimit, chainId, data != null ? Numeric.toHexString(data) : "0x"))
-				.subscribeOn(Schedulers.io());
-	}
-
-	@Override
-	public Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, long chainId)
-	{
-		final Web3j web3j = getWeb3jService(chainId);
-		final BigInteger useGasPrice = gasPriceForNode(chainId, gasPrice);
-
-		TransactionData txData = new TransactionData();
-
-		return networkRepository.getLastTransactionNonce(web3j, from.address)
-				.flatMap(nonce -> {
-					txData.nonce = nonce;
-					return accountKeystoreService.signTransaction(from, toAddress, subunitAmount, useGasPrice, gasLimit, nonce.longValue(), data, chainId);
-				})
-				.flatMap(signedMessage -> Single.fromCallable(() -> {
-					if (signedMessage.sigType != SignatureReturnType.SIGNATURE_GENERATED)
-					{
-						throw new Exception(signedMessage.failMessage);
-					}
-					txData.signature = Numeric.toHexString(signedMessage.signature);
-					EthSendTransaction raw = web3j
-							.ethSendRawTransaction(Numeric.toHexString(signedMessage.signature))
-							.send();
-					if (raw.hasError())
-					{
-						throw new Exception(raw.getError().getMessage());
-					}
-					txData.txHash = raw.getTransactionHash();
-					return txData;
-				}))
-				.flatMap(tx -> storeUnconfirmedTransaction(from, tx.txHash, toAddress, subunitAmount, tx.nonce, useGasPrice, gasLimit, chainId, data != null ? Numeric.toHexString(data) : "0x"))
 				.subscribeOn(Schedulers.io());
 	}
 
@@ -189,55 +154,39 @@ public class TransactionRepository implements TransactionRepositoryType {
 	}
 
 	/**
-	 * Given a Web3Transaction, return a signature. Note that we can't fix up nonce, gas price or limit;
-	 * This is a request to sign a transaction from an external source -
-	 * presumably that external source will broadcast the transaction; together with this signature
+	 * 	 * Given a Web3Transaction, return a signature. Note that we can't fix up nonce, gas price or limit;
+	 * 	 * This is a request to sign a transaction from an external source -
+	 * 	 * presumably that external source will broadcast the transaction; together with this signature
 	 *
-	 * @param wallet
-	 * @param w3tx
+	 * @param from
+	 * @param toAddress
+	 * @param subunitAmount
+	 * @param gasPrice
+	 * @param gasLimit
+	 * @param nonce
+	 * @param data
 	 * @param chainId
 	 * @return
 	 */
 	@Override
-	public Single<TransactionData> getSignatureForTransaction(Wallet wallet, Web3Transaction w3tx, long chainId) {
-		TransactionData txData = new TransactionData();
-
-		return getRawTransaction(txData.nonce, w3tx.gasPrice, w3tx.gasLimit, w3tx.value, w3tx.payload)
-				.flatMap(rawTx -> signEncodeRawTransaction(rawTx, wallet, chainId))
-				.flatMap(signedMessage -> Single.fromCallable( () -> {
-					txData.signature = Numeric.toHexString(signedMessage);
-					txData.txHash = "";
-					return txData;
-				}));
-	}
-
-	// Called for constructors from web3 Dapp transaction
-	@Override
-	public Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, long chainId) {
+	public Single<TransactionData> getSignatureForTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, long nonce, byte[] data, long chainId) {
 		final Web3j web3j = getWeb3jService(chainId);
 		final BigInteger useGasPrice = gasPriceForNode(chainId, gasPrice);
-
 		TransactionData txData = new TransactionData();
 
-		return networkRepository.getLastTransactionNonce(web3j, from.address)
+		return getNonceForTransaction(web3j, from.address, nonce)
 				.flatMap(txNonce -> {
 					txData.nonce = txNonce;
-					return getRawTransaction(txNonce, useGasPrice, gasLimit, BigInteger.ZERO, data);
+					return accountKeystoreService.signTransaction(from, toAddress, subunitAmount, useGasPrice, gasLimit, txNonce.longValue(), data, chainId);
 				})
-				.flatMap(rawTx -> signEncodeRawTransaction(rawTx, from, chainId))
 				.flatMap(signedMessage -> Single.fromCallable( () -> {
-					txData.signature = Numeric.toHexString(signedMessage);
-					EthSendTransaction raw = web3j
-							.ethSendRawTransaction(Numeric.toHexString(signedMessage))
-							.send();
-					if (raw.hasError()) {
-						throw new Exception(raw.getError().getMessage());
+					if (signedMessage.sigType != SignatureReturnType.SIGNATURE_GENERATED)
+					{
+						throw new Exception(signedMessage.failMessage);
 					}
-					txData.txHash = raw.getTransactionHash();
+					txData.signature = Numeric.toHexString(signedMessage.signature);
 					return txData;
-				})) //TODO: Calculate new contract address and store here
-				.flatMap(tx -> storeUnconfirmedTransaction(from, tx, "", BigInteger.ZERO, txData.nonce, useGasPrice, gasLimit, chainId, data, C.BURN_ADDRESS))
-				.subscribeOn(Schedulers.io());
+				}));
 	}
 
 	private BigInteger gasPriceForNode(long chainId, BigInteger gasPrice)
@@ -287,39 +236,6 @@ public class TransactionRepository implements TransactionRepositoryType {
 		});
 	}
 
-	private Single<RawTransaction> getRawTransaction(BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit, BigInteger value, String data)
-	{
-		return Single.fromCallable(() ->
-			RawTransaction.createContractTransaction(
-					nonce,
-					gasPrice,
-					gasLimit,
-					value,
-					data));
-	}
-
-	private Single<byte[]> signEncodeRawTransaction(RawTransaction rtx, Wallet wallet, long chainId)
-	{
-		return Single.fromCallable(() -> TransactionEncoder.encode(rtx))
-				.flatMap(encoded -> accountKeystoreService.signTransaction(wallet, encoded, chainId))
-				.flatMap(signatureReturn -> {
-						 	if (signatureReturn.sigType != SignatureReturnType.SIGNATURE_GENERATED)
-							{
-								throw new Exception(signatureReturn.failMessage);
-							}
-						 	return encodeTransaction(signatureReturn.signature, rtx);
-						 });
-	}
-
-	private Single<byte[]> encodeTransaction(byte[] signatureBytes, RawTransaction rtx)
-	{
-		return Single.fromCallable(() -> {
-			Sign.SignatureData sigData = sigFromByteArray(signatureBytes);
-			if (sigData == null) return FAILED_SIGNATURE.getBytes();
-			return encode(rtx, sigData);
-		});
-	}
-
 	@Override
 	public Single<SignatureFromKey> getSignature(Wallet wallet, Signable message, long chainId) {
 		return accountKeystoreService.signMessage(wallet, message, chainId);
@@ -328,18 +244,6 @@ public class TransactionRepository implements TransactionRepositoryType {
 	@Override
 	public Single<byte[]> getSignatureFast(Wallet wallet, String password, byte[] message, long chainId) {
 		return accountKeystoreService.signTransactionFast(wallet, password, message, chainId);
-	}
-
-	/**
-	 * From Web3j to encode a constructor
-	 * @param rawTransaction
-	 * @param signatureData
-	 * @return
-	 */
-	private static byte[] encode(RawTransaction rawTransaction, Sign.SignatureData signatureData) {
-		List<RlpType> values = TransactionEncoder.asRlpValues(rawTransaction, signatureData);
-		RlpList rlpList = new RlpList(values);
-		return RlpEncoder.encode(rlpList);
 	}
 
 	@Override

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepositoryType.java
@@ -18,12 +18,10 @@ import io.reactivex.Single;
 import io.realm.Realm;
 
 public interface TransactionRepositoryType {
-	Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, long chainId);
 	Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, long nonce, byte[] data, long chainId);
-	Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, long chainId);
 	Single<TransactionData> create1559TransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasLimit, BigInteger maxFeePerGas, BigInteger maxPriorityFee, long nonce, byte[] data, long chainId);
+	Single<TransactionData> getSignatureForTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, long nonce, byte[] data, long chainId);
 
-	Single<TransactionData> getSignatureForTransaction(Wallet wallet, Web3Transaction w3tx, long chainId);
 	Single<SignatureFromKey> getSignature(Wallet wallet, Signable message, long chainId);
 	Single<byte[]> getSignatureFast(Wallet wallet, String password, byte[] message, long chainId);
 

--- a/app/src/main/java/com/alphawallet/app/service/AccountKeystoreService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AccountKeystoreService.java
@@ -82,11 +82,6 @@ public interface AccountKeystoreService {
 			Signable message,
 			long chainId);
 
-	Single<SignatureFromKey> signTransaction(
-			Wallet signer,
-			byte[] rawTx,
-			long chainId);
-
 	Single<byte[]> signTransactionFast(
 			Wallet signer,
 			String password,

--- a/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
+++ b/app/src/test/java/com/alphawallet/app/QRSelectionTest.java
@@ -69,19 +69,7 @@ public class QRSelectionTest
         transactionRepository = new TransactionRepositoryType()
         {
             @Override
-            public Single<String> createTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, long chainId)
-            {
-                return null;
-            }
-
-            @Override
             public Single<TransactionData> createTransactionWithSig(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, long nonce, byte[] data, long chainId)
-            {
-                return null;
-            }
-
-            @Override
-            public Single<TransactionData> createTransactionWithSig(Wallet from, BigInteger gasPrice, BigInteger gasLimit, String data, long chainId)
             {
                 return null;
             }
@@ -92,7 +80,7 @@ public class QRSelectionTest
             }
 
             @Override
-            public Single<TransactionData> getSignatureForTransaction(Wallet wallet, Web3Transaction w3tx, long chainId)
+            public Single<TransactionData> getSignatureForTransaction(Wallet from, String toAddress, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, long nonce, byte[] data, long chainId)
             {
                 return null;
             }


### PR DESCRIPTION
Refactor/Simplify sending transactions to ensure consistency; and ease of maintenance.

- Deduplicate code
- Use single signing path for transactions
- Remove code clutter.