### PR TITLE
Milkomeda chain support

### DIFF
--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -86,6 +86,7 @@ public abstract class C {
     public static final String KLAYTN_SYMBOL = "KLAY";
     public static final String IOTEX_SYMBOL = "IOTX";
     public static final String MILKOMEDA_SYMBOL = "milkADA";
+    public static final String MILKOMEDA_TEST_SYMBOL = "milktADA";
 
     public static final String BURN_ADDRESS = "0x0000000000000000000000000000000000000000";
 

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -54,6 +54,8 @@ public abstract class C {
     public static final String IOTEX_TESTNET_NAME = "IoTeX (Test)";
     public static final String AURORA_MAINNET_NAME = "Aurora";
     public static final String AURORA_TESTNET_NAME = "Aurora (Test)";
+    public static final String MILKOMEDA_NAME = "Milkomeda Cardano";
+    public static final String MILKOMEDA_TESTNET_NAME = "Milkomeda Cardano (Test)";
 
     public static final String ETHEREUM_TICKER_NAME = "ethereum";
     public static final String CLASSIC_TICKER_NAME = "ethereum-classic";
@@ -83,6 +85,7 @@ public abstract class C {
     public static final String PALM_SYMBOL = "PALM";
     public static final String KLAYTN_SYMBOL = "KLAY";
     public static final String IOTEX_SYMBOL = "IOTX";
+    public static final String MILKOMEDA_SYMBOL = "milkADA";
 
     public static final String BURN_ADDRESS = "0x0000000000000000000000000000000000000000";
 

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -338,7 +338,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                     MILKOMEDA_C1_RPC,
                     "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/tx/", MILKOMEDA_C1_ID, "",
                     "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/api?"));
-            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo(C.MILKOMEDA_TESTNET_NAME, C.MILKOMEDA_SYMBOL,
+            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo(C.MILKOMEDA_TESTNET_NAME, C.MILKOMEDA_TEST_SYMBOL,
                     MILKOMEDA_C1_TEST_RPC,
                     "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/", MILKOMEDA_C1_TEST_ID, "",
                     "https://explorer-devnet-cardano-evm.c1.milkomeda.com/api?"));

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -34,6 +34,10 @@ import static com.alphawallet.ethereum.EthereumNetworkBase.KOVAN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MATIC_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MATIC_TEST_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MILKOMEDA_C1_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MILKOMEDA_C1_RPC;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MILKOMEDA_C1_TEST_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MILKOMEDA_C1_TEST_RPC;
 import static com.alphawallet.ethereum.EthereumNetworkBase.OPTIMISTIC_MAIN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.OPTIMISTIC_TEST_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.PALM_ID;
@@ -190,7 +194,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
     //Then xDai would appear as the first token at the top of the wallet
     private static final List<Long> hasValue = new ArrayList<>(Arrays.asList(
             MAINNET_ID, CLASSIC_ID, XDAI_ID, POA_ID, ARTIS_SIGMA1_ID, BINANCE_MAIN_ID, HECO_ID, AVALANCHE_ID,
-            FANTOM_ID, MATIC_ID, OPTIMISTIC_MAIN_ID, ARBITRUM_MAIN_ID, PALM_ID, KLAYTN_ID, IOTEX_MAINNET_ID, AURORA_MAINNET_ID));
+            FANTOM_ID, MATIC_ID, OPTIMISTIC_MAIN_ID, ARBITRUM_MAIN_ID, PALM_ID, KLAYTN_ID, IOTEX_MAINNET_ID, AURORA_MAINNET_ID, MILKOMEDA_C1_ID));
 
     // for reset built-in network
     private static final LongSparseArray<NetworkInfo> builtinNetworkMap = new LongSparseArray<NetworkInfo>() {
@@ -321,7 +325,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
                     "https://api.covalenthq.com/v1/" + COVALENT));
             put(IOTEX_TESTNET_ID, new NetworkInfo(C.IOTEX_TESTNET_NAME, C.IOTEX_SYMBOL,
                     IOTEX_TESTNET_RPC_URL,
-                    "https://testnet.iotexscan.io/tx", IOTEX_TESTNET_ID, "",
+                    "https://testnet.iotexscan.io/tx/", IOTEX_TESTNET_ID, "",
                     "https://api.covalenthq.com/v1/" + COVALENT));
             put(AURORA_MAINNET_ID, new NetworkInfo(C.AURORA_MAINNET_NAME, C.ETH_SYMBOL, AURORA_MAINNET_RPC_URL,
                     "https://aurorascan.dev/tx/", AURORA_MAINNET_ID, "",
@@ -329,6 +333,15 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(AURORA_TESTNET_ID, new NetworkInfo(C.AURORA_TESTNET_NAME, C.ETH_SYMBOL, AURORA_TESTNET_RPC_URL,
                     "https://testnet.aurorascan.dev/tx/", AURORA_TESTNET_ID, "",
                     "https://api-testnet.aurorascan.dev/api?"));
+
+            put(MILKOMEDA_C1_ID, new NetworkInfo(C.MILKOMEDA_NAME, C.MILKOMEDA_SYMBOL,
+                    MILKOMEDA_C1_RPC,
+                    "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/tx/", MILKOMEDA_C1_ID, "",
+                    "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/api?"));
+            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo(C.MILKOMEDA_TESTNET_NAME, C.MILKOMEDA_SYMBOL,
+                    MILKOMEDA_C1_TEST_RPC,
+                    "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/", MILKOMEDA_C1_TEST_ID, "",
+                    "https://explorer-devnet-cardano-evm.c1.milkomeda.com/api?"));
         }
     };
 
