### PR TITLE
Improve gas estimate

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/GasService.java
+++ b/app/src/main/java/com/alphawallet/app/service/GasService.java
@@ -437,28 +437,6 @@ public class GasService implements ContractGasProvider
                 .flatMap(feeHistory -> SuggestEIP1559Kt.SuggestEIP1559(this, feeHistory));
     }
 
-    private EIP1559FeeOracleResult get1559Gas(long chainId)
-    {
-        EIP1559FeeOracleResult oracleResult = null;
-        try (Realm realm = realmManager.getRealmInstance(TICKER_DB))
-        {
-            Realm1559Gas rgs = realm.where(Realm1559Gas.class)
-                    .equalTo("chainId", chainId)
-                    .findFirst();
-
-            if (rgs != null)
-            {
-                oracleResult = rgs.getResult().get(0);
-            }
-        }
-        catch (Exception e)
-        {
-            //
-        }
-
-        return oracleResult;
-    }
-
     private void handleError(Throwable err)
     {
         Timber.w(err);

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -679,6 +679,7 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
             {
                 viewModel.startBalanceUpdate();
                 startBalanceListener();
+                viewModel.updateGasPrice(activeNetwork.chainId);
             }
         }
         if (urlTv != null)
@@ -1154,6 +1155,7 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
             viewModel.setNetwork(newNetworkId);
             onNetworkChanged(viewModel.getNetworkInfo(newNetworkId));
             startBalanceListener();
+            viewModel.updateGasPrice(newNetworkId);
         }
         //refresh URL page
         reloadPage();
