### PR TITLE
Ignore case when filtering suggestions

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
@@ -124,7 +124,7 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
     private void processSeed(View view)
     {
         this.seedPhrase.setError(null);
-        String newMnemonic = seedPhrase.getText().toString().toLowerCase();
+        String newMnemonic = seedPhrase.getText().toString().toLowerCase(Locale.ENGLISH);
         seedPhrase.getEditText().setText("");
         seedPhrase.getEditText().append(newMnemonic);
         if (TextUtils.isEmpty(newMnemonic)) {
@@ -174,7 +174,7 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
     @Override
     public void afterTextChanged(Editable editable)
     {
-        String value = seedPhrase.getText().toString().toLowerCase();
+        String value = seedPhrase.getText().toString().toLowerCase(Locale.ENGLISH);
         passwordPhraseCounter = new PasswordPhraseCounter(wordCount(value));
 
         if (seedPhrase.isErrorState()) seedPhrase.setError(null);
@@ -303,6 +303,6 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
         seed.append(value);
         seed.append(" ");
         seedPhrase.getEditText().setText("");
-        seedPhrase.getEditText().append(seed.toString().toLowerCase());
+        seedPhrase.getEditText().append(seed.toString().toLowerCase(Locale.ENGLISH));
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
@@ -124,7 +124,9 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
     private void processSeed(View view)
     {
         this.seedPhrase.setError(null);
-        String newMnemonic = seedPhrase.getText().toString();
+        String newMnemonic = seedPhrase.getText().toString().toLowerCase();
+        seedPhrase.getEditText().setText("");
+        seedPhrase.getEditText().append(newMnemonic);
         if (TextUtils.isEmpty(newMnemonic)) {
             this.seedPhrase.setError(getString(R.string.error_field_required));
         } else {

--- a/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/ImportSeedFragment.java
@@ -172,7 +172,7 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
     @Override
     public void afterTextChanged(Editable editable)
     {
-        String value = seedPhrase.getText().toString();
+        String value = seedPhrase.getText().toString().toLowerCase();
         passwordPhraseCounter = new PasswordPhraseCounter(wordCount(value));
 
         if (seedPhrase.isErrorState()) seedPhrase.setError(null);
@@ -297,6 +297,10 @@ public class ImportSeedFragment extends ImportFragment implements OnSuggestionCl
     @Override
     public void onSuggestionClick(String value)
     {
-        seedPhrase.getEditText().append(value + " ");
+        StringBuilder seed = new StringBuilder(seedPhrase.getEditText().getText().toString());
+        seed.append(value);
+        seed.append(" ");
+        seedPhrase.getEditText().setText("");
+        seedPhrase.getEditText().append(seed.toString().toLowerCase());
     }
 }


### PR DESCRIPTION
Closes #2543

Unfortunately, for this issue
> Should start with lowercase (Look for the shift key in the keyboard in the screenshot)

It varies from every device. We have already implemented the most common solution for this which is `inputType=textMultiline`, but some manufacturers still force capitalization for the first letter.

This PR alleviates this by:
1. Ignoring the case when filtering for suggestions
2. Converting the whole seed phrase to lower case whenever a suggestion is clicked OR before submitting the final seed