### PR TITLE
Ensure selector is reset when switching networks

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
@@ -288,6 +288,11 @@ public class SwapActivity extends BaseActivity implements StandardFunctionInterf
             sourceSelector.init(selectedToken);
             sourceTokenChanged(selectedToken);
         }
+        else
+        {
+            sourceSelector.reset();
+            infoLayout.setVisibility(View.GONE);
+        }
 
         //TODO: Add base 'ETH' to dest tokens in selector
         /*long networkId = fromTokens.get(0).chainId;


### PR DESCRIPTION
Fixed an issue where source selector is not visible when switching network from swap settings