### PR TITLE
[DMZ] Tweak message shown https://aw.app/wc is visited

### DIFF
--- a/dmz/src/main/java/com/alphawallet/token/web/AppSiteController.java
+++ b/dmz/src/main/java/com/alphawallet/token/web/AppSiteController.java
@@ -130,6 +130,10 @@ public class AppSiteController implements AttributeInterface
     )
             throws IOException, SAXException, NoHandlerFoundException
     {
+        if (universalLink.equals("wc"))
+        {
+            return "If you are using AlphaWallet with WalletConnect, please launch the AlphaWallet app";
+        }
         String domain = request.getServerName();
         ParseMagicLink parser = new ParseMagicLink(cryptoFunctions, null);
         MagicLinkData data;


### PR DESCRIPTION
Occassionally certain dapp + WalletConnect usage combination results in the user loading https://aw.app/wc in iOS mobile Safari. This smoothens it a little, making it less confusing for users, but ideally users should never need this. Example to reproduce: https://github.com/AlphaWallet/alpha-wallet-ios/issues/4660#issuecomment-1139221167

Before|After
-|-
<img width="634" alt="Screenshot 2022-07-18 at 3 22 39 PM" src="https://user-images.githubusercontent.com/56189/179462720-4f1058f7-c7db-4364-a57f-4b96bb6afaf5.png">|<img width="660" alt="Screenshot 2022-07-18 at 3 21 55 PM" src="https://user-images.githubusercontent.com/56189/179462731-822f4a81-6c3e-4db8-aee4-bc5e385027fe.png">