@@ -372,6 +385,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(IOTEX_TESTNET_ID, R.drawable.ic_iotex_test);
             put(AURORA_MAINNET_ID, R.drawable.ic_aurora);
             put(AURORA_TESTNET_ID, R.drawable.ic_aurora_test);
+            put(MILKOMEDA_C1_ID, R.drawable.ic_milkomeda);
+            put(MILKOMEDA_C1_TEST_ID, R.drawable.ic_milkomeda_test);
         }
     };
 
@@ -411,6 +426,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(IOTEX_TESTNET_ID, R.drawable.ic_iotex_test);
             put(AURORA_MAINNET_ID, R.drawable.ic_aurora);
             put(AURORA_TESTNET_ID, R.drawable.ic_aurora_test);
+            put(MILKOMEDA_C1_ID, R.drawable.ic_milkomeda);
+            put(MILKOMEDA_C1_TEST_ID, R.drawable.ic_milkomeda_test);
         }
     };
 
@@ -450,6 +467,8 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(IOTEX_TESTNET_ID, R.color.iotex_mainnet);
             put(AURORA_MAINNET_ID, R.color.aurora_mainnet);
             put(AURORA_TESTNET_ID, R.color.aurora_testnet);
+            put(MILKOMEDA_C1_ID, R.color.milkomeda);
+            put(MILKOMEDA_C1_TEST_ID, R.color.milkomeda_test);
         }
     };
 

--- a/app/src/main/java/com/alphawallet/app/service/TickerService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TickerService.java
@@ -13,6 +13,7 @@ import static com.alphawallet.ethereum.EthereumNetworkBase.IOTEX_MAINNET_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.KLAYTN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.MATIC_ID;
+import static com.alphawallet.ethereum.EthereumNetworkBase.MILKOMEDA_C1_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.OPTIMISTIC_MAIN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.POA_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.RINKEBY_ID;
@@ -709,6 +710,7 @@ public class TickerService
         put(KLAYTN_ID, "klay-token");
         put(IOTEX_MAINNET_ID, "iotex");
         put(AURORA_MAINNET_ID, "aurora");
+        put(MILKOMEDA_C1_ID, "cardano");
     }};
 
     private static final Map<Long, String> dexGuruChainIdToAPISymbol = new HashMap<Long, String>(){{
@@ -739,6 +741,7 @@ public class TickerService
         put(KLAYTN_ID, "klay-token");
         put(IOTEX_MAINNET_ID, "iotex");
         put(AURORA_MAINNET_ID, "aurora");
+        put(MILKOMEDA_C1_ID, "cardano");
     }};
 
     public static boolean validateCoinGeckoAPI(Token token)

--- a/app/src/main/res/drawable/ic_milkomeda.xml
+++ b/app/src/main/res/drawable/ic_milkomeda.xml
@@ -4,7 +4,7 @@
     android:viewportHeight="32" xmlns:android="http://schemas.android.com/apk/res/android">
     <path
         android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
