### PR TITLE
Exclude unsupported chains from swap settings list

### DIFF
--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/ChainFilter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/ChainFilter.java
@@ -1,0 +1,30 @@
+package com.alphawallet.app.ui.widget.adapter;
+
+import com.alphawallet.app.entity.lifi.Chain;
+import com.alphawallet.ethereum.EthereumNetworkBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChainFilter
+{
+    private final List<Chain> chains;
+
+    public ChainFilter(List<Chain> chains)
+    {
+        this.chains = chains;
+    }
+
+    public List<Chain> getSupportedChains()
+    {
+        List<Chain> filteredChains = new ArrayList<>();
+        for (Chain c : chains)
+        {
+            if (EthereumNetworkBase.getNetworkByChain(c.id) != null)
+            {
+                filteredChains.add(c);
+            }
+        }
+        return filteredChains;
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/widget/SwapSettingsDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/SwapSettingsDialog.java
@@ -3,7 +3,6 @@ package com.alphawallet.app.widget;
 import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED;
 
 import android.app.Activity;
-import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.view.View;
 import android.widget.ImageView;
@@ -14,8 +13,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.alphawallet.app.R;
 import com.alphawallet.app.entity.lifi.Chain;
+import com.alphawallet.app.ui.widget.adapter.ChainFilter;
 import com.alphawallet.app.ui.widget.adapter.SelectChainAdapter;
-import com.alphawallet.app.ui.widget.divider.ListDivider;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
@@ -51,8 +50,8 @@ public class SwapSettingsDialog extends BottomSheetDialog
     public SwapSettingsDialog(Activity activity, List<Chain> chains, SwapSettingsInterface swapSettingsInterface)
     {
         this(activity);
-
-        adapter = new SelectChainAdapter(activity, chains, swapSettingsInterface);
+        ChainFilter filter = new ChainFilter(chains);
+        adapter = new SelectChainAdapter(activity, filter.getSupportedChains(), swapSettingsInterface);
         chainList.setLayoutManager(new LinearLayoutManager(getContext()));
         chainList.setAdapter(adapter);
     }

--- a/app/src/test/java/com/alphawallet/app/ui/widget/adapter/ChainFilterTest.java
+++ b/app/src/test/java/com/alphawallet/app/ui/widget/adapter/ChainFilterTest.java
@@ -1,0 +1,46 @@
+package com.alphawallet.app.ui.widget.adapter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import androidx.annotation.NonNull;
+
+import com.alphawallet.app.entity.lifi.Chain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChainFilterTest
+{
+    private ChainFilter chainFilter;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        List<Chain> list = new ArrayList<>();
+        list.add(createChain(1285, "Moonriver"));
+        list.add(createChain(1, "Ethereum"));
+        list.add(createChain(137, "Matic"));
+        chainFilter = new ChainFilter(list);
+    }
+
+    @Test
+    public void should_not_contain_unsupported_chain()
+    {
+        List<Chain> result = chainFilter.getSupportedChains();
+        assertThat(result.get(0).name, equalTo("Ethereum"));
+        assertThat(result.get(1).name, equalTo("Matic"));
+    }
+
+    @NonNull
+    private Chain createChain(long id, String name)
+    {
+        Chain c = new Chain();
+        c.id = id;
+        c.name = name;
+        return c;
+    }
+}


### PR DESCRIPTION
The LiFi API supports these networks, which are not available in AlphaWallet:

- OKXChain Mainnet (66)
- Harmony Mainnet Shard 0 (1666600000)
- Moonriver (1285)
- Moonbeam (1284)
- Celo Mainnet (42220)
- Fuse Mainnet (122)

This PR removes these from the list in Swap Settings