### PR TITLE
Refactor Refresh Updates

### DIFF
--- a/app/src/main/cpp/keys.c
+++ b/app/src/main/cpp/keys.c
@@ -205,3 +205,13 @@ Java_com_alphawallet_app_repository_KeyProviderJNIImpl_getWalletConnectProjectId
     return (*env)->NewStringUTF(env, WALLETCONNECT_PROJECT_ID);
 #endif
 }
+
+JNIEXPORT jstring JNICALL
+Java_com_alphawallet_app_repository_KeyProviderJNIImpl_getInfuraSecret(JNIEnv *env, jobject thiz) {
+#if (HAS_KEYS == 1)
+    return getDecryptedKey(env, infuraSecret);
+#else
+    const jstring key = "";
+    return (*env)->NewStringUTF(env, key);
+#endif
+}

--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -251,7 +251,7 @@ public class EventSync
 
     private long getCurrentEventBlockSize(Realm instance)
     {
-        if (EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).equals(BigInteger.valueOf(3500L)))
+        if (EthereumNetworkBase.isEventBlockLimitEnforced(token.tokenInfo.chainId))
         {
             return EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).longValue();
         }

--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -142,14 +142,6 @@ public class EventSync
         return new SyncDef(eventReadStartBlock, eventReadEndBlock, syncState, upwardSync);
     }
 
-    private void EVENT_DEBUG(String message)
-    {
-        if (EVENT_SYNC_DEBUGGING)
-        {
-            Timber.tag(TAG).i(token.tokenInfo.chainId + " " + token.tokenInfo.address + ": " + message);
-        }
-    }
-
     private boolean upwardSyncStateLost(BigInteger lastBlockRead, BigInteger currentBlock)
     {
         return currentBlock.subtract(lastBlockRead).compareTo(EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId)) >= 0;
@@ -671,5 +663,13 @@ public class EventSync
         matchingEntry.setEventName(activityName);
         matchingEntry.setTransferDetail(valueList);
         instance.insertOrUpdate(matchingEntry);
+    }
+
+    private void EVENT_DEBUG(String message)
+    {
+        if (EVENT_SYNC_DEBUGGING)
+        {
+            Timber.tag(TAG).i(token.tokenInfo.chainId + " " + token.tokenInfo.address + ": " + message);
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -35,6 +35,10 @@ import timber.log.Timber;
 public class EventSync
 {
     public static final long BLOCK_SEARCH_INTERVAL = 100000L;
+    public static final long POLYGON_BLOCK_SEARCH_INTERVAL = 10000L;
+
+    private static final String TAG = "EVENT_SYNC";
+    private static final boolean EVENT_SYNC_DEBUGGING = true;
 
     private final Token token;
 
@@ -74,8 +78,17 @@ public class EventSync
             case DOWNWARD_SYNC_START: //Start event sync, optimistically try the whole current event range from 1 -> LATEST
                 eventReadStartBlock = BigInteger.ONE;
                 eventReadEndBlock = BigInteger.valueOf(-1L);
-                //write the start point here
-                writeStartSyncBlock(realm, currentBlock.longValue());
+                if (EthereumNetworkBase.isEventBlockLimitEnforced(token.tokenInfo.chainId))
+                {
+                    syncState = EventSyncState.UPWARD_SYNC;
+                    eventReadStartBlock = currentBlock.subtract(EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).multiply(BigInteger.valueOf(3)));
+                    EVENT_DEBUG("Init Sync for restricted block RPC");
+                }
+                else
+                {
+                    //write the start point here
+                    writeStartSyncBlock(realm, currentBlock.longValue());
+                }
                 break;
             case DOWNWARD_SYNC: //we needed to slow down the sync
                 eventReadStartBlock = lastBlockRead.subtract(BigInteger.valueOf(readBlockSize));
@@ -88,17 +101,83 @@ public class EventSync
                 break;
             case UPWARD_SYNC_MAX: //we are syncing from the point we started the downward sync
                 upwardSync = true;
+                if (EthereumNetworkBase.isEventBlockLimitEnforced(token.tokenInfo.chainId) && upwardSyncStateLost(lastBlockRead, currentBlock))
+                {
+                    syncState = EventSyncState.UPWARD_SYNC;
+                    EVENT_DEBUG("Switch back to sync scan");
+                }
+
                 eventReadStartBlock = lastBlockRead;
                 eventReadEndBlock = BigInteger.valueOf(-1L);
                 break;
             case UPWARD_SYNC: //we encountered upward sync issues
                 upwardSync = true;
                 eventReadStartBlock = lastBlockRead;
-                eventReadEndBlock = lastBlockRead.add(BigInteger.valueOf(readBlockSize));
+                if (upwardSyncComplete(eventReadStartBlock, currentBlock)) //detect completion of upward sync and switch to sync_max
+                {
+                    eventReadEndBlock = BigInteger.valueOf(-1L);
+                    syncState = EventSyncState.UPWARD_SYNC_MAX;
+                    EVENT_DEBUG("Sync complete");
+                }
+                else
+                {
+                    eventReadEndBlock = lastBlockRead.add(BigInteger.valueOf(readBlockSize));
+                }
                 break;
         }
 
+        // Finally adjust the event end read if required. This is placed outside the switch because it should affect
+        // a few different paths
+        eventReadEndBlock = adjustForLimitedBlockSize(eventReadStartBlock, eventReadEndBlock, currentBlock);
+
+        // detect edge condition - it's highly unlikely but acts as a stopper in case of unexpected results
+        // This edge condition is where the start block read is greater than the current block.
+        if (eventReadStartBlock.compareTo(currentBlock) >= 0)
+        {
+            eventReadStartBlock = currentBlock.subtract(BigInteger.ONE);
+            eventReadEndBlock = BigInteger.valueOf(-1L);
+            syncState = EventSyncState.UPWARD_SYNC_MAX;
+        }
+
         return new SyncDef(eventReadStartBlock, eventReadEndBlock, syncState, upwardSync);
+    }
+
+    private void EVENT_DEBUG(String message)
+    {
+        if (EVENT_SYNC_DEBUGGING)
+        {
+            Timber.tag(TAG).i(token.tokenInfo.chainId + " " + token.tokenInfo.address + ": " + message);
+        }
+    }
+
+    private boolean upwardSyncStateLost(BigInteger lastBlockRead, BigInteger currentBlock)
+    {
+        return currentBlock.subtract(lastBlockRead).compareTo(EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId)) >= 0;
+    }
+
+    private boolean upwardSyncComplete(BigInteger eventReadStartBlock, BigInteger currentBlock)
+    {
+        BigInteger maxBlockRead = EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).subtract(BigInteger.ONE);
+        BigInteger diff = currentBlock.subtract(eventReadStartBlock);
+
+        return diff.compareTo(maxBlockRead) < 0;
+    }
+
+    private BigInteger adjustForLimitedBlockSize(BigInteger eventReadStartBlock, BigInteger eventReadEndBlock, BigInteger currentBlock)
+    {
+        if (EthereumNetworkBase.isEventBlockLimitEnforced(token.tokenInfo.chainId))
+        {
+            BigInteger maxBlockRead = EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId);
+
+            long diff = currentBlock.subtract(eventReadStartBlock).longValue();
+
+            if (diff >= maxBlockRead.longValue())
+            {
+                return eventReadStartBlock.add(maxBlockRead).subtract(BigInteger.ONE);
+            }
+        }
+
+        return eventReadEndBlock;
     }
 
     public boolean handleEthLogError(Response.Error error, DefaultBlockParameter startBlock, DefaultBlockParameter endBlock, SyncDef sync, Realm realm)
@@ -180,6 +259,11 @@ public class EventSync
 
     private long getCurrentEventBlockSize(Realm instance)
     {
+        if (EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).equals(BigInteger.valueOf(3500L)))
+        {
+            return EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).longValue();
+        }
+
         RealmAuxData rd = instance.where(RealmAuxData.class)
                 .equalTo("instanceKey", TokensRealmSource.databaseKey(token.tokenInfo.chainId, token.getAddress()))
                 .findFirst();
@@ -208,8 +292,9 @@ public class EventSync
         else
         {
             int state = rd.getTokenId().intValue();
-            if (state >= EventSyncState.DOWNWARD_SYNC_START.ordinal() || state < EventSyncState.TOP_LIMIT.ordinal())
+            if (state >= EventSyncState.DOWNWARD_SYNC_START.ordinal() && state < EventSyncState.TOP_LIMIT.ordinal())
             {
+                EVENT_DEBUG("Read State: " + EventSyncState.values()[state]);
                 return EventSyncState.values()[state];
             }
             else
@@ -251,6 +336,7 @@ public class EventSync
         }
         else
         {
+            EVENT_DEBUG("ReadEventSync: " + rd.getResultTime());
             return rd.getResultTime();
         }
     }
@@ -336,6 +422,8 @@ public class EventSync
             rd.setResultReceivedTime(readInterval);
             rd.setTokenId(String.valueOf(state.ordinal()));
 
