### PR TITLE
[Swap] Sort Tokens in Dialog

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/SelectTokenDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/SelectTokenDialog.java
@@ -21,10 +21,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.lifi.Connection;
 import com.alphawallet.app.ui.widget.adapter.SelectTokenAdapter;
-import com.alphawallet.app.ui.widget.divider.ListDivider;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 public class SelectTokenDialog extends BottomSheetDialog
@@ -64,6 +65,13 @@ public class SelectTokenDialog extends BottomSheetDialog
         this.tokenItems = tokenItems;
 
         noResultsText.setVisibility(tokenItems.size() > 0 ? View.GONE : View.VISIBLE);
+
+        Collections.sort(tokenItems, (l, r) -> l.name.compareTo(r.name));
+        Collections.sort(tokenItems, (l, r) -> {
+            BigDecimal lBal = new BigDecimal(l.balance);
+            BigDecimal rBal = new BigDecimal(r.balance);
+            return rBal.compareTo(lBal);
+        });
 
         adapter = new SelectTokenAdapter(tokenItems, callback);
 

--- a/app/src/main/java/com/alphawallet/app/widget/SelectTokenDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/SelectTokenDialog.java
@@ -66,7 +66,7 @@ public class SelectTokenDialog extends BottomSheetDialog
 
         noResultsText.setVisibility(tokenItems.size() > 0 ? View.GONE : View.VISIBLE);
 
-        Collections.sort(tokenItems, (l, r) -> l.name.compareTo(r.name));
+        Collections.sort(tokenItems, (l, r) -> l.name.compareToIgnoreCase(r.name));
         Collections.sort(tokenItems, (l, r) -> {
             BigDecimal lBal = new BigDecimal(l.balance);
             BigDecimal rBal = new BigDecimal(r.balance);


### PR DESCRIPTION
Fixes one of the items in #2692

Sorted the tokens in the selection dialog such that:

- Tokens with balance are showed first - sorted in descending order; then
- Tokens with zero balance are sorted alphabetically