@@ -1371,8 +1373,6 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
     {
         try
         {
-            viewModel.updateGasPrice(activeNetwork.chainId); //start updating gas price right before we open
-            //TODO: Ensure we have received gas price before continuing
             //minimum for transaction to be valid: recipient and value or payload
             if ((confirmationDialog == null || !confirmationDialog.isShowing()) &&
                     (transaction.recipient.equals(Address.EMPTY) && transaction.payload != null) // Constructor

--- a/app/src/main/java/com/alphawallet/app/ui/GasSettingsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/GasSettingsActivity.java
@@ -125,7 +125,7 @@ public class GasSettingsActivity extends BaseActivity implements GasSettingsCall
         availableBalance = new BigDecimal(getIntent().getStringExtra(C.EXTRA_TOKEN_BALANCE));
         sendAmount = new BigDecimal(getIntent().getStringExtra(C.EXTRA_AMOUNT));
         gasSliderView.setNonce(getIntent().getLongExtra(C.EXTRA_NONCE, -1));
-        gasSliderView.initGasLimit(customGasLimit.toBigInteger());
+        gasSliderView.initGasLimit(customGasLimit.toBigInteger(), presetGasLimit.toBigInteger());
         gasSpread = getIntent().getParcelableExtra(C.EXTRA_GAS_PRICE);
         isUsing1559 = getIntent().getBooleanExtra(C.EXTRA_1559_TX, false);
 
@@ -355,7 +355,7 @@ public class GasSettingsActivity extends BaseActivity implements GasSettingsCall
             holder.itemLayout.setOnClickListener(v -> {
                 if (position == TXSpeed.CUSTOM && currentGasSpeedIndex != TXSpeed.CUSTOM)
                 {
-                    gasSliderView.initGasLimit(customGasLimit.toBigInteger());
+                    gasSliderView.initGasLimit(customGasLimit.toBigInteger(), presetGasLimit.toBigInteger());
                     gasSliderView.reportPosition();
                 }
                 else if (position != TXSpeed.CUSTOM && currentGasSpeedIndex == TXSpeed.CUSTOM)

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -189,8 +189,6 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         }
     }
 
-    int fragCount = 0;
-
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState)
     {

--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
@@ -1,6 +1,5 @@
 package com.alphawallet.app.ui;
 
-import static com.alphawallet.app.widget.AWalletAlertDialog.ERROR;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 
 import android.content.BroadcastReceiver;
@@ -849,17 +848,15 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
 
     private ActionSheetDialog generateTransactionRequest(Web3Transaction w3Tx, long chainId)
     {
-        ActionSheetDialog confDialog = null;
         try
         {
-            //minimum for transaction to be valid: recipient and value or payload
             if ((confirmationDialog == null || !confirmationDialog.isShowing()) &&
                     (w3Tx.recipient.equals(Address.EMPTY) && w3Tx.payload != null) // Constructor
                     || (!w3Tx.recipient.equals(Address.EMPTY) && (w3Tx.payload != null || w3Tx.value != null))) // Raw or Function TX
             {
                 WCPeerMeta remotePeerData = viewModel.getRemotePeer(getSessionId());
                 Token token = viewModel.getTokensService().getTokenOrBase(chainId, w3Tx.recipient.toString());
-                confDialog = new ActionSheetDialog(this, w3Tx, token, "",
+                final ActionSheetDialog confDialog = new ActionSheetDialog(this, w3Tx, token, "",
                         w3Tx.recipient.toString(), viewModel.getTokensService(), this);
                 confDialog.setURL(remotePeerData.getUrl());
                 confDialog.setCanceledOnTouchOutside(false);
@@ -869,18 +866,19 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
                         chainId, w3Tx.recipient.toString(), new BigDecimal(w3Tx.value), w3Tx.gasLimit)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(estimate -> confirmationDialog.setGasEstimate(estimate),
+                        .subscribe(confDialog::setGasEstimate,
                                 Throwable::printStackTrace)
                         .isDisposed();
+
+                return confDialog;
             }
         }
         catch (Exception e)
         {
-            confDialog = null;
             Timber.e(e);
         }
 
-        return confDialog;
+        return null;
     }
 
     private void killSession()

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -1,5 +1,7 @@
 package com.alphawallet.app.viewmodel;
 
+import static com.alphawallet.app.C.Key.WALLET;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -46,6 +48,8 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.inject.Inject;
+
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -53,10 +57,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
-
-import static com.alphawallet.app.C.Key.WALLET;
-
-import javax.inject.Inject;
 
 @HiltViewModel
 public class DappBrowserViewModel extends BaseViewModel  {
@@ -276,6 +276,7 @@ public class DappBrowserViewModel extends BaseViewModel  {
     public void onDestroy()
     {
         if (balanceTimerDisposable != null && !balanceTimerDisposable.isDisposed()) balanceTimerDisposable.dispose();
+        gasService.stopGasPriceCycle();
     }
 
     public void updateGasPrice(long chainId)
@@ -301,6 +302,7 @@ public class DappBrowserViewModel extends BaseViewModel  {
     {
         if (balanceTimerDisposable != null && !balanceTimerDisposable.isDisposed()) balanceTimerDisposable.dispose();
         balanceTimerDisposable = null;
+        gasService.stopGasPriceCycle();
     }
 
     public void handleWalletConnect(Context context, String url, NetworkInfo activeNetwork)

--- a/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
@@ -183,7 +183,8 @@ public class ActionSheetDialog extends BottomSheetDialog implements StandardFunc
 
         use1559Transactions = canUse1559Transactions && has1559Gas() //1559 Transactions toggled on in settings and this chain supports 1559
                 && !(token.isEthereum() && candidateTransaction.leafPosition == -2) //User not sweeping wallet (if so we need to use legacy tx)
-                && !tokensService.hasLockedGas(token.tokenInfo.chainId); //Service has locked gas, can only use legacy (eg Optimism).
+                && !tokensService.hasLockedGas(token.tokenInfo.chainId) //Service has locked gas, can only use legacy (eg Optimism).
+                && !candidateTransaction.isConstructor(); //Currently cannot use EIP1559 for constructors due to gas calculation issues
 
         if (use1559Transactions)
         {

--- a/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
@@ -5,7 +5,6 @@ import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_
 import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.media.Image;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -27,7 +26,6 @@ import com.alphawallet.app.entity.TXSpeed;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.nftassets.NFTAsset;
 import com.alphawallet.app.entity.tokens.Token;
-import com.alphawallet.app.repository.EthereumNetworkBase;
 import com.alphawallet.app.repository.SharedPreferenceRepository;
 import com.alphawallet.app.repository.entity.Realm1559Gas;
 import com.alphawallet.app.repository.entity.RealmTransaction;
@@ -145,6 +143,11 @@ public class ActionSheetDialog extends BottomSheetDialog implements StandardFunc
         functionBar.revealButtons();
 
         gasWidgetInterface = setupGasWidget();
+
+        if (!tx.gasLimit.equals(BigInteger.ZERO))
+        {
+            setGasEstimate(tx.gasLimit);
+        }
 
         updateAmount();
 

--- a/app/src/main/java/com/alphawallet/app/widget/GasWidget.java
+++ b/app/src/main/java/com/alphawallet/app/widget/GasWidget.java
@@ -525,6 +525,11 @@ public class GasWidget extends LinearLayout implements Runnable, GasWidgetInterf
      */
     public void setGasEstimate(BigInteger estimate)
     {
+        if (!isSendingAll && estimate.longValue() > C.GAS_LIMIT_MIN) //some kind of contract interaction
+        {
+            estimate = estimate.multiply(BigInteger.valueOf(6)).divide(BigInteger.valueOf(5)); // increase estimate by 20% to be safe
+        }
+
         //Override custom gas limit
         if (customGasLimit.equals(baseLineGasLimit))
         {

--- a/app/src/main/java/com/alphawallet/app/widget/GasWidget2.java
+++ b/app/src/main/java/com/alphawallet/app/widget/GasWidget2.java
@@ -494,6 +494,11 @@ public class GasWidget2 extends LinearLayout implements Runnable, GasWidgetInter
      */
     public void setGasEstimate(BigInteger estimate)
     {
+        if (estimate.longValue() > C.GAS_LIMIT_MIN) //some kind of contract interaction
+        {
+            estimate = estimate.multiply(BigInteger.valueOf(6)).divide(BigInteger.valueOf(5)); // increase estimate by 20% to be safe
+        }
+
         //Override custom gas limit if required
         if (customGasLimit.equals(presetGasLimit))
         {


### PR DESCRIPTION
Improves gas estimate:

- Use +20% safety margin for contract transaction sends.
- If pure Ethereum to address; use 21000 as normal.
- If pure Ethereum send to contract, with additional receive handling; add 20% to estimate.
- In Gas limit slider, set minimum gas to estimate, default to estimate +20% and max to estimate +500%. This allows for better fine tuning of gas. Previously we went from 21000 to max block gas, which means it was almost impossible to fine tune the limit as the slider is too sensitive.