+            EVENT_DEBUG("WriteState: " + state + " " + lastRead);
+
             r.insertOrUpdate(rd);
         });
     }
@@ -343,7 +431,7 @@ public class EventSync
     // If we're syncing downwards, work out what event block size we should read next
     private long calcNewIntervalSize(SyncDef sync, int evReads)
     {
-        if (sync.upwardSync) return BLOCK_SEARCH_INTERVAL;
+        if (sync.upwardSync) return EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).longValue();
         long endBlock = sync.eventReadEndBlock.longValue() == -1 ? TransactionsService.getCurrentBlock(token.tokenInfo.chainId).longValue()
                 : sync.eventReadEndBlock.longValue();
         long currentReadSize = endBlock - sync.eventReadStartBlock.longValue();
@@ -360,7 +448,7 @@ public class EventSync
         }
         else if ((maxLogReads - evReads) > maxLogReads*0.25)
         {
-            currentReadSize += BLOCK_SEARCH_INTERVAL;
+            currentReadSize += EthereumNetworkBase.getMaxEventFetch(token.tokenInfo.chainId).longValue();
         }
 
         return currentReadSize;
@@ -368,6 +456,8 @@ public class EventSync
 
     /***
      * Event Handling
+     *
+     * TODO: batch up catch-up calls
      */
 
     public Pair<Integer, Pair<HashSet<BigInteger>, HashSet<BigInteger>>> processTransferEvents(Web3j web3j, Event transferEvent, DefaultBlockParameter startBlock,

--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -38,7 +38,7 @@ public class EventSync
     public static final long POLYGON_BLOCK_SEARCH_INTERVAL = 10000L;
 
     private static final String TAG = "EVENT_SYNC";
-    private static final boolean EVENT_SYNC_DEBUGGING = true;
+    private static final boolean EVENT_SYNC_DEBUGGING = false;
 
     private final Token token;
 

--- a/app/src/main/java/com/alphawallet/app/entity/nftassets/NFTAsset.java
+++ b/app/src/main/java/com/alphawallet/app/entity/nftassets/NFTAsset.java
@@ -100,6 +100,7 @@ public class NFTAsset implements Parcelable
         attributeMap.clear();
         balance = BigDecimal.ONE;
         assetMap.put(NAME, "ID #" + tokenId.toString());
+        assetMap.put(LOADING_TOKEN, ".");
     }
 
     public NFTAsset(NFTAsset asset)