-        android:fillColor="#222222"/>
+        android:fillColor="#141414"/>
     <group android:scaleX="0.15" android:scaleY="0.15" android:translateX="1.5" android:translateY="8.3">
         <path android:fillColor="#FFFFFF" android:pathData="M179,35.45l13.54,23.43 -71.3,41.17S77.6,126.44 46.21,72l22.2,-12.82s14.42,31.89 39.43,17.41S179,35.45 179,35.45Z"/>
         <path android:fillColor="#FFFFFF" android:pathData="M13.54,71.87 L0,48.44l72.82,-42s43.66,-26.39 75.05,28L125.66,47.23S111.24,15.34 86.23,29.82 13.54,71.87 13.54,71.87Z"/>

--- a/app/src/main/res/drawable/ic_milkomeda.xml
+++ b/app/src/main/res/drawable/ic_milkomeda.xml
@@ -1,0 +1,15 @@
+<vector android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
+        android:fillColor="#222222"/>
+    <group android:scaleX="0.15" android:scaleY="0.15" android:translateX="1.5" android:translateY="8.3">
+        <path android:fillColor="#FFFFFF" android:pathData="M179,35.45l13.54,23.43 -71.3,41.17S77.6,126.44 46.21,72l22.2,-12.82s14.42,31.89 39.43,17.41S179,35.45 179,35.45Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M13.54,71.87 L0,48.44l72.82,-42s43.66,-26.39 75.05,28L125.66,47.23S111.24,15.34 86.23,29.82 13.54,71.87 13.54,71.87Z"/>
+        <path android:fillColor="#ff931e" android:pathData="M97.66,71.3A17.8,17.8 0,1 0,79.87 53.51,17.8 17.8,0 0,0 97.66,71.3Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M34.84,99.07a9.29,9.29 0,1 0,-9.3 -9.29A9.28,9.28 0,0 0,34.84 99.07Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M158.86,27.46a9.3,9.3 0,1 0,-9.29 -9.3A9.29,9.29 0,0 0,158.86 27.46Z"/>
+    </group>
+</vector>

--- a/app/src/main/res/drawable/ic_milkomeda_test.xml
+++ b/app/src/main/res/drawable/ic_milkomeda_test.xml
@@ -4,7 +4,7 @@
     android:viewportHeight="32" xmlns:android="http://schemas.android.com/apk/res/android">
     <path
         android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
-        android:fillColor="#292929"/>
+        android:fillColor="#242424"/>
     <group android:scaleX="0.15" android:scaleY="0.15" android:translateX="1.5" android:translateY="8.3">
         <path android:fillColor="#FFFFFF" android:pathData="M179,35.45l13.54,23.43 -71.3,41.17S77.6,126.44 46.21,72l22.2,-12.82s14.42,31.89 39.43,17.41S179,35.45 179,35.45Z"/>
         <path android:fillColor="#FFFFFF" android:pathData="M13.54,71.87 L0,48.44l72.82,-42s43.66,-26.39 75.05,28L125.66,47.23S111.24,15.34 86.23,29.82 13.54,71.87 13.54,71.87Z"/>

--- a/app/src/main/res/drawable/ic_milkomeda_test.xml
+++ b/app/src/main/res/drawable/ic_milkomeda_test.xml
@@ -1,0 +1,15 @@
+<vector android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
+        android:fillColor="#292929"/>
+    <group android:scaleX="0.15" android:scaleY="0.15" android:translateX="1.5" android:translateY="8.3">
+        <path android:fillColor="#FFFFFF" android:pathData="M179,35.45l13.54,23.43 -71.3,41.17S77.6,126.44 46.21,72l22.2,-12.82s14.42,31.89 39.43,17.41S179,35.45 179,35.45Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M13.54,71.87 L0,48.44l72.82,-42s43.66,-26.39 75.05,28L125.66,47.23S111.24,15.34 86.23,29.82 13.54,71.87 13.54,71.87Z"/>
+        <path android:fillColor="#ff931e" android:pathData="M97.66,71.3A17.8,17.8 0,1 0,79.87 53.51,17.8 17.8,0 0,0 97.66,71.3Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M34.84,99.07a9.29,9.29 0,1 0,-9.3 -9.29A9.28,9.28 0,0 0,34.84 99.07Z"/>
+        <path android:fillColor="#FFFFFF" android:pathData="M158.86,27.46a9.3,9.3 0,1 0,-9.29 -9.3A9.29,9.29 0,0 0,158.86 27.46Z"/>
+    </group>
+</vector>

