### PR TITLE
[Swap] Improve search filter on SelectTokenDialog

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
@@ -95,11 +95,11 @@ public class SelectTokenAdapter extends RecyclerView.Adapter<SelectTokenAdapter.
         {
             if (data.name.toLowerCase(Locale.ENGLISH).contains(searchFilter.toLowerCase(Locale.ENGLISH)))
             {
-                filteredList.add(data);
+                if (!filteredList.contains(data)) filteredList.add(data);
             }
             else if (data.symbol.toLowerCase(Locale.ENGLISH).contains(searchFilter.toLowerCase(Locale.ENGLISH)))
             {
-                filteredList.add(data);
+                if (!filteredList.contains(data)) filteredList.add(data);
             }
         }
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
@@ -81,6 +81,18 @@ public class SelectTokenAdapter extends RecyclerView.Adapter<SelectTokenAdapter.
         List<Connection.LToken> filteredList = new ArrayList<>();
         for (Connection.LToken data : tokens)
         {
+            if (data.name.toLowerCase(Locale.ENGLISH).startsWith(searchFilter.toLowerCase(Locale.ENGLISH)))
+            {
+                filteredList.add(data);
+            }
+            else if (data.symbol.toLowerCase(Locale.ENGLISH).startsWith(searchFilter.toLowerCase(Locale.ENGLISH)))
+            {
+                filteredList.add(data);
+            }
+        }
+
+        for (Connection.LToken data : tokens)
+        {
             if (data.name.toLowerCase(Locale.ENGLISH).contains(searchFilter.toLowerCase(Locale.ENGLISH)))
             {
                 filteredList.add(data);
@@ -90,6 +102,7 @@ public class SelectTokenAdapter extends RecyclerView.Adapter<SelectTokenAdapter.
                 filteredList.add(data);
             }
         }
+
         updateList(filteredList);
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/SelectTokenAdapter.java
@@ -18,18 +18,17 @@ import com.google.android.material.radiobutton.MaterialRadioButton;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 public class SelectTokenAdapter extends RecyclerView.Adapter<SelectTokenAdapter.ViewHolder>
 {
-    private final List<Connection.LToken> tokens;
     private final List<Connection.LToken> displayData;
     private final SelectTokenDialog.SelectTokenDialogEventListener callback;
     private String selectedTokenAddress;
+    private final TokenFilter tokenFilter;
 
     public SelectTokenAdapter(List<Connection.LToken> tokens, SelectTokenDialog.SelectTokenDialogEventListener callback)
     {
-        this.tokens = tokens;
+        tokenFilter = new TokenFilter(tokens);
         this.callback = callback;
         displayData = new ArrayList<>();
         displayData.addAll(tokens);
@@ -76,34 +75,9 @@ public class SelectTokenAdapter extends RecyclerView.Adapter<SelectTokenAdapter.
         }
     }
 
-    public void filter(String searchFilter)
+    public void filter(String keyword)
     {
-        List<Connection.LToken> filteredList = new ArrayList<>();
-        for (Connection.LToken data : tokens)
-        {
-            if (data.name.toLowerCase(Locale.ENGLISH).startsWith(searchFilter.toLowerCase(Locale.ENGLISH)))
-            {
-                filteredList.add(data);
-            }
-            else if (data.symbol.toLowerCase(Locale.ENGLISH).startsWith(searchFilter.toLowerCase(Locale.ENGLISH)))
-            {
-                filteredList.add(data);
-            }
-        }
-
-        for (Connection.LToken data : tokens)
-        {
-            if (data.name.toLowerCase(Locale.ENGLISH).contains(searchFilter.toLowerCase(Locale.ENGLISH)))
-            {
-                if (!filteredList.contains(data)) filteredList.add(data);
-            }
-            else if (data.symbol.toLowerCase(Locale.ENGLISH).contains(searchFilter.toLowerCase(Locale.ENGLISH)))
-            {
-                if (!filteredList.contains(data)) filteredList.add(data);
-            }
-        }
-
-        updateList(filteredList);
+        updateList(tokenFilter.filterBy(keyword));
     }
 
     public void updateList(List<Connection.LToken> filteredList)

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokenFilter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokenFilter.java
@@ -22,15 +22,30 @@ public class TokenFilter
         String lowerCaseKeyword = lowerCase(keyword);
 
         List<Connection.LToken> result = new ArrayList<>();
+        // First filter: Add all entries that start with the keyword on top of the list.
         for (Connection.LToken lToken : this.tokens)
         {
             String name = lowerCase(lToken.name);
             String symbol = lowerCase(lToken.symbol);
 
-            if (name.startsWith(lowerCaseKeyword) || name.contains(lowerCaseKeyword)
-                    || symbol.startsWith(lowerCaseKeyword) || symbol.contains(lowerCaseKeyword))
+            if (name.startsWith(lowerCaseKeyword) || symbol.startsWith(lowerCaseKeyword))
             {
                 result.add(lToken);
+            }
+        }
+
+        // Second filter: Add the rest of the entries that contain the keyword on top of the list.
+        for (Connection.LToken lToken : this.tokens)
+        {
+            String name = lowerCase(lToken.name);
+            String symbol = lowerCase(lToken.symbol);
+
+            if (name.contains(lowerCaseKeyword) || symbol.contains(lowerCaseKeyword))
+            {
+                if (!result.contains(lToken))
+                {
+                    result.add(lToken);
+                }
             }
         }
         return result;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokenFilter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokenFilter.java