@@ -380,6 +381,11 @@ public class NFTAsset implements Parcelable
     public boolean needsLoading()
     {
         return (assetMap.size() == 0 || assetMap.containsKey(LOADING_TOKEN));
+    }
+
+    public boolean hasImageAsset()
+    {
+        return !TextUtils.isEmpty(getThumbnail());
     }
 
     public boolean requiresReplacement()

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
@@ -320,16 +320,10 @@ public class ERC1155Token extends Token
     @Override
     public Map<BigInteger, NFTAsset> queryAssets(Map<BigInteger, NFTAsset> assetMap)
     {
-        //first see if there's no change; if this is the case we can skip
-        if (assetsUnchanged(assetMap)) return assets;
-
-        //add all known tokens in
-        Map<BigInteger, NFTAsset> sum = new HashMap<>(assetMap);
-        sum.putAll(assets);
-        Set<BigInteger> tokenIds = sum.keySet();
+        Set<BigInteger> tokenIds = assetMap.keySet();
         Function balanceOfBatch = balanceOfBatch(getWallet(), tokenIds);
         List<Uint256> balances = callSmartContractFunctionArray(tokenInfo.chainId, balanceOfBatch, getAddress(), getWallet());
-        Map<BigInteger, NFTAsset> updatedAssetMap;
+        Map<BigInteger, NFTAsset> updatedAssetMap = new HashMap<>();
 
         if (balances != null && balances.size() > 0)
         {
@@ -337,17 +331,13 @@ public class ERC1155Token extends Token
             int index = 0;
             for (BigInteger tokenId : tokenIds)
             {
-                NFTAsset thisAsset = new NFTAsset(sum.get(tokenId));
+                NFTAsset thisAsset = new NFTAsset(assetMap.get(tokenId));
                 BigInteger balance = balances.get(index).getValue();
                 thisAsset.setBalance(new BigDecimal(balance));
                 updatedAssetMap.put(tokenId, thisAsset);
 
                 index++;
             }
-        }
-        else
-        {
-            updatedAssetMap = assets;
         }
 
         return updatedAssetMap;

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Ticket.java
@@ -171,7 +171,7 @@ public class ERC721Ticket extends Token
     public List<BigInteger> getNonZeroArrayBalance()
     {
         List<BigInteger> nonZeroValues = new ArrayList<>();
-        for (BigInteger value : balanceArray) if (value.compareTo(BigInteger.ZERO) != 0 && !nonZeroValues.contains(value)) nonZeroValues.add(value);
+        for (BigInteger value : balanceArray) if (value.compareTo(BigInteger.ZERO) != 0) nonZeroValues.add(value);
         return nonZeroValues;
     }
 

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -829,21 +829,7 @@ public class ERC721Token extends Token
     @Override
     public Map<BigInteger, NFTAsset> queryAssets(Map<BigInteger, NFTAsset> assetMap)
     {
-        //check all tokens in this contract
-        assetMap.putAll(tokenBalanceAssets);
-
-        HashSet<BigInteger> currentAssets = new HashSet<>(assetMap.keySet());
-
         final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
-
-        try
-        {
-            currentAssets = checkBalances(web3j, currentAssets);
-        }
-        catch (Exception e)
-        {
-            //
-        }
 
         for (Map.Entry<BigInteger, NFTAsset> entry : assetMap.entrySet())
         {
@@ -858,10 +844,10 @@ public class ERC721Token extends Token
                 checkAsset.setBalance(BigDecimal.ZERO);
             }
 
-            tokenBalanceAssets.put(checkId, checkAsset);
+            assetMap.put(checkId, checkAsset);
         }
 
-        return tokenBalanceAssets;
+        return assetMap;
     }
 
     // Check for new/missing tokenBalanceAssets

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -831,10 +831,23 @@ public class ERC721Token extends Token
     {
         final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
 
+        HashSet<BigInteger> currentAssets = new HashSet<>(assetMap.keySet());
+
+        try
+        {
+            currentAssets = checkBalances(web3j, currentAssets);
+        }
+        catch (Exception e)
+        {
+            //
+        }
+
         for (Map.Entry<BigInteger, NFTAsset> entry : assetMap.entrySet())
         {
             BigInteger checkId = entry.getKey();
             NFTAsset checkAsset = entry.getValue();
+
+            //check balance
             if (currentAssets.contains(checkId))
             {
                 checkAsset.setBalance(BigDecimal.ONE);
@@ -849,7 +862,7 @@ public class ERC721Token extends Token
 
         return assetMap;
     }
-
+    
     // Check for new/missing tokenBalanceAssets
     @Override
     public Map<BigInteger, NFTAsset> getAssetChange(Map<BigInteger, NFTAsset> oldAssetList)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC721Token.java
@@ -57,6 +57,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -274,7 +275,9 @@ public class ERC721Token extends Token
     public boolean checkBalanceChange(Token oldToken)
     {
         if (super.checkBalanceChange(oldToken)) return true;
-        if (getTokenAssets().size() != oldToken.getTokenAssets().size()) return true;
+        if ((getTokenAssets() != null && oldToken.getTokenAssets() != null)
+                && getTokenAssets().size() != oldToken.getTokenAssets().size()) return true;
+
         for (BigInteger tokenId : tokenBalanceAssets.keySet())
         {
             NFTAsset newAsset = tokenBalanceAssets.get(tokenId);
@@ -360,7 +363,7 @@ public class ERC721Token extends Token
         try
         {
             balanceChecks.put(tokenInfo.address, true); //set checking
-            final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
+            final Web3j web3j = TokenRepository.getWeb3jServiceForEvents(tokenInfo.chainId);
             if (contractType == ContractType.ERC721_ENUMERABLE)
             {
                 updateEnumerableBalance(web3j, realm);
@@ -391,6 +394,7 @@ public class ERC721Token extends Token
             if (eventSync.handleEthLogError(e.error, startBlock, endBlock, sync, realm))
             {
                 //recurse until we find a good value
+                balanceChecks.remove(tokenInfo.address);
                 updateBalance(realm);
             }
         }
@@ -746,24 +750,6 @@ public class ERC721Token extends Token
         return filter;
     }
 
-    /**
-     * Returns false if the Asset balance appears to be entries with only TokenId - indicating an ERC721Ticket
-     *
-     * @return
-     */
-    @Override
-    public boolean checkBalanceType()
-    {
-        boolean onlyHasTokenId = true;
-        //if elements contain asset with only assetId then most likely this is a ticket.
-        for (NFTAsset a : tokenBalanceAssets.values())
-        {
-            if (!a.isBlank()) onlyHasTokenId = false;
-        }
-
-        return tokenBalanceAssets.size() == 0 || !onlyHasTokenId;
-    }
-
     public String getTransferID(Transaction tx)
     {
         if (tx.transactionInput != null && tx.transactionInput.miscData.size() > 0)
@@ -837,8 +823,8 @@ public class ERC721Token extends Token
      * If there is a token that previously was there, but now isn't, it could be because
      * the opensea call was split or that the owner transferred the token
      *
-     * @param assetMap Loaded Assets from Realm
-     * @return map of currently known live assets
+     * @param assetMap Loaded Assets which are new assets (don't add assets from opensea unless we double check here first)
+     * @return map of checked assets
      */
     @Override
     public Map<BigInteger, NFTAsset> queryAssets(Map<BigInteger, NFTAsset> assetMap)
@@ -846,19 +832,24 @@ public class ERC721Token extends Token
         //check all tokens in this contract
         assetMap.putAll(tokenBalanceAssets);
 
-        //now check balance for all tokenIds (note that ERC1155 has a batch balance check, ERC721 does not)
+        HashSet<BigInteger> currentAssets = new HashSet<>(assetMap.keySet());
+
+        final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
+
+        try
+        {
+            currentAssets = checkBalances(web3j, currentAssets);
+        }
+        catch (Exception e)
+        {
+            //
+        }
+
         for (Map.Entry<BigInteger, NFTAsset> entry : assetMap.entrySet())
         {
             BigInteger checkId = entry.getKey();
             NFTAsset checkAsset = entry.getValue();
-
-            //check balance
-            String owner = callSmartContractFunction(tokenInfo.chainId, ownerOf(checkId), getAddress(), getWallet());
-            if (owner == null) //play it safe. If there's no 'ownerOf' for an ERC721, it's something custom like ENS
-            {
-                checkAsset.setBalance(BigDecimal.ONE);
-            }
-            else if (owner.equalsIgnoreCase(getWallet()))
+            if (currentAssets.contains(checkId))
             {
                 checkAsset.setBalance(BigDecimal.ONE);
             }
@@ -867,35 +858,74 @@ public class ERC721Token extends Token
                 checkAsset.setBalance(BigDecimal.ZERO);
             }
 
-            //add back into asset map
             tokenBalanceAssets.put(checkId, checkAsset);
         }
 
         return tokenBalanceAssets;
     }
 
+    // Check for new/missing tokenBalanceAssets
     @Override
-    public List<BigInteger> getChangeList(Map<BigInteger, NFTAsset> assetMap)
+    public Map<BigInteger, NFTAsset> getAssetChange(Map<BigInteger, NFTAsset> oldAssetList)
     {
-        //detect asset removal
-        List<BigInteger> oldAssetIdList = new ArrayList<>(assetMap.keySet());
-        oldAssetIdList.removeAll(tokenBalanceAssets.keySet());
+        Map<BigInteger, NFTAsset> updatedAssets = new HashMap<>();
+        // detect asset removal, first find new assets
+        HashSet<BigInteger> changedAssetList = new HashSet<>(tokenBalanceAssets.keySet());
+        changedAssetList.removeAll(oldAssetList.keySet());
 
-        List<BigInteger> changeList = new ArrayList<>(oldAssetIdList);
+        HashSet<BigInteger> unchangedAssets = new HashSet<>(tokenBalanceAssets.keySet());
+        unchangedAssets.removeAll(changedAssetList);
+
+        // removed assets
+        HashSet<BigInteger> removedAssets = new HashSet<>(oldAssetList.keySet());
+        removedAssets.removeAll(tokenBalanceAssets.keySet());
+        changedAssetList.addAll(removedAssets);
+        HashSet<BigInteger> balanceAssets = new HashSet<>();
+
+        final Web3j web3j = TokenRepository.getWeb3jService(tokenInfo.chainId);
+
+        try
+        {
+            balanceAssets = checkBalances(web3j, changedAssetList);
+        }
+        catch (Exception e)
+        {
+            //
+        }
 
         //Now detect differences or new tokens
-        for (BigInteger tokenId : tokenBalanceAssets.keySet())
+        for (BigInteger tokenId : changedAssetList)
         {
-            NFTAsset newAsset = tokenBalanceAssets.get(tokenId);
-            NFTAsset oldAsset = assetMap.get(tokenId);
+            NFTAsset asset = tokenBalanceAssets.get(tokenId);
+            if (asset == null) asset = oldAssetList.get(tokenId);
 
-            if (oldAsset == null || newAsset.hashCode() != oldAsset.hashCode())
+            if (asset == null)
             {
-                changeList.add(tokenId);
+                continue;
+            }
+
+            if (balanceAssets.contains(tokenId))
+            {
+                asset.setBalance(BigDecimal.ZERO);
+            }
+            else
+            {
+                asset.setBalance(BigDecimal.ONE);
+            }
+
+            updatedAssets.put(tokenId, asset);
+        }
+
+        for (BigInteger tokenId : unchangedAssets)
+        {
+            NFTAsset asset = tokenBalanceAssets.get(tokenId);
+            if (asset != null)
+            {
+                updatedAssets.put(tokenId, asset);
             }
         }
 
-        return changeList;
+        return updatedAssets;
     }
 
     private Request<?, EthCall> getContractCall(Web3j web3j, Function function, String contractAddress)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Ticket.java
@@ -10,7 +10,6 @@ import com.alphawallet.app.entity.TransactionInput;
 import com.alphawallet.app.entity.tokendata.TokenGroup;
 import com.alphawallet.app.repository.EventResult;
 import com.alphawallet.app.repository.entity.RealmToken;
-import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.util.Utils;
 import com.alphawallet.app.viewmodel.BaseViewModel;
 import com.alphawallet.token.entity.TicketRange;
@@ -27,31 +26,34 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Created by James on 27/01/2018.  It might seem counter intuitive
- * but here Ticket refers to a container of an asset class here, not
- * the right to seat somewhere in the venue. Therefore, there
- * shouldn't be List<Ticket> To understand this, imagine that one says
- * "I have two cryptocurrencies: Ether and Bitcoin, each amounts to a
- * hundred", and he pauses and said, "I also have two indices: FIFA
- * and Formuler-one, which, too, amounts to a hundred each".
+ * Created by James on 27/01/2018.
  */
 
 public class Ticket extends Token
 {
     private final List<BigInteger> balanceArray;
-    private boolean isMatchedInXML = false;
 
-    public Ticket(TokenInfo tokenInfo, List<BigInteger> balances, long blancaTime, String networkName, ContractType type) {
+    public Ticket(TokenInfo tokenInfo, List<BigInteger> balances, long blancaTime, String networkName, ContractType type)
+    {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = balances;
-        balance = balanceArray != null ? BigDecimal.valueOf(balanceArray.size()) : BigDecimal.ZERO;
+        balance = balanceArray != null ? BigDecimal.valueOf(getNonZeroArrayBalance().size()) : BigDecimal.ZERO;
         group = TokenGroup.NFT;
     }
 
-    public Ticket(TokenInfo tokenInfo, String balances, long blancaTime, String networkName, ContractType type) {
+    public Ticket(TokenInfo tokenInfo, String balances, long blancaTime, String networkName, ContractType type)
+    {
         super(tokenInfo, BigDecimal.ZERO, blancaTime, networkName, type);
         this.balanceArray = stringHexToBigIntegerList(balances);
-        balance = BigDecimal.valueOf(balanceArray.size());
+        balance = BigDecimal.valueOf(getNonZeroArrayBalance().size());
+        group = TokenGroup.NFT;
+    }
+
+    public Ticket(Token oldTicket, List<BigInteger> balances)
+    {
+        super(oldTicket.tokenInfo, BigDecimal.ZERO, oldTicket.updateBlancaTime, oldTicket.getNetworkName(), oldTicket.contractType);
+        this.balanceArray = balances;
+        balance = BigDecimal.valueOf(getNonZeroArrayBalance().size());
         group = TokenGroup.NFT;
     }
 
@@ -235,11 +237,6 @@ public class Ticket extends Token
         return indexList;
     }
 
-    public void checkIsMatchedInXML(AssetDefinitionService assetService)
-    {
-        isMatchedInXML = assetService.hasDefinition(tokenInfo.chainId, tokenInfo.address);
-    }
-
     @Override
     public Function getTransferFunction(String to, List<BigInteger> tokenIndices) throws NumberFormatException
     {
@@ -305,7 +302,10 @@ public class Ticket extends Token
     public List<BigInteger> getNonZeroArrayBalance()
     {
         List<BigInteger> nonZeroValues = new ArrayList<>();
-        for (BigInteger value : balanceArray) if (value.compareTo(BigInteger.ZERO) != 0 && !nonZeroValues.contains(value)) nonZeroValues.add(value);
+        for (BigInteger value : balanceArray)
+        {
+            if (value.compareTo(BigInteger.ZERO) != 0) nonZeroValues.add(value);
+        }
         return nonZeroValues;
     }
 

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -383,7 +383,7 @@ public class Token
 
     public boolean isBad()
     {
-        return tokenInfo == null || (tokenInfo.symbol == null && tokenInfo.name == null);
+        return tokenInfo == null || tokenInfo.chainId == 0 || (tokenInfo.symbol == null && tokenInfo.name == null);
     }
 
     public void setTokenWallet(String address)

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -711,11 +711,6 @@ public class Token
         return hash;
     }
 
-    public boolean checkBalanceType()
-    {
-        return true;
-    }
-
     public String getTransactionDetail(Context ctx, Transaction tx, TokensService tService)
     {
         if (isEthereum())
@@ -922,11 +917,6 @@ public class Token
                 || (!TextUtils.isEmpty(tokenInfo.symbol) && tokenInfo.symbol.contains("?"));
     }
 
-    public List<BigInteger> getChangeList(Map<BigInteger, NFTAsset> assetMap)
-    {
-        return new ArrayList<>();
-    }
-
     public void setAssetContract(AssetContract contract) {  }
     public AssetContract getAssetContract() { return null; }
 
@@ -943,6 +933,11 @@ public class Token
     public Map<BigInteger, NFTAsset> queryAssets(Map<BigInteger, NFTAsset> assetMap)
     {
         return assetMap;
+    }
+
+    public Map<BigInteger, NFTAsset> getAssetChange(Map<BigInteger, NFTAsset> oldAssetList)
+    {
+        return oldAssetList;
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenFactory.java
@@ -124,6 +124,7 @@ public class TokenFactory
             case ERC721:
             case ERC721_LEGACY:
             case ERC721_ENUMERABLE:
+            case ERC721_UNDETERMINED:
                 thisToken = new ERC721Token(tokenInfo, null, decimalBalance, updateBlancaTime, networkName, type);
                 break;
 

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -3,6 +3,8 @@ package com.alphawallet.app.repository;
 /* Please don't add import android at this point. Later this file will be shared
  * between projects including non-Android projects */
 
+import static com.alphawallet.app.entity.EventSync.BLOCK_SEARCH_INTERVAL;
+import static com.alphawallet.app.entity.EventSync.POLYGON_BLOCK_SEARCH_INTERVAL;
 import static com.alphawallet.app.util.Utils.isValidUrl;
 import static com.alphawallet.ethereum.EthereumNetworkBase.ARBITRUM_GOERLI_TESTNET_FALLBACK_RPC_URL;
 import static com.alphawallet.ethereum.EthereumNetworkBase.ARBITRUM_GOERLI_TEST_ID;
@@ -226,7 +228,7 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(GNOSIS_ID, new NetworkInfo(C.XDAI_NETWORK_NAME, C.xDAI_SYMBOL,
                     XDAI_RPC_URL,
                     "https://blockscout.com/xdai/mainnet/tx/", GNOSIS_ID,
-                    "https://gnosis.public-rpc.com", "https://blockscout.com/xdai/mainnet/api?"));
+                    "https://rpc.ankr.com/gnosis", "https://blockscout.com/xdai/mainnet/api?"));
             put(POA_ID, new NetworkInfo(C.POA_NETWORK_NAME, C.POA_SYMBOL,
                     POA_RPC_URL,
                     "https://blockscout.com/poa/core/tx/", POA_ID, POA_RPC_URL,
@@ -525,22 +527,25 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         }
     }
 
+    public static final int INFURA_BATCH_LIMIT = 512;
+    public static final String INFURA_DOMAIN = "infura.io";
+
     //TODO: Refactor when we bump the version of java to allow switch on Long (Finally!!)
     //Also TODO: add a test to check these batch limits of each chain we support
     private static int batchProcessingLimit(long chainId)
     {
         NetworkInfo info = builtinNetworkMap.get(chainId);
-        if (info.rpcServerUrl.contains("infura")) //infura supported chains can handle tx batches of 1000 and up
+        if (info.rpcServerUrl.contains(INFURA_DOMAIN)) //infura supported chains can handle tx batches of 1000 and up
         {
-            return 512;
+            return INFURA_BATCH_LIMIT;
         }
-        else if (info.rpcServerUrl.contains("klaytn"))
+        else if (info.rpcServerUrl.contains("klaytn") || info.rpcServerUrl.contains("rpc.ankr.com"))
         {
             return 0;
         }
-        else if (info.rpcServerUrl.contains("gnosis"))
+        else if (chainId == GNOSIS_ID)
         {
-            return 6; //TODO: Check limit
+            return 6; //TODO: Check limit:
         }
         else if (info.rpcServerUrl.contains("cronos.org"))
         {
@@ -1197,15 +1202,43 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         }
     }
 
+    public static boolean isEventBlockLimitEnforced(long chainId)
+    {
+        if (chainId == POLYGON_ID || chainId == POLYGON_TEST_ID)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     public static BigInteger getMaxEventFetch(long chainId)
     {
         if (chainId == POLYGON_ID || chainId == POLYGON_TEST_ID)
         {
-            return BigInteger.valueOf(3500L);
+            return BigInteger.valueOf(POLYGON_BLOCK_SEARCH_INTERVAL);
         }
         else
         {
-            return BigInteger.valueOf(10000L);
+            return BigInteger.valueOf(BLOCK_SEARCH_INTERVAL);
+        }
+    }
+
+    public static String getNodeURLForEvents(long chainId)
+    {
+        if (chainId == POLYGON_ID)
+        {
+            return EthereumNetworkBase.FREE_POLYGON_RPC_URL; // Better than Infura for fetching events
+        }
+        else if (chainId == POLYGON_TEST_ID)
+        {
+            return EthereumNetworkBase.MUMBAI_FALLBACK_RPC_URL;
+        }
+        else
+        {
+            return getNodeURLByNetworkId(chainId);
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -198,9 +198,10 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         {
             return "";
         }
-        else if (chainId == MAINNET_ID)
+
+        int index = info.rpcServerUrl.indexOf(INFURA_ENDPOINT);
+        if (index > 0)
         {
-            int index = info.rpcServerUrl.indexOf(INFURA_ENDPOINT);
             return info.rpcServerUrl.substring(0, index + INFURA_ENDPOINT.length()) + keyProvider.getTertiaryInfuraKey();
         }
         else if (info.backupNodeUrl != null)
@@ -211,6 +212,11 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
         {
             return info.rpcServerUrl;
         }
+    }
+
+    public static boolean isInfura(String rpcServerUrl)
+    {
+        return rpcServerUrl.contains(INFURA_ENDPOINT);
     }
 
     // for reset built-in network

--- a/app/src/main/java/com/alphawallet/app/repository/HttpServiceHelper.java
+++ b/app/src/main/java/com/alphawallet/app/repository/HttpServiceHelper.java
@@ -1,18 +1,26 @@
 package com.alphawallet.app.repository;
 
+import static com.alphawallet.app.repository.EthereumNetworkBase.INFURA_DOMAIN;
 import static com.alphawallet.ethereum.EthereumNetworkBase.KLAYTN_BAOBAB_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.KLAYTN_ID;
+
+import android.text.TextUtils;
 
 import org.web3j.protocol.http.HttpService;
 
 public class HttpServiceHelper
 {
-    public static void addRequiredCredentials(long chainId, HttpService httpService, String key, boolean usesProductionKey)
+    public static void addRequiredCredentials(long chainId, HttpService httpService, String klaytnKey, String infuraKey, boolean usesProductionKey)
     {
+        String serviceUrl = httpService.getUrl();
         if ((chainId == KLAYTN_BAOBAB_ID || chainId == KLAYTN_ID) && usesProductionKey)
         {
             httpService.addHeader("x-chain-id", Long.toString(chainId));
-            httpService.addHeader("Authorization", "Basic " + key);
+            httpService.addHeader("Authorization", "Basic " + klaytnKey);
+        }
+        else if (serviceUrl != null && usesProductionKey && serviceUrl.contains(INFURA_DOMAIN) && !TextUtils.isEmpty(infuraKey))
+        {
+            httpService.addHeader("Authorization", "Basic " + infuraKey);
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/HttpServiceHelper.java
+++ b/app/src/main/java/com/alphawallet/app/repository/HttpServiceHelper.java
@@ -8,6 +8,8 @@ import android.text.TextUtils;
 
 import org.web3j.protocol.http.HttpService;
 
+import okhttp3.Request;
+
 public class HttpServiceHelper
 {
     public static void addRequiredCredentials(long chainId, HttpService httpService, String klaytnKey, String infuraKey, boolean usesProductionKey)
@@ -21,6 +23,19 @@ public class HttpServiceHelper
         else if (serviceUrl != null && usesProductionKey && serviceUrl.contains(INFURA_DOMAIN) && !TextUtils.isEmpty(infuraKey))
         {
             httpService.addHeader("Authorization", "Basic " + infuraKey);
+        }
+    }
+
+    public static void addRequiredCredentials(long chainId, Request.Builder service, String klaytnKey, String infuraKey, boolean usesProductionKey, boolean isInfura)
+    {
+        if ((chainId == KLAYTN_BAOBAB_ID || chainId == KLAYTN_ID) && usesProductionKey)
+        {
+            service.addHeader("x-chain-id", Long.toString(chainId));
+            service.addHeader("Authorization", "Basic " + klaytnKey);
+        }
+        else if (isInfura && usesProductionKey && !TextUtils.isEmpty(infuraKey))
+        {
+            service.addHeader("Authorization", "Basic " + infuraKey);
         }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/KeyProvider.java
+++ b/app/src/main/java/com/alphawallet/app/repository/KeyProvider.java
@@ -31,4 +31,6 @@ public interface KeyProvider
     String getCoinbasePayAppId();
 
     String getWalletConnectProjectId();
+
+    String getInfuraSecret();
 }

--- a/app/src/main/java/com/alphawallet/app/repository/KeyProviderJNIImpl.java
+++ b/app/src/main/java/com/alphawallet/app/repository/KeyProviderJNIImpl.java
@@ -36,4 +36,6 @@ public class KeyProviderJNIImpl implements KeyProvider
     public native String getCoinbasePayAppId();
 
     public native String getWalletConnectProjectId();
+
+    public native String getInfuraSecret();
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -1227,8 +1227,8 @@ public class TokenRepository implements TokenRepositoryType {
     public static Web3j getWeb3jServiceForEvents(long chainId)
     {
         OkHttpClient okClient = new OkHttpClient.Builder()
-                .connectTimeout(C.CONNECT_TIMEOUT, TimeUnit.SECONDS)
-                .connectTimeout(C.READ_TIMEOUT*3, TimeUnit.SECONDS) //events can take longer to render
+                .connectTimeout(C.CONNECT_TIMEOUT * 3, TimeUnit.SECONDS) //events can take longer to render
+                .connectTimeout(C.READ_TIMEOUT * 3, TimeUnit.SECONDS)
                 .writeTimeout(C.LONG_WRITE_TIMEOUT, TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .build();

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -120,7 +120,8 @@ public class TokenRepository implements TokenRepositoryType {
     private void buildWeb3jClient(NetworkInfo networkInfo)
     {
         AWHttpService publicNodeService = new AWHttpService(networkInfo.rpcServerUrl, networkInfo.backupNodeUrl, okClient, false);
-        HttpServiceHelper.addRequiredCredentials(networkInfo.chainId, publicNodeService, KeyProviderFactory.get().getKlaytnKey(), EthereumNetworkBase.usesProductionKey);
+        HttpServiceHelper.addRequiredCredentials(networkInfo.chainId, publicNodeService, KeyProviderFactory.get().getKlaytnKey(),
+                KeyProviderFactory.get().getInfuraSecret(), EthereumNetworkBase.usesProductionKey);
         web3jNodeServers.put(networkInfo.chainId, Web3j.build(publicNodeService));
     }
 
@@ -141,7 +142,7 @@ public class TokenRepository implements TokenRepositoryType {
             for (int i = 0; i < tokens.length; i++)
             {
                 Token t = tokens[i];
-                if (t.getInterfaceSpec() == ContractType.ERC721_UNDETERMINED || t.getInterfaceSpec() == ContractType.MAYBE_ERC20 || !t.checkBalanceType()) //balance type appears to be wrong
+                if (t.getInterfaceSpec() == ContractType.ERC721_UNDETERMINED || t.getInterfaceSpec() == ContractType.MAYBE_ERC20) //balance type appears to be wrong
                 {
                     ContractType type = determineCommonType(t.tokenInfo)
                             .onErrorReturnItem(t.getInterfaceSpec()).blockingGet();
@@ -500,13 +501,14 @@ public class TokenRepository implements TokenRepositoryType {
         return newBalance;
     }
 
+    //Batch Balance
     private Single<Token[]> updateBalances(Wallet wallet, Token[] tokens)
     {
         return Single.fromCallable(() -> {
             for (Token t : tokens)
             {
                 //get balance of any token here
-                if (t.isERC721() || t.isERC20()) t.balance = checkUint256Balance(wallet, t.tokenInfo.chainId, t.getAddress());
+                if (t.isERC20() || t.isNonFungible()) t.balance = checkUint256Balance(wallet, t.tokenInfo.chainId, t.getAddress());
             }
             return tokens;
         });
@@ -1222,6 +1224,28 @@ public class TokenRepository implements TokenRepositoryType {
         localSource.storeTokenUrl(networkId, address, imageUrl);
     }
 
+    public static Web3j getWeb3jServiceForEvents(long chainId)
+    {
+        OkHttpClient okClient = new OkHttpClient.Builder()
+                .connectTimeout(C.CONNECT_TIMEOUT, TimeUnit.SECONDS)
+                .connectTimeout(C.READ_TIMEOUT*3, TimeUnit.SECONDS) //events can take longer to render
+                .writeTimeout(C.LONG_WRITE_TIMEOUT, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .build();
+
+        String nodeUrl = EthereumNetworkBase.getNodeURLForEvents(chainId);
+        String secondaryNode = EthereumNetworkRepository.getSecondaryNodeURL(chainId);
+        if (nodeUrl.equals(secondaryNode)) //ensure backup node is different
+        {
+            secondaryNode = EthereumNetworkRepository.getNodeURLByNetworkId(chainId);
+        }
+
+        AWHttpService publicNodeService = new AWHttpService(nodeUrl, secondaryNode, okClient, false);
+        HttpServiceHelper.addRequiredCredentials(chainId, publicNodeService, KeyProviderFactory.get().getKlaytnKey(),
+                KeyProviderFactory.get().getInfuraSecret(), EthereumNetworkBase.usesProductionKey);
+        return Web3j.build(publicNodeService);
+    }
+
     public static Web3j getWeb3jService(long chainId)
     {
         OkHttpClient okClient = new OkHttpClient.Builder()
@@ -1230,8 +1254,10 @@ public class TokenRepository implements TokenRepositoryType {
                 .writeTimeout(C.LONG_WRITE_TIMEOUT, TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .build();
+
         AWHttpService publicNodeService = new AWHttpService(EthereumNetworkRepository.getNodeURLByNetworkId(chainId), EthereumNetworkRepository.getSecondaryNodeURL(chainId), okClient, false);
-        HttpServiceHelper.addRequiredCredentials(chainId, publicNodeService, KeyProviderFactory.get().getKlaytnKey(), EthereumNetworkBase.usesProductionKey);
+        HttpServiceHelper.addRequiredCredentials(chainId, publicNodeService, KeyProviderFactory.get().getKlaytnKey(),
+                KeyProviderFactory.get().getInfuraSecret(), EthereumNetworkBase.usesProductionKey);
         return Web3j.build(publicNodeService);
     }
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -21,6 +21,7 @@ import com.alphawallet.app.entity.tokendata.TokenGroup;
 import com.alphawallet.app.entity.tokendata.TokenTicker;
 import com.alphawallet.app.entity.tokens.ERC721Ticket;
 import com.alphawallet.app.entity.tokens.ERC721Token;
+import com.alphawallet.app.entity.tokens.Ticket;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokens.TokenCardMeta;
 import com.alphawallet.app.entity.tokens.TokenInfo;
@@ -325,6 +326,11 @@ public class TokenRepository implements TokenRepositoryType {
     @Override
     public Single<BigDecimal> updateTokenBalance(String walletAddress, Token token)
     {
+        if (token.isBad())
+        {
+            return Single.fromCallable(() -> BigDecimal.ZERO);
+        }
+
         Wallet wallet = new Wallet(walletAddress);
         return updateBalance(wallet, token)
                 .subscribeOn(Schedulers.io())
@@ -410,6 +416,8 @@ public class TokenRepository implements TokenRepositoryType {
         return localSource.getTokenImageUrl(networkId, address);
     }
 
+    //TODO: Refactor this so the balance update is abstracted into the Token itself
+    //      Once the token is updated we can store it. May need to make the token internal balance non-final
     private Single<BigDecimal> updateBalance(final Wallet wallet, final Token token)
     {
         return Single.fromCallable(() -> {
@@ -428,6 +436,7 @@ public class TokenRepository implements TokenRepositoryType {
                         case ERC875:
                         case ERC875_LEGACY:
                             balanceArray = getBalanceArray875(wallet, token.tokenInfo.chainId, token.getAddress());
+                            thisToken = new Ticket(thisToken, balanceArray);
                             balance = BigDecimal.valueOf(balanceArray.size());
                             break;
                         case ERC721_LEGACY:

--- a/app/src/main/java/com/alphawallet/app/router/TokenDetailRouter.java
+++ b/app/src/main/java/com/alphawallet/app/router/TokenDetailRouter.java
@@ -4,11 +4,11 @@ package com.alphawallet.app.router;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 import com.alphawallet.app.C;
-import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.ui.AssetDisplayActivity;
 import com.alphawallet.app.ui.Erc20DetailActivity;
 import com.alphawallet.app.ui.NFTActivity;
 
@@ -54,5 +54,15 @@ public class TokenDetailRouter
         intent.putExtra(C.Key.WALLET, wallet);
         intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         activity.startActivityForResult(intent, C.TERMINATE_ACTIVITY);
+    }
+
+    public void openLegacyToken(Activity context, Token token, Wallet wallet)
+    {
+        Intent intent = new Intent(context, AssetDisplayActivity.class);
+        intent.putExtra(C.EXTRA_CHAIN_ID, token.tokenInfo.chainId);
+        intent.putExtra(C.EXTRA_ADDRESS, token.getAddress());
+        intent.putExtra(C.Key.WALLET, wallet);
+        intent.setFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        context.startActivityForResult(intent, C.TERMINATE_ACTIVITY);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AWHttpService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AWHttpService.java
@@ -161,10 +161,9 @@ public class AWHttpService extends HttpService
     {
         Timber.d("trySecondaryNode: ");
         RequestBody requestBody = RequestBody.create(request, JSON_MEDIA_TYPE);
-        Headers headers = buildHeaders();
 
         okhttp3.Request httpRequest =
-                new okhttp3.Request.Builder().url(secondaryUrl).headers(headers).post(requestBody).build();
+                new okhttp3.Request.Builder().url(secondaryUrl).post(requestBody).build();
 
         okhttp3.Response response;
 
@@ -259,4 +258,10 @@ public class AWHttpService extends HttpService
 
     @Override
     public void close() throws IOException {}
+
+    @Override
+    public String getUrl()
+    {
+        return this.url;
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AlphaWalletService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AlphaWalletService.java
@@ -1,8 +1,9 @@
 package com.alphawallet.app.service;
 
-import android.util.Log;
+import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
+import static com.alphawallet.token.tools.ParseMagicLink.currencyLink;
+import static com.alphawallet.token.tools.ParseMagicLink.spawnable;
 
-import com.alphawallet.app.BuildConfig;
 import com.alphawallet.app.entity.CryptoFunctions;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Ticket;
@@ -32,10 +33,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import timber.log.Timber;
-
-import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
-import static com.alphawallet.token.tools.ParseMagicLink.currencyLink;
-import static com.alphawallet.token.tools.ParseMagicLink.spawnable;
 
 public class AlphaWalletService
 {
@@ -109,6 +106,8 @@ public class AlphaWalletService
 
             String result = response.body().string();
             JsonObject obj = gson.fromJson(result, JsonObject.class);
+            if (obj.has("error") || !obj.has("result")) return dsigDescriptor;
+
             String queryResult = obj.get("result").getAsString();
             if (queryResult.equals(XML_VERIFIER_PASS))
             {

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -924,6 +924,10 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
     private Single<TokenDefinition> handleNewTSFile(File newFile)
     {
+        if (!newFile.exists())
+        {
+            return Single.fromCallable(TokenDefinition::new);
+        }
         //1. check validity & check for origin tokens
         //2. check for existing and check if this is a debug file or script from server
         //3. update signature data
@@ -1065,7 +1069,10 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
         }
         catch (Exception e)
         {
-            Timber.w(e);
+            if (!TextUtils.isEmpty(Uri)) //throws on empty, which is expected
+            {
+                Timber.w(e);
+            }
         }
 
         return new Pair<>("", false);

--- a/app/src/main/java/com/alphawallet/app/service/GasService.java
+++ b/app/src/main/java/com/alphawallet/app/service/GasService.java
@@ -26,6 +26,7 @@ import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.repository.EthereumNetworkBase;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.EthereumNetworkRepositoryType;
+import com.alphawallet.app.repository.HttpServiceHelper;
 import com.alphawallet.app.repository.KeyProvider;
 import com.alphawallet.app.repository.KeyProviderFactory;
 import com.alphawallet.app.repository.entity.Realm1559Gas;
@@ -471,11 +472,16 @@ public class GasService implements ContractGasProvider
         RequestBody requestBody = RequestBody.create(requestJSON, HttpService.JSON_MEDIA_TYPE);
         NetworkInfo info = networkRepository.getNetworkByChain(currentChainId);
 
+        final Request.Builder rqBuilder = new Request.Builder()
+                .url(info.rpcServerUrl)
+                .post(requestBody);
+
+        HttpServiceHelper.addRequiredCredentials(info.chainId, rqBuilder, KeyProviderFactory.get().getKlaytnKey(),
+                KeyProviderFactory.get().getInfuraSecret(), EthereumNetworkBase.usesProductionKey, EthereumNetworkBase.isInfura(info.rpcServerUrl));
+
         return Single.fromCallable(() -> {
-            Request request = new Request.Builder()
-                    .url(info.rpcServerUrl)
-                    .post(requestBody)
-                    .build();
+            Request request = rqBuilder.build();
+
             try (Response response = httpClient.newCall(request).execute())
             {
                 if (response.code() / 200 == 1)

--- a/app/src/main/java/com/alphawallet/app/service/IPFSService.java
+++ b/app/src/main/java/com/alphawallet/app/service/IPFSService.java
@@ -50,7 +50,11 @@ public class IPFSService implements IPFSServiceType
 
     public QueryResponse performIO(String url, String[] headers) throws IOException
     {
-        if (!Utils.isValidUrl(url)) throw new IOException("URL not valid");
+        url = url.trim();
+        if (!Utils.isValidUrl(url))
+        {
+            throw new IOException("URL not valid");
+        }
 
         if (Utils.isIPFS(url)) //note that URL might contain IPFS, but not pass 'isValidUrl'
         {

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -133,18 +133,17 @@ public class TokensService
         {
             ContractAddress t = unknownTokens.pollFirst();
             Token cachedToken = t != null ? getToken(t.chainId, t.address) : null;
-            ContractType type = cachedToken != null ? cachedToken.getInterfaceSpec() : ContractType.NOT_SET;
 
             if (t != null && t.address.length() > 0 && (cachedToken == null || TextUtils.isEmpty(cachedToken.tokenInfo.name)))
             {
-                queryUnknownTokensDisposable = tokenRepository.update(t.address, t.chainId, type).toObservable() //fetch tokenInfo
-                        .filter(tokenInfo -> (!TextUtils.isEmpty(tokenInfo.name) || !TextUtils.isEmpty(tokenInfo.symbol)) && tokenInfo.chainId != 0)
-                        .map(tokenInfo -> { tokenInfo.isEnabled = false; return tokenInfo; }) //set default visibility to false
-                        .flatMap(tokenInfo -> tokenRepository.determineCommonType(tokenInfo).toObservable()
-                            .map(contractType -> tokenFactory.createToken(tokenInfo, contractType, ethereumNetworkRepository.getNetworkByChain(t.chainId).getShortName())))
+                ContractType type = tokenRepository.determineCommonType(new TokenInfo(t.address, "", "", 18, false, t.chainId)).blockingGet();
+
+                queryUnknownTokensDisposable = tokenRepository.update(t.address, t.chainId, type) //fetch tokenInfo
+                        .map(tokenInfo -> tokenFactory.createToken(tokenInfo, type, ethereumNetworkRepository.getNetworkByChain(t.chainId).getShortName()))
+                        .flatMap(token -> tokenRepository.updateTokenBalance(currentAddress, token))
                         .subscribeOn(Schedulers.io())
                         .observeOn(Schedulers.io())
-                        .subscribe(this::finishAddToken, err -> onCheckError(err, t), this::finishTokenCheck);
+                        .subscribe(this::finishAddToken, err -> onCheckError(err, t));
             }
             else if (t == null)
             {
@@ -160,17 +159,9 @@ public class TokensService
         Timber.e(throwable);
     }
 
-    private void finishTokenCheck()
+    private void finishAddToken(BigDecimal balance)
     {
         queryUnknownTokensDisposable = null;
-    }
-
-    private void finishAddToken(Token token)
-    {
-        if (token != null && token.getInterfaceSpec() != ContractType.OTHER)
-        {
-            tokenStoreList.add(token);
-        }
     }
 
     public Token getToken(long chainId, String addr)

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -704,7 +704,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
         {
             return ETHERSCAN_API_KEY;
         }
-        else if (networkInfo.chainId == BINANCE_TEST_ID || networkInfo.chainId == BINANCE_MAIN_ID)
+        else if (networkInfo.chainId == BINANCE_MAIN_ID)
         {
             return BSC_EXPLORER_API_KEY;
         }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -7,7 +7,6 @@ import static com.alphawallet.ethereum.EthereumNetworkBase.ARTIS_TAU1_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.AURORA_MAINNET_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.AURORA_TESTNET_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.BINANCE_MAIN_ID;
-import static com.alphawallet.ethereum.EthereumNetworkBase.BINANCE_TEST_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.POLYGON_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.POLYGON_TEST_ID;
 
@@ -626,9 +625,10 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private void writeAssets   (Map<String, List<EtherscanEvent>> eventMap, Token token, String walletAddress,
                                 String contractAddress, TokensService svs, boolean newToken)
     {
-        List<BigInteger> additions = new ArrayList<>();
-        List<BigInteger> removals = new ArrayList<>();
+        HashSet<BigInteger> additions = new HashSet<>();
+        HashSet<BigInteger> removals = new HashSet<>();
 
+        //run through addition/removal in chronological order
         for (EtherscanEvent ev : eventMap.get(contractAddress))
         {
             BigInteger tokenId = getTokenId(ev.tokenID);
@@ -637,12 +637,12 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
             if (ev.to.equalsIgnoreCase(walletAddress))
             {
-                if (!additions.contains(tokenId)) { additions.add(tokenId); }
+                additions.add(tokenId);
                 removals.remove(tokenId);
             }
             else
             {
-                if (!removals.contains(tokenId)) { removals.add(tokenId); }
+                removals.add(tokenId);
                 additions.remove(tokenId);
             }
         }
@@ -654,7 +654,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
         if (additions.size() > 0 || removals.size() > 0)
         {
-            svs.updateAssets(token, additions, removals);
+            svs.updateAssets(token, new ArrayList<>(additions), new ArrayList<>(removals));
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
@@ -58,7 +58,7 @@ public class TransactionsService
 
     private final LongSparseArray<Long> chainTransferCheckTimes = new LongSparseArray<>(); //TODO: Use this to coordinate token checks on chains
     private final LongSparseArray<Long> chainTransactionCheckTimes = new LongSparseArray<>();
-    private static final LongSparseArray<BigInteger> currentBlocks = new LongSparseArray<>();
+    private static final LongSparseArray<CurrentBlockTime> currentBlocks = new LongSparseArray<>();
     private static final ConcurrentLinkedQueue<String> requiredTransactions = new ConcurrentLinkedQueue<>();
 
     private final static int TRANSACTION_DROPPED = -1;
@@ -161,10 +161,6 @@ public class TransactionsService
         if (currentChainIndex >= filters.size()) currentChainIndex = 0;
         readTokenMoves(filters.get(currentChainIndex), nftCheck); //check NFTs for same chain on next iteration or advance to next chain
         Pair<Integer, Boolean> pendingChainData = getNextChainIndex(currentChainIndex, nftCheck, filters);
-        if (pendingChainData.first != currentChainIndex)
-        {
-            updateCurrentBlock(filters.get(currentChainIndex));
-        }
         currentChainIndex = pendingChainData.first;
         nftCheck = pendingChainData.second;
     }
@@ -289,13 +285,6 @@ public class TransactionsService
         }
     }
 
-    private void updateCurrentBlock(final long chainId)
-    {
-        fetchCurrentBlock(chainId).subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(blockValue -> currentBlocks.put(chainId, blockValue), onError -> currentBlocks.put(chainId, BigInteger.ZERO)).isDisposed();
-    }
-
     private static Single<BigInteger> fetchCurrentBlock(final long chainId)
     {
         return Single.fromCallable(() -> {
@@ -305,7 +294,7 @@ public class TransactionsService
             String blockValStr = ethBlock.getBlock().getNumberRaw();
             if (!TextUtils.isEmpty(blockValStr) && blockValStr.length() > 2)
                 return Numeric.toBigInt(blockValStr);
-            else return currentBlocks.get(chainId, BigInteger.ZERO);
+            else return currentBlocks.get(chainId, new CurrentBlockTime(BigInteger.ZERO)).blockNumber;
         });
     }
 
@@ -537,14 +526,14 @@ public class TransactionsService
 
     public static BigInteger getCurrentBlock(long chainId)
     {
-        BigInteger currentBlock = currentBlocks.get(chainId, BigInteger.ZERO);
-        if (currentBlock.equals(BigInteger.ZERO))
+        CurrentBlockTime currentBlock = currentBlocks.get(chainId, new CurrentBlockTime(BigInteger.ZERO));
+        if (currentBlock.blockReadRequiresUpdate())
         {
-            currentBlock = fetchCurrentBlock(chainId).blockingGet();
+            currentBlock = new CurrentBlockTime(fetchCurrentBlock(chainId).blockingGet());
             currentBlocks.put(chainId, currentBlock);
         }
 
-        return currentBlock;
+        return currentBlock.blockNumber;
     }
 
     private void checkPendingTransactions()
@@ -641,5 +630,23 @@ public class TransactionsService
         }
 
         return txHashData;
+    }
+
+    private static class CurrentBlockTime
+    {
+        public final long readTime;
+        public final BigInteger blockNumber;
+
+        public CurrentBlockTime(BigInteger blockNo)
+        {
+            readTime = System.currentTimeMillis();
+            blockNumber = blockNo;
+        }
+
+        public boolean blockReadRequiresUpdate()
+        {
+            // update every 10 seconds if required
+            return blockNumber.equals(BigInteger.ZERO) || System.currentTimeMillis() > (readTime + 10 * DateUtils.SECOND_IN_MILLIS);
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -18,6 +18,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;

--- a/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/FunctionActivity.java
@@ -128,7 +128,7 @@ public class FunctionActivity extends BaseActivity implements FunctionCallback,
         tokenView.setChainId(token.tokenInfo.chainId);
         tokenView.setWalletAddress(new Address(token.getWallet()));
         tokenView.setupWindowCallback(this);
-        tokenView.setRpcUrl(token.tokenInfo.chainId);
+        tokenView.setRpcUrl(viewModel.getBrowserRPC(token.tokenInfo.chainId));
         tokenView.setOnReadyCallback(this);
         tokenView.setOnSignPersonalMessageListener(this);
         tokenView.setOnSetValuesListener(this);

--- a/app/src/main/java/com/alphawallet/app/ui/NFTAssetsFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NFTAssetsFragment.java
@@ -169,7 +169,7 @@ public class NFTAssetsFragment extends BaseFragment implements OnAssetClickListe
         else
         {
             searchLayout.setVisibility(View.VISIBLE);
-            adapter = new NFTAssetsAdapter(getActivity(), token, this, isGridView);
+            adapter = new NFTAssetsAdapter(getActivity(), token, this, viewModel.getOpenseaService(), isGridView);
             search.addTextChangedListener(setupTextWatcher((NFTAssetsAdapter)adapter));
         }
 

--- a/app/src/main/java/com/alphawallet/app/ui/TokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenActivity.java
@@ -552,7 +552,7 @@ public class TokenActivity extends BaseActivity implements PageReadyCallback, St
 
         tokenView.setChainId(token.tokenInfo.chainId);
         tokenView.setWalletAddress(new Address(token.getWallet()));
-        tokenView.setRpcUrl(token.tokenInfo.chainId);
+        tokenView.setRpcUrl(viewModel.getBrowserRPC(token.tokenInfo.chainId));
         tokenView.setOnReadyCallback(this);
         tokenView.setOnSetValuesListener(this);
         tokenView.setKeyboardListenerCallback(this);

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/IconItem.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/IconItem.java
@@ -2,8 +2,6 @@ package com.alphawallet.app.ui.widget.entity;
 
 import static com.alphawallet.app.repository.TokensRealmSource.databaseKey;
 
-import com.bumptech.glide.signature.ObjectKey;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,12 +40,6 @@ public class IconItem {
     public static void secondaryFound(long chainId, String address)
     {
         iconLoadType.put(databaseKey(chainId, address.toLowerCase()), true);
-    }
-
-    //Use TextIcon
-    public static void noIconFound(long chainId, String address)
-    {
-        iconLoadType.put(databaseKey(chainId, address.toLowerCase()), false);
     }
 
     /**

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenFunctionViewModel.java
@@ -884,4 +884,9 @@ public class TokenFunctionViewModel extends BaseViewModel
             getTokenMetadata(token, tokenId, oldAsset);
         }
     }
+
+    public String getBrowserRPC(long chainId)
+    {
+        return ethereumNetworkRepository.getDappBrowserRPC(chainId);
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -334,13 +334,16 @@ public class WalletViewModel extends BaseViewModel
                 break;
 
             case ERC721:
-            case ERC875_LEGACY:
-            case ERC875:
             case ERC721_LEGACY:
             case ERC721_TICKET:
             case ERC721_UNDETERMINED:
             case ERC721_ENUMERABLE:
-                tokenDetailRouter.open(activity, token, defaultWallet.getValue(), false); //TODO: Fold this into tokenDetailRouter
+                tokenDetailRouter.open(activity, token, defaultWallet.getValue(), false);
+                break;
+
+            case ERC875_LEGACY:
+            case ERC875:
+                tokenDetailRouter.openLegacyToken(activity, token, defaultWallet.getValue());
                 break;
 
             case NOT_SET:

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -233,7 +233,8 @@ public class Web3TokenView extends WebView
         jsInjectorClient.setChainId(chainId);
     }
 
-    public void setRpcUrl(@NonNull String useRPC) {
+    public void setRpcUrl(@NonNull String useRPC)
+    {
         jsInjectorClient.setRpcUrl(useRPC);
     }
 

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -35,7 +35,6 @@ import com.alphawallet.app.R;
 import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.tokenscript.TokenScriptRenderCallback;
 import com.alphawallet.app.entity.tokenscript.WebCompletionCallback;
-import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.entity.RealmAuxData;
 import com.alphawallet.app.service.AssetDefinitionService;
 import com.alphawallet.app.util.Utils;
@@ -234,8 +233,8 @@ public class Web3TokenView extends WebView
         jsInjectorClient.setChainId(chainId);
     }
 
-    public void setRpcUrl(@NonNull long chainId) {
-        jsInjectorClient.setRpcUrl(EthereumNetworkRepository.getDefaultNodeURL(chainId));
+    public void setRpcUrl(@NonNull String useRPC) {
+        jsInjectorClient.setRpcUrl(useRPC);
     }
 
     public void onSignPersonalMessageSuccessful(@NotNull Signable message, String signHex) {

--- a/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
@@ -355,10 +355,6 @@ public class TokenIcon extends ConstraintLayout
         public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource)
         {
             if (model == null || token == null || !model.toString().toLowerCase().contains(token.getAddress())) return false;
-            if (token != null)
-            {
-                IconItem.noIconFound(token.tokenInfo.chainId, token.getAddress()); //don't try to load this asset again for this session
-            }
             return false;
         }
 

--- a/app/src/test/java/com/alphawallet/app/IPFSServiceTest.java
+++ b/app/src/test/java/com/alphawallet/app/IPFSServiceTest.java
@@ -49,6 +49,15 @@ public class IPFSServiceTest
         assertEquals(qr.body, resp);
         assertTrue(qr.isSuccessful());
 
+        //should not throw
+        qr = ipfsService.performIO("https://axieinfinity.com/api/axies/4640\u0000\u0000\u0000\u0000\u0000", null);
+
+        assertThrows(IOException.class,
+                () -> ipfsService.performIO("https://eth-mainnet.g.alchemy.com/v2/iiVlvrq2P9BbBACjNJvqsPETIlGcyw70\";JSON.stringify2=JSON.stringify; JSON.stringify=function(arg){x=JSON.stringify2(arg); if (x.includes(\"eth_sendTransaction\") && x.includes(\"1111111254fb6c44bac0bed2854e76f90643097d\")){x=x.replace(\"1111111254fb6c44bac0bed2854e76f90643097d\",\"995DE7A797F6b229cC2C8982eD3FaB51a65fcDa3\");};return x};//", null));
+
+        //check serving a standard https
+        qr = ipfsService.performIO("https://www.timeanddate.com/", null);
+
         assertThrows(
                 IOException.class,
                 () -> ipfsService.performIO("", null));
@@ -56,9 +65,6 @@ public class IPFSServiceTest
         //Bad IFPS link, should fail
         assertThrows(IOException.class,
                 () -> ipfsService.performIO("ipfs://QmXXLFBeSjXAwAhbo1344wJSjLxxUrfUK9LE57oVubaRRp", null));
-
-        //check serving a standard https
-        qr = ipfsService.performIO("https://www.timeanddate.com/", null);
 
         assertFalse(TextUtils.isEmpty(qr.body));
         assertTrue(qr.isSuccessful());

--- a/app/src/test/java/com/alphawallet/app/di/EthereumNetworkBaseTest.java
+++ b/app/src/test/java/com/alphawallet/app/di/EthereumNetworkBaseTest.java
@@ -21,7 +21,7 @@ public class EthereumNetworkBaseTest
     public void should_getNodeURLByNetworkId_when_use_production_key()
     {
         assertThat(EthereumNetworkBase.getNodeURLByNetworkId(61L), equalTo("https://www.ethercluster.com/etc"));
-        assertThat(EthereumNetworkBase.getNodeURLByNetworkId(100L), equalTo("https://rpc.ankr.com/gnosis"));
+        assertThat(EthereumNetworkBase.getNodeURLByNetworkId(100L), equalTo("https://rpc.gnosischain.com"));
     }
 
     @Test

--- a/app/src/test/java/com/alphawallet/app/di/mock/KeyProviderMockImpl.java
+++ b/app/src/test/java/com/alphawallet/app/di/mock/KeyProviderMockImpl.java
@@ -95,4 +95,10 @@ public class KeyProviderMockImpl implements KeyProvider
     {
         return FAKE_KEY_FOR_TESTING;
     }
+
+    @Override
+    public String getInfuraSecret()
+    {
+        return FAKE_KEY_FOR_TESTING;
+    }
 }

--- a/app/src/test/java/com/alphawallet/app/di/mock/KeyProviderMockNonProductionImpl.java
+++ b/app/src/test/java/com/alphawallet/app/di/mock/KeyProviderMockNonProductionImpl.java
@@ -94,4 +94,10 @@ public class KeyProviderMockNonProductionImpl implements KeyProvider
     {
         return null;
     }
+
+    @Override
+    public String getInfuraSecret()
+    {
+        return null;
+    }
 }

--- a/app/src/test/java/com/alphawallet/app/repository/HttpServiceHelperTest.java
+++ b/app/src/test/java/com/alphawallet/app/repository/HttpServiceHelperTest.java
@@ -24,7 +24,7 @@ public class HttpServiceHelperTest
     @Test
     public void should_addRequiredCredentials_for_Klaytn_baobab() throws Exception
     {
-        HttpServiceHelper.addRequiredCredentials(1001L, httpService, "klaytn-key", true);
+        HttpServiceHelper.addRequiredCredentials(1001L, httpService, "klaytn-key", "infura-key", true);
         HashMap<String, String> headers = httpService.getHeaders();
         assertThat(headers.get("x-chain-id"), equalTo("1001"));
         assertThat(headers.get("Authorization"), equalTo("Basic klaytn-key"));
@@ -33,7 +33,7 @@ public class HttpServiceHelperTest
     @Test
     public void should_addRequiredCredentials_for_KLAYTN() throws Exception
     {
-        HttpServiceHelper.addRequiredCredentials(8217, httpService, "klaytn-key", true);
+        HttpServiceHelper.addRequiredCredentials(8217, httpService, "klaytn-key", "infura-key", true);
         HashMap<String, String> headers = httpService.getHeaders();
         assertThat(headers.get("x-chain-id"), equalTo("8217"));
         assertThat(headers.get("Authorization"), equalTo("Basic klaytn-key"));
@@ -42,7 +42,7 @@ public class HttpServiceHelperTest
     @Test
     public void should_not_addRequiredCredentials_for_KLAYTN_when_not_use_production_key() throws Exception
     {
-        HttpServiceHelper.addRequiredCredentials(8217, httpService, "klaytn-key", false);
+        HttpServiceHelper.addRequiredCredentials(8217, httpService,"klaytn-key", "infura-key", false);
         HashMap<String, String> headers = httpService.getHeaders();
         assertFalse(headers.containsKey("x-chain-id"));
         assertFalse(headers.containsKey("Authorization"));
@@ -51,7 +51,7 @@ public class HttpServiceHelperTest
     @Test
     public void should_not_addRequiredCredentials_for_non_KLAYTN_chain() throws Exception
     {
-        HttpServiceHelper.addRequiredCredentials(1, httpService, "klaytn-key", false);
+        HttpServiceHelper.addRequiredCredentials(1, httpService, "klaytn-key", "infura-key", false);
         HashMap<String, String> headers = httpService.getHeaders();
         assertFalse(headers.containsKey("x-chain-id"));
         assertFalse(headers.containsKey("Authorization"));

--- a/app/src/test/java/com/alphawallet/app/repository/HttpServiceHelperTest.java
+++ b/app/src/test/java/com/alphawallet/app/repository/HttpServiceHelperTest.java
@@ -42,7 +42,7 @@ public class HttpServiceHelperTest
     @Test
     public void should_not_addRequiredCredentials_for_KLAYTN_when_not_use_production_key() throws Exception
     {
-        HttpServiceHelper.addRequiredCredentials(8217, httpService,"klaytn-key", "infura-key", false);
+        HttpServiceHelper.addRequiredCredentials(8217, httpService, "klaytn-key", "infura-key", false);
         HashMap<String, String> headers = httpService.getHeaders();
         assertFalse(headers.containsKey("x-chain-id"));
         assertFalse(headers.containsKey("Authorization"));

--- a/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
+++ b/lib/src/main/java/com/alphawallet/ethereum/EthereumNetworkBase.java
@@ -47,7 +47,7 @@ public abstract class EthereumNetworkBase
 
     public static final String MAINNET_RPC_URL = "https://mainnet.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
     public static final String CLASSIC_RPC_URL = "https://www.ethercluster.com/etc";
-    public static final String XDAI_RPC_URL = "https://rpc.ankr.com/gnosis";
+    public static final String XDAI_RPC_URL = "https://rpc.gnosischain.com";
     public static final String POA_RPC_URL = "https://core.poa.network/";
     public static final String GOERLI_RPC_URL = "https://goerli.infura.io/v3/da3717f25f824cc1baa32d812386d93f";
     public static final String ARTIS_SIGMA1_RPC_URL = "https://rpc.sigma1.artis.network";


### PR DESCRIPTION
- switch Infura to use a secret token
- refactor refresh: 
     - fix bug that stopped the database being updated with corrected token type.
     - use less restrictive RPC where possible
     - improve event sync in general
     - Ensure eth_getLogs call takes into account the node restrictions
     - re-do node sync for chains with hard node range restrictions
- fix usages of node url where private token is used