### PR TITLE
Optimize image display

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
@@ -269,7 +269,7 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
     {
         if (asset != null)
         {
-            updateTokenImage(asset);
+            updateTokenImage(asset.getImage());
 
             addMetaDataInfo(asset);
 
@@ -279,31 +279,20 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
         }
     }
 
-    private void updateTokenImage(NFTAsset asset)
+    private void updateTokenImage(String imageUrl)
     {
-        if (asset.isBlank())
+        if (tokenImage.shouldLoad(imageUrl))
         {
-            tokenImage.showFallbackLayout(token);
-        }
-        else
-        {
-            tokenImage.setWebViewHeight(tokenImage.getLayoutParams().width);
-            tokenImage.showLoadingProgress(true);
-            tokenImage.setupTokenImage(asset);
-        }
-    }
-
-    private void updateTokenImage(OpenSeaAsset openSeaAsset)
-    {
-        if (TextUtils.isEmpty(openSeaAsset.getImageUrl()))
-        {
-            tokenImage.showFallbackLayout(token);
-        }
-        else
-        {
-            tokenImage.setWebViewHeight(tokenImage.getLayoutParams().width);
-            tokenImage.showLoadingProgress(true);
-            tokenImage.setupTokenImage(openSeaAsset);
+            if (TextUtils.isEmpty(imageUrl))
+            {
+                tokenImage.showFallbackLayout(token);
+            }
+            else
+            {
+                tokenImage.setWebViewHeight(tokenImage.getLayoutParams().width);
+                tokenImage.showLoadingProgress(true);
+                tokenImage.setupTokenImage(asset);
+            }
         }
     }
 
@@ -343,7 +332,7 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
     {
         updateDefaultTokenData();
 
-        updateTokenImage(openSeaAsset);
+        updateTokenImage(openSeaAsset.getImageUrl());
 
         String name = openSeaAsset.name;
         if (!TextUtils.isEmpty(name))

--- a/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
@@ -41,7 +41,8 @@ import java.nio.charset.StandardCharsets;
 /**
  * Created by JB on 30/05/2021.
  */
-public class NFTImageView extends RelativeLayout {
+public class NFTImageView extends RelativeLayout
+{
     private final ImageView image;
     private final RelativeLayout webLayout;
     private final WebView webView;
@@ -50,17 +51,17 @@ public class NFTImageView extends RelativeLayout {
     private final TokenIcon fallbackIcon;
     private final ProgressBar progressBar;
     private final Handler handler = new Handler(Looper.getMainLooper());
-    private Request loadRequest;
-
     /**
      * Prevent glide dumping log errors - it is expected that load will fail
      */
-    private final RequestListener<Drawable> requestListener = new RequestListener<Drawable>() {
+    private final RequestListener<Drawable> requestListener = new RequestListener<Drawable>()
+    {
         @Override
         public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource)
         {
             //couldn't load using glide, fallback to webview
-            if (model != null) {
+            if (model != null)
+            {
                 progressBar.setVisibility(View.GONE);
                 setWebView(model.toString());
             }
@@ -74,7 +75,8 @@ public class NFTImageView extends RelativeLayout {
             return false;
         }
     };
-
+    private Request loadRequest;
+    private String imageUrl;
     private boolean hasContent;
     private boolean showProgress;
 
@@ -109,18 +111,19 @@ public class NFTImageView extends RelativeLayout {
 
     public void setupTokenImage(NFTAsset asset)
     {
-        progressBar.setVisibility(showProgress? View.VISIBLE : View.GONE);
+        progressBar.setVisibility(showProgress ? View.VISIBLE : View.GONE);
         loadTokenImage(asset, asset.getImage());
     }
 
     public void setupTokenImage(OpenSeaAsset asset)
     {
-        progressBar.setVisibility(showProgress? View.VISIBLE : View.GONE);
+        progressBar.setVisibility(showProgress ? View.VISIBLE : View.GONE);
         loadTokenImage(asset);
     }
 
     private void loadTokenImage(OpenSeaAsset asset)
     {
+        this.imageUrl = asset.getImageUrl();
         fallbackLayout.setVisibility(View.GONE);
         image.setVisibility(View.VISIBLE);
 
@@ -131,7 +134,7 @@ public class NFTImageView extends RelativeLayout {
         }
 
         loadRequest = Glide.with(image.getContext())
-                .load(asset.getImageUrl())
+                .load(this.imageUrl)
                 .centerCrop()
                 .transition(withCrossFade())
                 .override(Target.SIZE_ORIGINAL)
@@ -141,11 +144,12 @@ public class NFTImageView extends RelativeLayout {
 
     private void loadTokenImage(NFTAsset asset, String imageUrl)
     {
+        this.imageUrl = imageUrl;
         fallbackLayout.setVisibility(View.GONE);
         image.setVisibility(View.VISIBLE);
 
         loadRequest = Glide.with(image.getContext())
-                .load(imageUrl)
+                .load(this.imageUrl)
                 .centerCrop()
                 .transition(withCrossFade())
                 .override(Target.SIZE_ORIGINAL)
@@ -195,7 +199,8 @@ public class NFTImageView extends RelativeLayout {
             {
                 setWebViewHeight(Utils.dp2px(getContext(), height));
             }
-        } finally
+        }
+        finally
         {
             a.recycle();
         }
@@ -221,7 +226,8 @@ public class NFTImageView extends RelativeLayout {
         return hasContent;
     }
 
-    public void showLoadingProgress(boolean showProgress) {
+    public void showLoadingProgress(boolean showProgress)
+    {
         this.showProgress = showProgress;
     }
 
@@ -229,5 +235,24 @@ public class NFTImageView extends RelativeLayout {
     public boolean onInterceptTouchEvent(MotionEvent ev)
     {
         return true;
+    }
+
+    public boolean shouldLoad(String url)
+    {
+        if (this.imageUrl == null)
+        {
+            return true;
+        }
+        else
+        {
+            if (TextUtils.isEmpty(url))
+            {
+                return false;
+            }
+            else
+            {
+                return !this.imageUrl.equals(url);
+            }
+        }
     }
 }


### PR DESCRIPTION
Since we are loading data from 3 sources, the image flickers when data rapidly changes. This PR attempts to smoothen out the process.

Current scenario (MachineFi token):
1. Image found in existing metadata:  **Load image**
2. OpenSea returns null image: **Display the fallback layout (token symbol)**
3. Contract fetch returns an image url: **Reload image**

With this PR:
1. Image found in existing metadata:  **Load image**
2. OpenSea returns null - **Do nothing since we already have an image displayed**
3. Contract fetch returns an image url: **Do nothing because it is the same as existing one**