### PR TITLE
Switch token icons back to `master` since everyone should have update d their app. It'll continue to work for those who haven't, only new token icons wouldn't appear for them #2870

### DIFF
--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -74,7 +74,7 @@ public class Utils {
     private static final String ICON_REPO_ADDRESS_TOKEN = "[TOKEN]";
     private static final String CHAIN_REPO_ADDRESS_TOKEN = "[CHAIN]";
     private static final String TOKEN_LOGO = "/logo.png";
-    public  static final String ALPHAWALLET_REPO_NAME = "https://raw.githubusercontent.com/alphawallet/iconassets/lowercased/";
+    public  static final String ALPHAWALLET_REPO_NAME = "https://raw.githubusercontent.com/alphawallet/iconassets/master/";
     private static final String TRUST_ICON_REPO_BASE = "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/";
     private static final String TRUST_ICON_REPO = TRUST_ICON_REPO_BASE + CHAIN_REPO_ADDRESS_TOKEN + "/assets/" + ICON_REPO_ADDRESS_TOKEN + TOKEN_LOGO;
     private static final String ALPHAWALLET_ICON_REPO = ALPHAWALLET_REPO_NAME + ICON_REPO_ADDRESS_TOKEN + TOKEN_LOGO;


### PR DESCRIPTION
Closes #2870 

Complements:

* https://github.com/AlphaWallet/iconassets/commit/f6ce2e16ce2ef37e0c09737d1cb5d1b12506fb19
* https://github.com/AlphaWallet/iconassets/commit/d01aafb3f0fad9f4399a45a911e6159441dbe512