### PR TITLE
2641 implicit internal intent

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/FinishReceiver.java
+++ b/app/src/main/java/com/alphawallet/app/entity/FinishReceiver.java
@@ -6,21 +6,35 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.alphawallet.app.C;
 
 public class FinishReceiver extends BroadcastReceiver
 {
     private final Activity activity;
+    private final LocalBroadcastManager broadcastManager;
+
     public FinishReceiver(Activity ctx)
     {
         activity = ctx;
-        ctx.registerReceiver(this, new IntentFilter(C.PRUNE_ACTIVITY));
+        broadcastManager = LocalBroadcastManager.getInstance(ctx);
+        register();
+    }
+
+    private void register()
+    {
+        broadcastManager.registerReceiver(this, new IntentFilter(C.PRUNE_ACTIVITY));
     }
 
     @Override
     public void onReceive(Context context, Intent intent)
     {
-        if (intent.getAction().equals(C.PRUNE_ACTIVITY))
-            activity.finish();
+        activity.finish();
+    }
+
+    public void unregister()
+    {
+        broadcastManager.unregisterReceiver(this);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/HomeReceiver.java
+++ b/app/src/main/java/com/alphawallet/app/entity/HomeReceiver.java
@@ -1,23 +1,23 @@
 package com.alphawallet.app.entity;
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.alphawallet.app.C;
 
 public class HomeReceiver extends BroadcastReceiver
 {
     private final HomeCommsInterface homeCommsInterface;
-    public HomeReceiver(Activity ctx, HomeCommsInterface homeCommsInterface)
+    private final LocalBroadcastManager broadcastManager;
+
+    public HomeReceiver(Context context, HomeCommsInterface homeCommsInterface)
     {
-        ctx.registerReceiver(this, new IntentFilter(C.DOWNLOAD_READY));
-        ctx.registerReceiver(this, new IntentFilter(C.REQUEST_NOTIFICATION_ACCESS));
-        ctx.registerReceiver(this, new IntentFilter(C.BACKUP_WALLET_SUCCESS));
-        ctx.registerReceiver(this, new IntentFilter(C.WALLET_CONNECT_REQUEST));
+        broadcastManager = LocalBroadcastManager.getInstance(context);
         this.homeCommsInterface = homeCommsInterface;
     }
 
@@ -44,5 +44,20 @@ public class HomeReceiver extends BroadcastReceiver
             default:
                 break;
         }
+    }
+
+    public void register()
+    {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(C.DOWNLOAD_READY);
+        filter.addAction(C.REQUEST_NOTIFICATION_ACCESS);
+        filter.addAction(C.BACKUP_WALLET_SUCCESS);
+        filter.addAction(C.WALLET_CONNECT_REQUEST);
+        broadcastManager.registerReceiver(this, filter);
+    }
+
+    public void unregister()
+    {
+        broadcastManager.unregisterReceiver(this);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/NotificationService.java
+++ b/app/src/main/java/com/alphawallet/app/service/NotificationService.java
@@ -14,6 +14,7 @@ import android.net.Uri;
 import android.os.Build;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
@@ -126,7 +127,7 @@ public class NotificationService
                         != PackageManager.PERMISSION_DENIED))
         {
             Intent intent = new Intent(C.REQUEST_NOTIFICATION_ACCESS);
-            context.sendBroadcast(intent);
+            LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/WalletConnectService.java
+++ b/app/src/main/java/com/alphawallet/app/service/WalletConnectService.java
@@ -15,6 +15,7 @@ import android.os.IBinder;
 import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.entity.WalletConnectActions;
@@ -364,7 +365,7 @@ public class WalletConnectService extends Service
             Intent intent = new Intent(WALLET_CONNECT_REQUEST);
             intent.putExtra("sessionid", sessionId);
             intent.putExtra("wcrequest", rq);
-            sendBroadcast(intent);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
 
             Timber.tag(TAG).d("Connected clients: %s", clientMap.size());
         }

--- a/app/src/main/java/com/alphawallet/app/service/WalletConnectService.java
+++ b/app/src/main/java/com/alphawallet/app/service/WalletConnectService.java
@@ -314,7 +314,7 @@ public class WalletConnectService extends Service
             i.putExtra(C.EXTRA_SESSION_ID, client.sessionId());
             i.putExtra(C.EXTRA_CHAIN_ID, chainId);
             i.putExtra(C.EXTRA_NAME, client.getPeerMeta().getName());
