### PR TITLE
Removed force dark mode for internal browser

### DIFF
--- a/app/src/main/java/com/alphawallet/app/web3/Web3View.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3View.java
@@ -225,20 +225,22 @@ public class Web3View extends WebView {
                 innerOnEthCallListener,
                 innerAddChainListener,
                 innerOnWalletActionListener), "alpha");
-
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK))
-        {
-            switch (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
-            {
-                case Configuration.UI_MODE_NIGHT_YES:
-                    WebSettingsCompat.setForceDark(getSettings(), FORCE_DARK_ON);
-                    break;
-                case Configuration.UI_MODE_NIGHT_NO:
-                case Configuration.UI_MODE_NIGHT_UNDEFINED:
-                    WebSettingsCompat.setForceDark(getSettings(), FORCE_DARK_OFF);
-                    break;
-            }
-        }
+        
+//        Removing this block for now.
+//        TODO: Figure out if we should support dark mode for external websites
+//        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK))
+//        {
+//            switch (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
+//            {
+//                case Configuration.UI_MODE_NIGHT_YES:
+//                    WebSettingsCompat.setForceDark(getSettings(), FORCE_DARK_ON);
+//                    break;
+//                case Configuration.UI_MODE_NIGHT_NO:
+//                case Configuration.UI_MODE_NIGHT_UNDEFINED:
+//                    WebSettingsCompat.setForceDark(getSettings(), FORCE_DARK_OFF);
+//                    break;
+//            }
+//        }
     }
 
     @Nullable


### PR DESCRIPTION
Closes #2632 

The internal browser previously forces dark mode (similar to how Chrome dark mode works). If a website has not implemented it's own dark mode feature, it could sometimes cause issues.

In this PR, I have commented out this block of code until we decide to revisit it in the future.