### PR TITLE
Hotfix for widget labels overflowing on long strings

### DIFF
--- a/app/src/main/res/layout/item_address_detail.xml
+++ b/app/src/main/res/layout/item_address_detail.xml
@@ -21,11 +21,11 @@
 
         <TextView
             android:id="@+id/text_recipient_title"
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:text="@string/recipient" />
 
         <TextView

--- a/app/src/main/res/layout/item_amount_display.xml
+++ b/app/src/main/res/layout/item_amount_display.xml
@@ -18,11 +18,11 @@
         android:paddingEnd="@dimen/mini_4">
 
         <TextView
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:text="@string/amount" />
 
         <TextView

--- a/app/src/main/res/layout/item_asset_detail.xml
+++ b/app/src/main/res/layout/item_asset_detail.xml
@@ -21,11 +21,11 @@
         android:paddingEnd="@dimen/mini_4">
 
         <TextView
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:text="@string/token_text" />
 
         <TextView

--- a/app/src/main/res/layout/item_balance_display.xml
+++ b/app/src/main/res/layout/item_balance_display.xml
@@ -17,11 +17,11 @@
         android:paddingEnd="@dimen/mini_4">
 
         <TextView
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:text="@string/balance" />
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_gas_settings.xml
+++ b/app/src/main/res/layout/item_gas_settings.xml
@@ -16,11 +16,11 @@
         android:paddingEnd="@dimen/mini_4">
 
         <TextView
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:lines="1"
             android:text="@string/speed_gas" />
 

--- a/app/src/main/res/layout/item_network_display.xml
+++ b/app/src/main/res/layout/item_network_display.xml
@@ -18,9 +18,10 @@
         android:paddingHorizontal="@dimen/standard_16">
 
         <TextView
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:gravity="start|center_vertical"
             android:layout_weight="@integer/widget_label"
             android:text="@string/subtitle_network" />
 

--- a/app/src/main/res/layout/item_sign_data.xml
+++ b/app/src/main/res/layout/item_sign_data.xml
@@ -21,11 +21,11 @@
 
         <TextView
             android:id="@+id/text_message_title"
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="@integer/widget_label"
-            android:gravity="start"
+            android:gravity="start|center_vertical"
             android:text="@string/message_to_sign" />
 
         <TextView

--- a/app/src/main/res/layout/item_simple_widget.xml
+++ b/app/src/main/res/layout/item_simple_widget.xml
@@ -21,7 +21,7 @@
 
         <TextView
             android:id="@+id/label"
-            style="@style/Aw.Typography.Label"
+            style="@style/Aw.Typography.Label.Widget"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="top"

--- a/app/src/main/res/layout/transaction_detail_widget.xml
+++ b/app/src/main/res/layout/transaction_detail_widget.xml
@@ -67,10 +67,10 @@
             android:paddingEnd="@dimen/mini_4">
 
             <TextView
-                style="@style/Aw.Typography.Label"
+                style="@style/Aw.Typography.Label.Widget"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
+                android:layout_gravity="start|center_vertical"
                 android:layout_weight="@integer/widget_content"
                 android:text="@string/title_transaction_details"
                 android:visibility="visible" />

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Widget Weights -->
-    <item type="integer" name="widget_label" format="float">1</item>
-    <item type="integer" name="widget_content" format="float">3.5</item>
+    <item type="integer" name="widget_label" format="float">1.3</item>
+    <item type="integer" name="widget_content" format="float">3.2</item>
     <item type="integer" name="widget_control" format="float">0.6</item>
 </resources>

--- a/app/src/main/res/values/typography.xml
+++ b/app/src/main/res/values/typography.xml
@@ -70,6 +70,11 @@
         <item name="android:textColor">?android:textColorSecondary</item>
     </style>
 
+    <style name="Aw.Typography.Label.Widget">
+        <item name="android:lines">1</item>
+        <item name="autoSizeTextType">uniform</item>
+    </style>
+
     <style name="Aw.Typography.Label.Small">
         <item name="fontFamily">@font/font_semibold</item>
         <item name="android:textSize">@dimen/sp13</item>


### PR DESCRIPTION
Hotfix for widget labels overflowing on long strings