### PR TITLE
Fix for incorrect background asset

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
@@ -286,7 +286,7 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
         tokenImage.setupTokenImage(asset);
         triggeredReload = false;
 
-        if (TextUtils.isEmpty(asset.getImage()))
+        if (!tokenImage.isDisplayingImage() && TextUtils.isEmpty(asset.getImage()))
         {
             tokenImage.showFallbackLayout(token);
         }

--- a/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
@@ -244,4 +244,9 @@ public class NFTImageView extends RelativeLayout
     {
         imageUrl = null;
     }
+
+    public boolean isDisplayingImage()
+    {
+        return !TextUtils.isEmpty(imageUrl);
+    }
 }


### PR DESCRIPTION
Fix for bug where background asset would be displayed if (eg) IPFS metadata load fails