--- a/app/src/main/res/values/colors_misc.xml
+++ b/app/src/main/res/values/colors_misc.xml
@@ -43,5 +43,8 @@
     <color name="iotex_mainnet">#00D4D5</color>
     <color name="aurora_mainnet">#6BBE47</color>
     <color name="aurora_testnet">#B2C6D8</color>
+    <color name="milkomeda">#222222</color>
+    <color name="milkomeda_test">#292929</color>
+
 
 </resources>

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -153,9 +153,9 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
             put(AURORA_TESTNET_ID, new NetworkInfo("Aurora (Test)","ETH", AURORA_TESTNET_RPC_URL, "https://testnet.aurorascan.dev/tx/",
                     AURORA_TESTNET_ID, false));
 
-            put(MILKOMEDA_C1_ID, new NetworkInfo("Milkomeda Cardano","milkADA", KLAYTN_RPC, "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/",
+            put(MILKOMEDA_C1_ID, new NetworkInfo("Milkomeda Cardano","milkADA", MILKOMEDA_C1_RPC, "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/tx/",
                     MILKOMEDA_C1_ID, false));
-            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo("Milkomeda Cardano (Test)","milkADA", KLAYTN_BAOBAB_RPC, "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/",
+            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo("Milkomeda Cardano (Test)","milktADA", MILKOMEDA_C1_TEST_RPC, "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/",
                     MILKOMEDA_C1_TEST_ID, false));
         }
     };

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -42,6 +42,8 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
     public static final long IOTEX_TESTNET_ID = 4690;
     public static final long AURORA_MAINNET_ID = 1313161554;
     public static final long AURORA_TESTNET_ID = 1313161555;
+    public static final long MILKOMEDA_C1_ID = 2001;
+    public static final long MILKOMEDA_C1_TEST_ID = 200101;
 
 
     public static final String MAINNET_RPC_URL = "https://mainnet.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
@@ -76,7 +78,8 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
     public static final String KLAYTN_BAOBAB_RPC = "https://api.baobab.klaytn.net:8651";
     public static final String AURORA_MAINNET_RPC_URL = "https://mainnet.aurora.dev";
     public static final String AURORA_TESTNET_RPC_URL = "https://testnet.aurora.dev";
-
+    public static final String MILKOMEDA_C1_RPC = "https://rpc-mainnet-cardano-evm.c1.milkomeda.com";
+    public static final String MILKOMEDA_C1_TEST_RPC = "https://rpc-devnet-cardano-evm.c1.milkomeda.com";
 
     static Map<Long, NetworkInfo> networkMap = new LinkedHashMap<Long, NetworkInfo>() {
         {
@@ -149,6 +152,11 @@ public abstract class EthereumNetworkBase { // implements EthereumNetworkReposit
                     AURORA_MAINNET_ID, false));
             put(AURORA_TESTNET_ID, new NetworkInfo("Aurora (Test)","ETH", AURORA_TESTNET_RPC_URL, "https://testnet.aurorascan.dev/tx/",
                     AURORA_TESTNET_ID, false));
+
+            put(MILKOMEDA_C1_ID, new NetworkInfo("Milkomeda Cardano","milkADA", KLAYTN_RPC, "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/",
+                    MILKOMEDA_C1_ID, false));
+            put(MILKOMEDA_C1_TEST_ID, new NetworkInfo("Milkomeda Cardano (Test)","milkADA", KLAYTN_BAOBAB_RPC, "https://explorer-devnet-cardano-evm.c1.milkomeda.com/tx/",
+                    MILKOMEDA_C1_TEST_ID, false));
         }
     };
 


### PR DESCRIPTION
This PR adds Milkomeda chain support. Milkomeda is a EVM compatible side-chain for the Cardano network. Milkomeda does not have a token of it's own, rather it's main asset is wrapped ADA, known as MilkADA. 

The PR includes the addition of Milkomeda chain definitions for main and tests nets, as well as Ticker service for mainnet.