-            WalletConnectService.this.sendBroadcast(i);
+            sendWalletConnectBroadcast(i);
             return Unit.INSTANCE;
         });
 
@@ -324,9 +324,14 @@ public class WalletConnectService extends Service
             i.putExtra(C.EXTRA_WC_REQUEST_ID, requestId);
             i.putExtra(C.EXTRA_SESSION_ID, client.sessionId());
             i.putExtra(C.EXTRA_CHAIN_OBJ, chainObj);
-            WalletConnectService.this.sendBroadcast(i);
+            sendWalletConnectBroadcast(i);
             return Unit.INSTANCE;
         });
+    }
+
+    private void sendWalletConnectBroadcast(Intent i)
+    {
+        LocalBroadcastManager.getInstance(this).sendBroadcast(i);
     }
 
     //TODO: Can we determine if AlphaWallet is running? If it is, no need to add this to the queue,
@@ -346,14 +351,14 @@ public class WalletConnectService extends Service
         Intent intent = new Intent(command);
         intent.putExtra("sessionid", sessionId);
         intent.putExtra("wcrequest", getPendingRequest(sessionId));     // pass WCRequest as parcelable in the intent
-        sendBroadcast(intent);
+        sendWalletConnectBroadcast(intent);
     }
 
     private void broadcastConnectionCount(int count)
     {
         Intent intent = new Intent(WALLET_CONNECT_COUNT_CHANGE);
         intent.putExtra("count", count);
-        sendBroadcast(intent);
+        sendWalletConnectBroadcast(intent);
     }
 
     private void switchToWalletConnectApprove(String sessionId, WCRequest rq)
@@ -365,7 +370,7 @@ public class WalletConnectService extends Service
             Intent intent = new Intent(WALLET_CONNECT_REQUEST);
             intent.putExtra("sessionid", sessionId);
             intent.putExtra("wcrequest", rq);
-            LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+            sendWalletConnectBroadcast(intent);
 
             Timber.tag(TAG).d("Connected clients: %s", clientMap.size());
         }

--- a/app/src/main/java/com/alphawallet/app/ui/AssetDisplayActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AssetDisplayActivity.java
@@ -246,7 +246,10 @@ public class AssetDisplayActivity extends BaseActivity implements StandardFuncti
     protected void onDestroy()
     {
         super.onDestroy();
-        unregisterReceiver(finishReceiver);
+        if (finishReceiver != null)
+        {
+            finishReceiver.unregister();
+        }
         viewModel.clearFocusToken();
         if (adapter != null) adapter.onDestroy(tokenView);
         viewModel.onDestroy();

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -502,6 +502,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         if (homeReceiver == null)
         {
             homeReceiver = new HomeReceiver(this, this);
+            homeReceiver.register();
         }
         initViews();
 
@@ -598,7 +599,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         viewModel.onClean();
         if (homeReceiver != null)
         {
-            unregisterReceiver(homeReceiver);
+            homeReceiver.unregister();
             homeReceiver = null;
         }
     }

--- a/app/src/main/java/com/alphawallet/app/ui/RedeemAssetSelectActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/RedeemAssetSelectActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -126,7 +127,10 @@ public class RedeemAssetSelectActivity extends BaseActivity implements TokensAda
     protected void onDestroy()
     {
         super.onDestroy();
-        unregisterReceiver(finishReceiver);
+        if (finishReceiver != null)
+        {
+            finishReceiver.unregister();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/RedeemSignatureDisplayActivity.java
@@ -10,6 +10,8 @@ import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ImageView;
@@ -153,7 +155,10 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
     protected void onDestroy()
     {
         super.onDestroy();
-        unregisterReceiver(finishReceiver);
+        if (finishReceiver != null)
+        {
+            finishReceiver.unregister();
+        }
     }
 
     @Override
@@ -179,7 +184,7 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
         dialog.setTitle(R.string.ticket_redeemed);
         dialog.setIcon(AWalletAlertDialog.SUCCESS);
         dialog.setOnDismissListener(v -> {
-            sendBroadcast(new Intent(PRUNE_ACTIVITY));
+            LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(PRUNE_ACTIVITY));
         });
         dialog.show();
     }
