### PR TITLE
Prevent drawing chart if there is insufficient data

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/HistoryChart.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/HistoryChart.java
@@ -219,7 +219,7 @@ public class HistoryChart extends View
         super.onDraw(canvas);
 
         Datasource datasource = cache.getCurrentDatasource(cache.range);
-        if (datasource == null || datasource.entries.size() == 0)
+        if (datasource == null || datasource.entries.size() <= 1)
         {
             // draw no chart data available message
             int xPos = (getWidth() / 2);


### PR DESCRIPTION
Closes #2520

Token: dForce (USDX) - 0xeb269732ab75A6fD61Ea60b06fE994cD32a83549

History Chart is attempting to draw the chart with insufficient data, where it gets stuck in an infinite loop during `onDraw` method

The CoinGecko API returns insufficient data (just 1 data point) for the 1D and 1W chart.