### PR TITLE
Refactor NFTAssetDetailActivity + Store OpenSea data to Realm

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
@@ -65,7 +65,6 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
     private Wallet wallet;
     private BigInteger tokenId;
     private String sequenceId;
-    private LinearLayout tokenInfoLayout;
     private ActionSheetDialog confirmationDialog;
     private AWalletAlertDialog dialog;
     private NFTAsset asset;
@@ -73,13 +72,24 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
     private NFTAttributeLayout nftAttributeLayout;
     private TextView tokenDescription;
     private ActionMenuItemView refreshMenu;
-    private Animation rotation;
+    private ProgressBar progressBar;
     private TokenInfoCategoryView detailsLabel;
     private TokenInfoCategoryView descriptionLabel;
-    private ProgressBar progressBar;
+    private TokenInfoView tivTokenId;
+    private TokenInfoView tivNetwork;
+    private TokenInfoView tivContractAddress;
+    private TokenInfoView tivBalance;
+    private TokenInfoView tivName;
+    private TokenInfoView tivExternalLink;
+    private TokenInfoView tivCreator;
+    private TokenInfoView tivTokenStandard;
+    private TokenInfoView tivTotalSupply;
+    private TokenInfoView tivNumOwners;
+    private TokenInfoView tivOwner;
+    private TokenInfoView tivLastSale;
+    private Animation rotation;
     private ActivityResultLauncher<Intent> handleTransactionSuccess;
     private ActivityResultLauncher<Intent> getGasSettings;
-
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState)
@@ -165,13 +175,24 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
 
     private void initViews()
     {
-        tokenInfoLayout = findViewById(R.id.layout_token_info);
         tokenImage = findViewById(R.id.asset_image);
         nftAttributeLayout = findViewById(R.id.attributes);
         tokenDescription = findViewById(R.id.token_description);
         detailsLabel = findViewById(R.id.label_details);
         descriptionLabel = findViewById(R.id.label_description);
         progressBar = findViewById(R.id.progress);
+        tivTokenId = findViewById(R.id.token_id);
+        tivNetwork = findViewById(R.id.network);
+        tivContractAddress = findViewById(R.id.contract_address);
+        tivBalance = findViewById(R.id.balance);
+        tivName = findViewById(R.id.name);
+        tivExternalLink = findViewById(R.id.external_link);
+        tivCreator = findViewById(R.id.creator);
+        tivTokenStandard = findViewById(R.id.token_standard);
+        tivTotalSupply = findViewById(R.id.total_supply);
+        tivNumOwners = findViewById(R.id.num_owners);
+        tivOwner = findViewById(R.id.owner);
+        tivLastSale = findViewById(R.id.last_sale);
 
         rotation = AnimationUtils.loadAnimation(this, R.anim.rotate_refresh);
         rotation.setRepeatCount(Animation.INFINITE);
@@ -223,16 +244,6 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
         progressBar.setVisibility(View.GONE);
     }
 