@@ -259,7 +264,7 @@ public class RedeemSignatureDisplayActivity extends BaseActivity implements View
         dialog.setIcon(AWalletAlertDialog.ERROR);
         dialog.setMessage(getString(R.string.fail_sign));
         dialog.setOnDismissListener(v -> {
-            sendBroadcast(new Intent(PRUNE_ACTIVITY));
+            LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(PRUNE_ACTIVITY));
         });
         dialog.show();
     }

--- a/app/src/main/java/com/alphawallet/app/ui/SellDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SellDetailActivity.java
@@ -9,7 +9,6 @@ import android.os.Handler;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.format.DateUtils;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -21,6 +20,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.MissingFormatArgumentException;
 
-import javax.inject.Inject;
 import timber.log.Timber;
 
 import static com.alphawallet.app.C.EXTRA_PRICE;
@@ -170,7 +169,10 @@ public class SellDetailActivity extends BaseActivity implements TokensAdapterCal
     protected void onDestroy()
     {
         super.onDestroy();
-        unregisterReceiver(finishReceiver);
+        if (finishReceiver != null)
+        {
+            finishReceiver.unregister();
+        }
     }
 
     private void setupPage(Wallet wallet)
@@ -497,7 +499,7 @@ public class SellDetailActivity extends BaseActivity implements TokensAdapterCal
 
     ActivityResultLauncher<Intent> sellLinkFinalResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
             result -> {
-                sendBroadcast(new Intent(PRUNE_ACTIVITY)); //TODO: implement prune via result codes
+                sendBroadcastToPrune(); //TODO: implement prune via result codes
             });
 
     private void sellLinkFinal(String universalLink) {
@@ -554,7 +556,7 @@ public class SellDetailActivity extends BaseActivity implements TokensAdapterCal
         switch (requestCode)
         {
             case SEND_INTENT_REQUEST_CODE:
-                sendBroadcast(new Intent(PRUNE_ACTIVITY));
+                sendBroadcastToPrune();
                 break;
 
             case SignTransactionDialog.REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS:
@@ -564,6 +566,11 @@ public class SellDetailActivity extends BaseActivity implements TokensAdapterCal
             default:
                 super.onActivityResult(requestCode, resultCode, data);
         }
+    }
+
+    private void sendBroadcastToPrune()
+    {
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(PRUNE_ACTIVITY));
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/TransferTicketDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TransferTicketDetailActivity.java
@@ -34,6 +34,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatRadioButton;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -685,7 +686,7 @@ public class TransferTicketDetailActivity extends BaseActivity
 
     ActivityResultLauncher<Intent> transferLinkFinalResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
             result -> {
-                sendBroadcast(new Intent(PRUNE_ACTIVITY)); //TODO: implement prune via result codes
+                LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(PRUNE_ACTIVITY)); //TODO: implement prune via result codes
             });
 
     private void transferLinkFinal(String universalLink)

--- a/app/src/main/java/com/alphawallet/app/ui/WalletActionsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletActionsActivity.java
@@ -21,6 +21,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.BackupOperationType;
@@ -288,7 +289,7 @@ public class WalletActionsActivity extends BaseActivity implements Runnable, Vie
     private void backupSuccessful() {
         Intent intent = new Intent(BACKUP_WALLET_SUCCESS);
         intent.putExtra("Key", wallet.address);
-        sendBroadcast(intent);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
     }
 
     private void hideDialog() {

--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectActivity.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
@@ -90,6 +91,7 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
     private static final String DEFAULT_IDON = "https://example.walletconnect.org/favicon.ico";
     private static final long CONNECT_TIMEOUT = 10 * DateUtils.SECOND_IN_MILLIS; // 10 Seconds timeout
     private final Handler handler = new Handler(Looper.getMainLooper());
+    private final LocalBroadcastManager broadcastManager;
     WalletConnectViewModel viewModel;
     private WCClient client;
     private WCSession session;
@@ -185,6 +187,11 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
             }
         }
     };
+
+    public WalletConnectActivity()
+    {
+        broadcastManager = LocalBroadcastManager.getInstance(this);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState)
@@ -580,7 +587,7 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
         filter.addAction(C.WALLET_CONNECT_CLIENT_TERMINATE);
         filter.addAction(C.WALLET_CONNECT_SWITCH_CHAIN);
         filter.addAction(C.WALLET_CONNECT_ADD_CHAIN);
