### PR TITLE
Fixed crash caused by TokenSelector

### DIFF
--- a/app/src/main/res/drawable/select_masking_circle.xml
+++ b/app/src/main/res/drawable/select_masking_circle.xml
@@ -4,8 +4,5 @@
     android:shape="ring"
     android:thicknessRatio="1"
     android:useLevel="false">
-    <gradient
-        android:endColor="?colorSurface"
-        android:gradientRadius="8dp"
-        android:type="radial" />
+    <solid android:color="?colorSurface" />
 </shape>


### PR DESCRIPTION
- Closes #2803

1. Gradient is not needed for this use case so the output is the same
2. Gradient with type `radial` is not supported pre-Android 10