### PR TITLE
Avoid HomeActivity.onWalletName getFragment() indexOutOfBounds crash.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -475,7 +475,15 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
             walletTitle = getString(R.string.toolbar_header_wallet);
         }
 
-        getFragment(WALLET).setToolbarTitle(walletTitle);
+        // putting in a try catch to avoid crashing the app
+        try
+        {
+            getFragment(WALLET).setToolbarTitle(walletTitle);
+        }
+        catch (Exception e)
+        {
+            Timber.e(e);
+        }
     }
 
     private void onError(ErrorEnvelope errorEnvelope)


### PR DESCRIPTION
Fixes #2642   

The app crashes on trying to rename the header with currently selected wallet's name/ens-name. Not able to reproduce the issue, but I have put in a try catch block to avoid crashing the app.