@@ -1,0 +1,45 @@
+package com.alphawallet.app.ui.widget.adapter;
+
+import androidx.annotation.NonNull;
+
+import com.alphawallet.app.entity.lifi.Connection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class TokenFilter
+{
+    private final List<Connection.LToken> tokens;
+
+    public TokenFilter(List<Connection.LToken> tokens)
+    {
+        this.tokens = tokens;
+    }
+
+    public List<Connection.LToken> filterBy(String keyword)
+    {
+        String lowerCaseKeyword = lowerCase(keyword);
+
+        List<Connection.LToken> result = new ArrayList<>();
+        for (Connection.LToken lToken : this.tokens)
+        {
+            String name = lowerCase(lToken.name);
+            String symbol = lowerCase(lToken.symbol);
+
+            if (name.startsWith(lowerCaseKeyword) || name.contains(lowerCaseKeyword)
+                    || symbol.startsWith(lowerCaseKeyword) || symbol.contains(lowerCaseKeyword))
+            {
+                result.add(lToken);
+            }
+        }
+        return result;
+    }
+
+    @NonNull
+    private String lowerCase(String name)
+    {
+        return name.toLowerCase(Locale.ENGLISH);
+    }
+
+}

--- a/app/src/test/java/com/alphawallet/app/ui/widget/adapter/TokenFilterTest.java
+++ b/app/src/test/java/com/alphawallet/app/ui/widget/adapter/TokenFilterTest.java
@@ -72,6 +72,21 @@ public class TokenFilterTest
         assertThat(result.get(0).name, equalTo("Binance"));
     }
 
+    @Test
+    public void should_sort_starts_with_in_front_of_contains()
+    {
+        List<Connection.LToken> list = new ArrayList<>();
+        list.add(createToken("Solana", "SOL", "2"));
+        list.add(createToken("WETH", "WETH", "2"));
+        list.add(createToken("Ethereum", "ETH", "1"));
+        tokenFilter = new TokenFilter(list);
+
+        List<Connection.LToken> result = tokenFilter.filterBy("eth");
+        assertThat(result.size(), equalTo(2));
+        assertThat(result.get(0).name, equalTo("Ethereum"));
+        assertThat(result.get(1).name, equalTo("WETH"));
+    }
+
     @NonNull
     private Connection.LToken createToken(String name, String symbol, String address)
     {

--- a/app/src/test/java/com/alphawallet/app/ui/widget/adapter/TokenFilterTest.java
+++ b/app/src/test/java/com/alphawallet/app/ui/widget/adapter/TokenFilterTest.java
@@ -1,0 +1,84 @@
+package com.alphawallet.app.ui.widget.adapter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import androidx.annotation.NonNull;
+
+import com.alphawallet.app.entity.lifi.Connection;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TokenFilterTest
+{
+    private TokenFilter tokenFilter;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        List<Connection.LToken> list = new ArrayList<>();
+        list.add(createToken("Ethereum", "ETH", "1"));
+        list.add(createToken("Solana", "SOL", "2"));
+        list.add(createToken("Binance", "BNB", "3"));
+        tokenFilter = new TokenFilter(list);
+    }
+
+    @Test
+    public void nameContains()
+    {
+        List<Connection.LToken> result = tokenFilter.filterBy("an");
+        assertThat(result.size(), equalTo(2));
+        assertThat(result.get(0).name, equalTo("Solana"));
+        assertThat(result.get(1).name, equalTo("Binance"));
+    }
+
+    @Test
+    public void nameStartsWith()
+    {
+        List<Connection.LToken> result = tokenFilter.filterBy("So");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).name, equalTo("Solana"));
+    }
+
+    @Test
+    public void symbolContains()
+    {
+        List<Connection.LToken> result = tokenFilter.filterBy("B");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).name, equalTo("Binance"));
+    }
+
+    @Test
+    public void symbolStartsWith()
+    {
+        List<Connection.LToken> result = tokenFilter.filterBy("S");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).name, equalTo("Solana"));
+    }
+
+    @Test
+    public void should_be_case_insensitive()
+    {
+        List<Connection.LToken> result = tokenFilter.filterBy("s");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).name, equalTo("Solana"));
+
+        result = tokenFilter.filterBy("b");
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(0).name, equalTo("Binance"));
+    }
+
+    @NonNull
+    private Connection.LToken createToken(String name, String symbol, String address)
+    {
+        Connection.LToken e = new Connection.LToken();
+        e.name = name;
+        e.symbol = symbol;
+        e.address = address;
+        return e;
+    }
+}


### PR DESCRIPTION
Added a slight improvement to user experience when searching through the token list. With this change, the filtered list prioritizes entries that **starts with** the search filter, THEN all other entries containing the filter

For example, if your search filter is `ETH`, the token `Ethereum (ETH)` will most likely be on top of the list (if combined with changes from #2724).