-    private void addInfoView(String elementName, String name)
-    {
-        if (!TextUtils.isEmpty(name))
-        {
-            TokenInfoView v = new TokenInfoView(this, elementName);
-            v.setValue(name);
-            tokenInfoLayout.addView(v);
-        }
-    }
-
     private void onNftAsset(NFTAsset asset)
     {
         loadAssetFromMetadata(asset);
@@ -240,20 +251,18 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
 
     private void updateDefaultTokenData()
     {
-        tokenInfoLayout.removeAllViews();
-
         if (!TextUtils.isEmpty(sequenceId))
         {
-            addInfoView(getString(R.string.label_token_id), sequenceId);
+            tivTokenId.setValue(sequenceId);
         }
         else
         {
-            addInfoView(getString(R.string.label_token_id), tokenId.toString());
+            tivTokenId.setValue(tokenId.toString());
         }
 
-        addInfoView(getString(R.string.subtitle_network), token.getNetworkName());
+        tivNetwork.setValue(token.getNetworkName());
 
-        addInfoView(getString(R.string.contract_address), Utils.formatAddress(token.tokenInfo.address));
+        tivContractAddress.setValue(Utils.formatAddress(token.tokenInfo.address));
     }
 
     private void loadAssetFromMetadata(NFTAsset asset)
@@ -304,17 +313,17 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
 
         if (asset.isAssetMultiple())
         {
-            addInfoView(getString(R.string.balance), asset.getBalance().toString());
+            tivBalance.setValue(asset.getBalance().toString());
         }
 
         String assetName = asset.getName();
         if (assetName != null)
         {
-            addInfoView(getString(R.string.hint_contract_name), assetName);
+            tivName.setValue(assetName);
             setTitle(assetName);
         }
 
-        addInfoView(getString(R.string.label_external_link), asset.getExternalLink());
+        tivExternalLink.setValue(asset.getExternalLink());
 
         updateDescription(asset.getDescription());
 
@@ -336,28 +345,29 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
 
         updateTokenImage(openSeaAsset);
 
-        if (!TextUtils.isEmpty(openSeaAsset.name))
+        String name = openSeaAsset.name;
+        if (!TextUtils.isEmpty(name))
         {
-            setTitle(openSeaAsset.name);
-            addInfoView(getString(R.string.hint_contract_name), openSeaAsset.name);
+            setTitle(name);
+            tivName.setValue(name);
         }
 
         if (openSeaAsset.creator != null
                 && openSeaAsset.creator.user != null)
         {
-            addInfoView(getString(R.string.asset_creator), openSeaAsset.creator.user.username);
+            tivCreator.setValue(openSeaAsset.creator.user.username);
         }
 
         if (openSeaAsset.assetContract != null)
         {
-            addInfoView(getString(R.string.asset_schema), openSeaAsset.assetContract.getSchemaName());
+            tivTokenStandard.setValue(openSeaAsset.assetContract.getSchemaName());
         }
 
         if (openSeaAsset.collection != null
                 && openSeaAsset.collection.stats != null)
         {
-            addInfoView(getString(R.string.asset_total_supply), String.valueOf(openSeaAsset.collection.stats.totalSupply));
-            addInfoView(getString(R.string.asset_number_of_owners), String.valueOf(openSeaAsset.collection.stats.numOwners));
+            tivTotalSupply.setValue(String.valueOf(openSeaAsset.collection.stats.totalSupply));
+            tivNumOwners.setValue(String.valueOf(openSeaAsset.collection.stats.numOwners));
             nftAttributeLayout.bind(token, openSeaAsset.traits, openSeaAsset.collection.stats.count);
         }
         else
@@ -368,12 +378,12 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
         if (openSeaAsset.owner != null
                 && openSeaAsset.owner.user != null)
         {
-            addInfoView(getString(R.string.asset_owner), openSeaAsset.owner.user.username);
+            tivOwner.setValue(openSeaAsset.owner.user.username);
         }
 
-        addInfoView(getString(R.string.asset_last_sale), openSeaAsset.getLastSale());
+        tivLastSale.setValue(openSeaAsset.getLastSale());
 
-        addInfoView(getString(R.string.label_external_link), openSeaAsset.externalLink);
+        tivExternalLink.setValue(openSeaAsset.externalLink);
 
         updateDescription(openSeaAsset.description);
 

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -769,8 +769,19 @@ public class TokenFunctionViewModel extends BaseViewModel {
         nftAsset.postValue(asset);
     }
 
+    private void loadExistingMetadata(Token token, BigInteger tokenId)
+    {
+        NFTAsset asset = token.getAssetForToken(tokenId);
+        if (asset != null && !asset.needsLoading())
+        {
+            nftAsset.postValue(asset);
+        }
+    }
+
     public void getAsset(Token token, BigInteger tokenId)
     {
+        loadExistingMetadata(token, tokenId);
+
         openseaDisposable = openseaService.getAsset(token, tokenId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -750,10 +750,10 @@ public class TokenFunctionViewModel extends BaseViewModel {
         return fetchedAsset;
     }
 
-    public void getTokenMetadata(Token token, BigInteger tokenId, NFTAsset a)
+    public void getTokenMetadata(Token token, BigInteger tokenId, NFTAsset oldAsset)
     {
         metadataDisposable = Single.fromCallable(() -> token.fetchTokenMetadata(tokenId))
-                .map(newAsset -> storeAsset(token, tokenId, newAsset, a))
+                .map(fetchedAsset -> storeAsset(token, tokenId, fetchedAsset, oldAsset))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onAssetMetadata, this::onAssetMetadataError);
@@ -784,6 +784,7 @@ public class TokenFunctionViewModel extends BaseViewModel {
 
     private void onAsset(String result, Token token, BigInteger tokenId)
     {
+        NFTAsset oldAsset = token.getAssetForToken(tokenId);
         boolean loadedFromApi = false;
         if (JsonUtils.isValidAsset(result))
         {
@@ -791,10 +792,20 @@ public class TokenFunctionViewModel extends BaseViewModel {
             {
                 JSONObject assetJson = new JSONObject(result);
                 OpenSeaAsset osAsset = new Gson().fromJson(assetJson.toString(), OpenSeaAsset.class);
-                if (osAsset != null && osAsset.isValid()) //check to ensure OpenSea has data
+                if (osAsset != null)
                 {
                     openSeaAsset.postValue(osAsset);
-                    loadedFromApi = true;
+
+                    if (osAsset.isValid())
+                    {
+                        // If asset does not have name, description or image, load from contract later
+                        loadedFromApi = true;
+                    }
+                    else
+                    {
+                        // Search OpenSeaAsset for name, description or image later when `NFTAsset.updateFromRaw()` is invoked
+                        oldAsset.attachOpenSeaAssetData(osAsset);
+                    }
                 }
             }
             catch (JSONException e)
@@ -810,7 +821,7 @@ public class TokenFunctionViewModel extends BaseViewModel {
 
         if (!loadedFromApi)
         {
-            getTokenMetadata(token, tokenId, token.getAssetForToken(tokenId));
+            getTokenMetadata(token, tokenId, oldAsset);
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
@@ -121,6 +121,9 @@ public class NFTImageView extends RelativeLayout {
 
     private void loadTokenImage(OpenSeaAsset asset)
     {
+        fallbackLayout.setVisibility(View.GONE);
+        image.setVisibility(View.VISIBLE);
+
         if (!TextUtils.isEmpty(asset.backgroundColor))
         {
             int color = Color.parseColor("#" + asset.backgroundColor);
@@ -138,6 +141,7 @@ public class NFTImageView extends RelativeLayout {
 
     private void loadTokenImage(NFTAsset asset, String imageUrl)
     {
+        fallbackLayout.setVisibility(View.GONE);
         image.setVisibility(View.VISIBLE);
 
         loadRequest = Glide.with(image.getContext())

--- a/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
@@ -79,10 +79,6 @@ public class TokenInfoView extends LinearLayout
             TextView useView = getTextView(text.length());
             useView.setText(text);
         }
-        else
-        {
-            setVisibility(View.GONE);
-        }
     }
 
     public void setCurrencyValue(double v)

--- a/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.net.Uri;
-import android.text.Spanned;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -16,10 +15,8 @@ import androidx.core.content.ContextCompat;
 import com.alphawallet.app.R;
 import com.alphawallet.app.service.TickerService;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
-public class TokenInfoView extends LinearLayout {
+public class TokenInfoView extends LinearLayout
+{
     private TextView label;
     private TextView value;
     private TextView valueLongText;
@@ -71,19 +68,16 @@ public class TokenInfoView extends LinearLayout {
 
     public void setValue(String text)
     {
-        if (!TextUtils.isEmpty(text))
+        if (!TextUtils.isEmpty(text) && TextUtils.isEmpty(valueStr))
         {
-            if (TextUtils.isEmpty(valueStr))
+            valueStr = text;
+            setVisibility(View.VISIBLE);
+            if (text.startsWith("http"))
             {
-                valueStr = text;
-                setVisibility(View.VISIBLE);
-                if (text.startsWith("http"))
-                {
-                    setLink();
-                }
-                TextView useView = getTextView(text.length());
-                useView.setText(text);
+                setLink();
             }
+            TextView useView = getTextView(text.length());
+            useView.setText(text);
         }
         else
         {
@@ -134,7 +128,8 @@ public class TokenInfoView extends LinearLayout {
         });
     }
 
-    public void setHasPrefix(boolean hasPrefix) {
+    public void setHasPrefix(boolean hasPrefix)
+    {
         this.hasPrefix = hasPrefix;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenInfoView.java
@@ -2,8 +2,11 @@ package com.alphawallet.app.widget;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.TypedArray;
 import android.net.Uri;
 import android.text.Spanned;
+import android.text.TextUtils;
+import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -17,22 +20,48 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 public class TokenInfoView extends LinearLayout {
-    private final TextView label;
-    private final TextView value;
-    private final TextView valueLongText;
+    private TextView label;
+    private TextView value;
+    private TextView valueLongText;
+    private String valueStr;
     private boolean isLink;
     private boolean hasPrefix = false;
 
     public TokenInfoView(Context context, String labelText)
     {
-        super(context);
-        inflate(context, R.layout.item_token_info, this);
-        label = findViewById(R.id.label);
-        value = findViewById(R.id.value);
-        valueLongText = findViewById(R.id.value_long);
-
+        this(context, (AttributeSet) null);
         label.setText(labelText);
         isLink = false;
+    }
+
+    public TokenInfoView(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+        inflate(context, R.layout.item_token_info, this);
+        getAttrs(context, attrs);
+    }
+
+    private void getAttrs(Context context, AttributeSet attrs)
+    {
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attrs,
+                R.styleable.TokenInfoView,
+                0, 0
+        );
+
+        try
+        {
+            int labelRes = a.getResourceId(R.styleable.TokenInfoView_tokenInfoLabel, R.string.empty);
+            label = findViewById(R.id.label);
+            value = findViewById(R.id.value);
+            valueLongText = findViewById(R.id.value_long);
+
+            label.setText(labelRes);
+        }
+        finally
+        {
+            a.recycle();
+        }
     }
 
     public void setLabel(String text)
@@ -40,21 +69,31 @@ public class TokenInfoView extends LinearLayout {
         label.setText(text);
     }
 
-    public void setValue(Spanned text)
-    {
-        TextView useView = getTextView(text.length());
-        useView.setText(text);
-    }
-
     public void setValue(String text)
     {
-        if (text.startsWith("http")) { setLink(); }
-        TextView useView = getTextView(text.length());
-        useView.setText(text);
+        if (!TextUtils.isEmpty(text))
+        {
+            if (TextUtils.isEmpty(valueStr))
+            {
+                valueStr = text;
+                setVisibility(View.VISIBLE);
+                if (text.startsWith("http"))
+                {
+                    setLink();
+                }
+                TextView useView = getTextView(text.length());
+                useView.setText(text);
+            }
+        }
+        else
+        {
+            setVisibility(View.GONE);
+        }
     }
 
     public void setCurrencyValue(double v)
     {
+        setVisibility(View.VISIBLE);
         value.setVisibility(View.VISIBLE);
         valueLongText.setVisibility(View.GONE);
         String prefix = hasPrefix && v > 0 ? "+" : "";

--- a/app/src/main/res/layout/activity_nft_asset_detail.xml
+++ b/app/src/main/res/layout/activity_nft_asset_detail.xml
@@ -44,11 +44,89 @@
                 custom:title="@string/label_details"
                 tools:visibility="visible" />
 
-            <LinearLayout
-                android:id="@+id/layout_token_info"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical" />
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/token_id"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/label_token_id" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/network"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/subtitle_network" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/contract_address"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/contract_address" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/balance"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/balance" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/hint_contract_name" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/external_link"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/label_external_link" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/creator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_creator" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/token_standard"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_schema" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/total_supply"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_total_supply" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/num_owners"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_number_of_owners" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/owner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_owner" />
+
+            <com.alphawallet.app.widget.TokenInfoView
+                android:id="@+id/last_sale"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                custom:tokenInfoLabel="@string/asset_last_sale" />
 
             <ProgressBar
                 android:id="@+id/progress"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -42,6 +42,9 @@
     <declare-styleable name="TokenInfoCategoryView">
         <attr name="title" format="string"/>
     </declare-styleable>
+    <declare-styleable name="TokenInfoView">
+        <attr name="tokenInfoLabel" format="integer"/>
+    </declare-styleable>
     <declare-styleable name="InputView">
         <attr name="label" format="integer" />
         <attr name="imeOptions" format="string" />


### PR DESCRIPTION
Closes #2522 

**NFTAssetDetailActivity**
Instead of dynamically adding entries, I made them static (but initially hidden) so that redundant info from OpenSea API and contract data will not interfere with each other. Previously, loading from one method will clear all the entries loaded from the other method.

**TokenFunctionViewModel**
Modified the flow a bit. Even if `OpenSeaAsset.isValid()` is `false` (no name, image or description), the value will still be posted to the Activity to check if there are any other meaningful data to display. After which, the data from the contract will still be loaded.

**NFTAsset**
When invoking `NFTAsset.updateFromRaw()`, the OpenSea data (via `NFTAsset.attachOpenSeaAssetData()`) from a successful API call will be checked for a valid name, image or description, and will overwrite null/empty values from the `assetMap`