### PR TITLE
Fixed missing +/- controls (Numeric Input Bottom Sheet)

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/NumericInputBottomSheet.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/NumericInputBottomSheet.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -22,8 +23,8 @@ public class NumericInputBottomSheet extends ConstraintLayout
 {
     private final TextView textAmountMax;
     private final NumericInput textAmount;
-    private final Button buttonUp;
-    private final Button buttonDown;
+    private final ImageButton buttonUp;
+    private final ImageButton buttonDown;
     private final ImageView cancel;
     private AmountReadyCallback amountReady;
     private final boolean gotFocus;

--- a/app/src/main/res/layout/numeric_input_bottom.xml
+++ b/app/src/main/res/layout/numeric_input_bottom.xml
@@ -72,7 +72,7 @@
         app:layout_constraintStart_toEndOf="@id/guidelineInnerLeft"
         app:layout_constraintTop_toBottomOf="@id/divider">
 
-        <Button
+        <ImageButton
             android:id="@+id/number_down"
             android:layout_width="32dp"
             android:layout_height="32dp"
@@ -90,7 +90,7 @@
             android:inputType="numberDecimal"
             tools:text="25" />
 
-        <Button
+        <ImageButton
             android:id="@+id/number_up"
             android:layout_width="32dp"
             android:layout_height="32dp"


### PR DESCRIPTION
Numeric Input Bottom Sheet has missing +/- controls; using `ImageButton` instead of `Button` solves the issue