-        registerReceiver(walletConnectActionReceiver, filter);
+        broadcastManager.registerReceiver(walletConnectActionReceiver, filter);
     }
 
     private String getSessionId()
@@ -966,7 +973,7 @@ public class WalletConnectActivity extends BaseActivity implements ActionSheetCa
     public void onPause()
     {
         super.onPause();
-        unregisterReceiver(walletConnectActionReceiver);
+        broadcastManager.unregisterReceiver(walletConnectActionReceiver);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/WalletConnectSessionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletConnectSessionActivity.java
@@ -22,6 +22,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -47,6 +48,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 public class WalletConnectSessionActivity extends BaseActivity
 {
     private final Handler handler = new Handler(Looper.getMainLooper());
+    private final LocalBroadcastManager broadcastManager;
     WalletConnectViewModel viewModel;
     private RecyclerView recyclerView;
     private Button btnConnectWallet;
@@ -68,6 +70,11 @@ public class WalletConnectSessionActivity extends BaseActivity
             }
         }
     };
+
+    public WalletConnectSessionActivity()
+    {
+        broadcastManager = LocalBroadcastManager.getInstance(this);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState)
@@ -209,12 +216,12 @@ public class WalletConnectSessionActivity extends BaseActivity
 
     private void startConnectionCheck()
     {
-        registerReceiver(walletConnectChangeReceiver, new IntentFilter(C.WALLET_CONNECT_COUNT_CHANGE));
+        broadcastManager.registerReceiver(walletConnectChangeReceiver, new IntentFilter(C.WALLET_CONNECT_COUNT_CHANGE));
     }
 
     private void stopConnectionCheck()
     {
-        unregisterReceiver(walletConnectChangeReceiver);
+        broadcastManager.unregisterReceiver(walletConnectChangeReceiver);
     }
 
     public class CustomAdapter extends RecyclerView.Adapter<CustomAdapter.CustomViewHolder>

--- a/app/src/main/java/com/alphawallet/app/ui/WalletsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletsActivity.java
@@ -408,7 +408,7 @@ public class WalletsActivity extends BaseActivity implements
     public void HDKeyCreated(String address, Context ctx, KeyService.AuthenticationLevel level)
     {
         if (address == null) onCreateWalletError(new ErrorEnvelope(""));
-        else viewModel.StoreHDWallet(address, level);
+        else viewModel.storeHDWallet(address, level);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -27,6 +27,7 @@ import android.widget.Toast;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.alphawallet.app.C;
 import com.alphawallet.app.R;
@@ -303,11 +304,11 @@ public class HomeViewModel extends BaseViewModel {
         BroadcastReceiver onComplete = new BroadcastReceiver() {
             public void onReceive(Context ctxt, Intent intent) {
                 installIntent.postValue(testFile);
-                ctx.unregisterReceiver(this);
+                LocalBroadcastManager.getInstance(ctxt).unregisterReceiver(this);
             }
         };
 
-        ctx.registerReceiver(onComplete, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        LocalBroadcastManager.getInstance(ctx).registerReceiver(onComplete, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
     }
 
     public void getWalletName(Context context) {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletsViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletsViewModel.java
@@ -419,7 +419,7 @@ public class WalletsViewModel extends BaseViewModel implements ServiceSyncCallba
         return currentNetwork;
     }
 
-    public void StoreHDWallet(String address, KeyService.AuthenticationLevel authLevel)
+    public void storeHDWallet(String address, KeyService.AuthenticationLevel authLevel)
     {
         if (!address.equals(ZERO_ADDRESS))
         {


### PR DESCRIPTION
fix #2641 
**TLDR;**
Helper to register for and send broadcasts of Intents to local objects within your process. This has a number of advantages over sending global broadcasts with [Context.sendBroadcast(Intent)](https://developer.android.com/reference/android/content/Context.html#sendBroadcast(android.content.Intent)):

1. You know that the data you are broadcasting won't leave your app, so don't need to worry about leaking private data.
2. It is not possible for other applications to send these broadcasts to your app, so you don't need to worry about having security holes they can exploit.
3. It is more efficient than sending a global broadcast through the system.

**Read more**
https://developer.android.com/reference/androidx/localbroadcastmanager/content/LocalBroadcastManager