### PR TITLE
Fix NFT balance update

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -362,7 +362,7 @@ public class EventSync
      * Event Handling
      */
 
-    public Pair<Integer, HashSet<BigInteger>> processTransferEvents(Web3j web3j, Event transferEvent, DefaultBlockParameter startBlock,
+    public Pair<Integer, Pair<HashSet<BigInteger>, HashSet<BigInteger>>> processTransferEvents(Web3j web3j, Event transferEvent, DefaultBlockParameter startBlock,
                                                                        DefaultBlockParameter endBlock, Realm realm)
             throws IOException, LogOverflowException
     {
@@ -378,7 +378,7 @@ public class EventSync
 
         int eventCount = receiveLogs.getLogs().size();
 
-        HashSet<BigInteger> tokenIds = new HashSet<>(token.processLogsAndStoreTransferEvents(receiveLogs, transferEvent, txHashes, realm));
+        HashSet<BigInteger> rcvTokenIds = new HashSet<>(token.processLogsAndStoreTransferEvents(receiveLogs, transferEvent, txHashes, realm));
 
         EthLog sentLogs = web3j.ethGetLogs(sendFilter).send();
 
@@ -389,7 +389,7 @@ public class EventSync
 
         if (sentLogs.getLogs().size() > eventCount) eventCount = sentLogs.getLogs().size();
 
-        token.processLogsAndStoreTransferEvents(sentLogs, transferEvent, txHashes, realm);
+        HashSet<BigInteger> sendTokenIds = token.processLogsAndStoreTransferEvents(sentLogs, transferEvent, txHashes, realm);
 
         //register Transaction fetches
         for (String txHash : txHashes)
@@ -397,7 +397,7 @@ public class EventSync
             TransactionsService.addTransactionHashFetch(txHash, token.tokenInfo.chainId, token.getWallet());
         }
 
-        return new Pair<>(eventCount, tokenIds);
+        return new Pair<>(eventCount, new Pair<>(rcvTokenIds, sendTokenIds));
     }
 
     public String getActivityName(String toAddress)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
@@ -638,20 +638,20 @@ public class ERC1155Token extends Token
         {
             final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
 
-            Pair<Integer, HashSet<BigInteger>> evRead = eventSync.processTransferEvents(web3j,
+            Pair<Integer, Pair<HashSet<BigInteger>, HashSet<BigInteger>>> evRead = eventSync.processTransferEvents(web3j,
                     getBalanceUpdateEvents(), startBlock, endBlock, realm);
 
-            Pair<Integer, HashSet<BigInteger>> batchRead = eventSync.processTransferEvents(web3j,
+            Pair<Integer, Pair<HashSet<BigInteger>, HashSet<BigInteger>>> batchRead = eventSync.processTransferEvents(web3j,
                     getBatchBalanceUpdateEvents(), startBlock, endBlock, realm);
 
-            evRead.second.addAll(batchRead.second);
+            evRead.second.first.addAll(batchRead.second.first);
             //combine the tokenIds with existing assets
-            evRead.second.addAll(assets.keySet());
+            evRead.second.first.addAll(assets.keySet());
 
             //update balances of all
-            List<Uint256> balances = fetchBalances(evRead.second);
+            List<Uint256> balances = fetchBalances(evRead.second.first);
             //update realm
-            updateRealmBalance(realm, evRead.second, balances);
+            updateRealmBalance(realm, evRead.second.first, balances);
 
             //update read points
             eventSync.updateEventReads(realm, sync, currentBlock, evRead.first); //means our event read was fine

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
@@ -387,13 +387,16 @@ public class ERC1155Token extends Token
                 BigDecimal newBalance = new BigDecimal(balances.get(index).getValue());
                 if (asset == null)
                 {
-                    assets.put(tokenId, new NFTAsset(tokenId));
+                    NFTAsset newAsset = new NFTAsset(tokenId);
+                    newAsset.setBalance(newBalance);
+                    assets.put(tokenId, newAsset);
                     updated = true;
                 }
-                if (assets.get(tokenId).setBalance(newBalance) && !updated) //set balance and check for change
+                else if (asset.setBalance(newBalance))
                 {
                     updated = true;
                 }
+
                 if (realm == null && newBalance.equals(BigDecimal.ZERO))
                 {
                     assets.remove(tokenId);
@@ -403,36 +406,40 @@ public class ERC1155Token extends Token
 
             if (updated)
             {
-                updateRealmBalances(realm, tokenIds);
+                updateRealmBalances(realm);
             }
         }
     }
 
-    private void updateRealmBalances(Realm realm, Set<BigInteger> tokenIds)
+    private void updateRealmBalances(Realm realm)
     {
         if (realm == null) return;
         realm.executeTransaction(r -> {
-            for (BigInteger tokenId : tokenIds)
+            for (Map.Entry<BigInteger, NFTAsset> entry : assets.entrySet())
             {
+                BigInteger tokenId = entry.getKey();
+                NFTAsset asset = entry.getValue();
                 String key = RealmNFTAsset.databaseKey(this, tokenId);
                 RealmNFTAsset realmAsset = realm.where(RealmNFTAsset.class)
                         .equalTo("tokenIdAddr", key)
                         .findFirst();
 
+                if (realmAsset == null && asset.getBalance().equals(BigDecimal.ZERO)) continue; // no recorded token, no balance, skip
+
                 if (realmAsset == null)
                 {
                     realmAsset = r.createObject(RealmNFTAsset.class, key); //create asset in realm
-                    realmAsset.setMetaData(assets.get(tokenId).jsonMetaData());
+                    realmAsset.setMetaData(asset.jsonMetaData());
                 }
 
-                if (assets.get(tokenId).getBalance().equals(BigDecimal.ZERO)) //remove asset no longer in balance
+                if (asset.getBalance().equals(BigDecimal.ZERO)) //remove asset no longer in balance
                 {
                     realmAsset.deleteFromRealm();
                     assets.remove(tokenId);
                 }
                 else
                 {
-                    realmAsset.setBalance(assets.get(tokenId).getBalance()); //update realm balance
+                    realmAsset.setBalance(entry.getValue().getBalance()); //update realm balance
                     r.insertOrUpdate(realmAsset);
                 }
             }
@@ -644,7 +651,11 @@ public class ERC1155Token extends Token
             Pair<Integer, Pair<HashSet<BigInteger>, HashSet<BigInteger>>> batchRead = eventSync.processTransferEvents(web3j,
                     getBatchBalanceUpdateEvents(), startBlock, endBlock, realm);
 
+            // All tokenIds which have passed through the owner address
+            evRead.second.first.addAll(evRead.second.second);
             evRead.second.first.addAll(batchRead.second.first);
+            evRead.second.first.addAll(batchRead.second.second);
+
             //combine the tokenIds with existing assets
             evRead.second.first.addAll(assets.keySet());
 

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -348,11 +348,6 @@ public class ERC721Token extends Token
             HashSet<BigInteger> allMovingTokens = new HashSet<>(evRead.second.first);
             allMovingTokens.addAll(evRead.second.second);
 
-            if (tokenInfo.address.equalsIgnoreCase("0xd915c8AD3241F459a45AdcBBF8af42caA561A154"))
-            {
-                System.out.println("YOLESS");
-            }
-
             if (allMovingTokens.size() == 0 && balance.intValue() != tokenBalanceAssets.size()) //if there's a mismatch, check all current assets
             {
                 allMovingTokens.addAll(tokenBalanceAssets.keySet());


### PR DESCRIPTION
For networks without OpenSea it was noticed that while receiving NFT works correctly, when sending them the balance was not updated correctly.

This update ensures the balance is always synced.