### PR TITLE
Regulate Token Updates

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
@@ -20,49 +20,66 @@ import java.util.Map;
 import io.reactivex.Single;
 import io.realm.Realm;
 
-public interface TokenLocalSource {
+public interface TokenLocalSource
+{
     Single<Token> saveToken(Wallet wallet, Token token);
+
     Single<Token[]> saveTokens(Wallet wallet, Token[] items);
+
     boolean updateTokenBalance(Wallet wallet, Token token, BigDecimal balance, List<BigInteger> balanceArray);
+
     Token fetchToken(long chainId, Wallet wallet, String address);
+
     void setEnable(Wallet wallet, Token token, boolean isEnabled);
+
     String getTokenImageUrl(long chainId, String address);
+
     void deleteRealmTokens(Wallet wallet, List<TokenCardMeta> tcmList);
+
     void storeTokenUrl(long chainId, String address, String imageUrl);
+
     Token[] initNFTAssets(Wallet wallet, Token[] tokens);
 
     Single<TokenCardMeta[]> fetchTokenMetas(Wallet wallet, List<Long> networkFilters,
                                             AssetDefinitionService svs);
 
     Single<TokenCardMeta[]> fetchAllTokenMetas(Wallet wallet, List<Long> networkFilters,
-                                             String seachTerm);
+                                               String seachTerm);
 
     TokenCardMeta[] fetchTokenMetasForUpdate(Wallet wallet, List<Long> networkFilters);
 
     Single<Token[]> fetchAllTokensWithNameIssue(String walletAddress, List<Long> networkFilters);
+
     Single<ContractAddress[]> fetchAllTokensWithBlankName(String walletAddress, List<Long> networkFilters);
 
     Single<Integer> fixFullNames(Wallet wallet, AssetDefinitionService svs);
 
     void updateEthTickers(Map<Long, TokenTicker> ethTickers);
+
     void updateERC20Tickers(long chainId, Map<String, TokenTicker> erc20Tickers);
+
     void removeOutdatedTickers();
 
     Realm getRealmInstance(Wallet wallet);
+
     Realm getTickerRealmInstance();
 
     TokenTicker getCurrentTicker(Token token);
+
     TokenTicker getCurrentTicker(String key);
 
     void setVisibilityChanged(Wallet wallet, Token token);
 
     boolean hasVisibilityBeenChanged(Token token);
+
     boolean getEnabled(Token token);
 
     void updateNFTAssets(String wallet, Token erc721Token, List<BigInteger> additions, List<BigInteger> removals);
+
     void storeAsset(String wallet, Token token, BigInteger tokenId, NFTAsset asset);
 
     int storeTokensMapping(Pair<Map<String, ContractAddress>, Map<String, TokenGroup>> mappings);
+
     long getLastMappingsUpdate();
 
     Single<Pair<Double, Double>> getTotalValue(String currentAddress, List<Long> networkFilters);
@@ -74,6 +91,7 @@ public interface TokenLocalSource {
     Single<List<String>> getTickerUpdateList(List<Long> networkFilter);
 
     ContractAddress getBaseToken(long chainId, String address);
+
     TokenGroup getTokenGroup(long chainId, String address, ContractType type);
 
     void updateTicker(long chainId, String address, TokenTicker ticker);

--- a/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
@@ -27,7 +27,7 @@ public interface TokenLocalSource {
     Token fetchToken(long chainId, Wallet wallet, String address);
     void setEnable(Wallet wallet, Token token, boolean isEnabled);
     String getTokenImageUrl(long chainId, String address);
-    void deleteRealmToken(long chainId, Wallet wallet, String address);
+    void deleteRealmTokens(Wallet wallet, List<TokenCardMeta> tcmList);
     void storeTokenUrl(long chainId, String address, String imageUrl);
     Token[] initNFTAssets(Wallet wallet, Token[] tokens);
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -51,6 +51,7 @@ public interface TokenRepositoryType {
 
     void addImageUrl(long chainId, String address, String imageUrl);
     void updateLocalAddress(String walletAddress);
+    void deleteRealmTokens(Wallet wallet, List<TokenCardMeta> tcmList);
 
     Single<TokenCardMeta[]> fetchTokenMetas(Wallet wallet, List<Long> networkFilters,
                                             AssetDefinitionService svs);

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -23,26 +23,42 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.realm.Realm;
 
-public interface TokenRepositoryType {
-
+public interface TokenRepositoryType
+{
     Observable<Token> fetchActiveTokenBalance(String walletAddress, Token token);
+
     Single<BigDecimal> updateTokenBalance(String walletAddress, Token token);
+
     Single<ContractLocator> getTokenResponse(String address, long chainId, String method);
+
     Single<Token[]> checkInterface(Token[] tokens, Wallet wallet);
+
     void setEnable(Wallet wallet, Token token, boolean isEnabled);
+
     void setVisibilityChanged(Wallet wallet, Token token);
+
     Single<TokenInfo> update(String address, long chainId, ContractType type);
+
     Observable<TransferFromEventResponse> burnListenerObservable(String contractAddress);
+
     Single<TokenTicker> getEthTicker(long chainId);
+
     TokenTicker getTokenTicker(Token token);
+
     Single<BigInteger> fetchLatestBlockNumber(long chainId);
+
     Token fetchToken(long chainId, String walletAddress, String address);
+
     String getTokenImageUrl(long chainId, String address);
 
     Single<Token[]> storeTokens(Wallet wallet, Token[] tokens);
+
     Single<String> resolveENS(long chainId, String address);
+
     void updateAssets(String wallet, Token erc721Token, List<BigInteger> additions, List<BigInteger> removals);
+
     void storeAsset(String currentAddress, Token token, BigInteger tokenId, NFTAsset asset);
+
     Token[] initNFTAssets(Wallet wallet, Token[] token);
 
     Single<ContractType> determineCommonType(TokenInfo tokenInfo);
@@ -50,31 +66,38 @@ public interface TokenRepositoryType {
     Single<Boolean> fetchIsRedeemed(Token token, BigInteger tokenId);
 
     void addImageUrl(long chainId, String address, String imageUrl);
+
     void updateLocalAddress(String walletAddress);
+
     void deleteRealmTokens(Wallet wallet, List<TokenCardMeta> tcmList);
 
     Single<TokenCardMeta[]> fetchTokenMetas(Wallet wallet, List<Long> networkFilters,
                                             AssetDefinitionService svs);
 
     Single<TokenCardMeta[]> fetchAllTokenMetas(Wallet wallet, List<Long> networkFilters,
-                                            String searchTerm);
+                                               String searchTerm);
 
     Single<Token[]> fetchTokensThatMayNeedUpdating(String walletAddress, List<Long> networkFilters);
+
     Single<ContractAddress[]> fetchAllTokensWithBlankName(String walletAddress, List<Long> networkFilters);
 
     TokenCardMeta[] fetchTokenMetasForUpdate(Wallet wallet, List<Long> networkFilters);
 
     Realm getRealmInstance(Wallet wallet);
+
     Realm getTickerRealmInstance();
 
     Single<BigDecimal> fetchChainBalance(String walletAddress, long chainId);
+
     Single<Integer> fixFullNames(Wallet wallet, AssetDefinitionService svs);
-    
+
     boolean isEnabled(Token newToken);
+
     boolean hasVisibilityBeenChanged(Token token);
 
     Single<Pair<Double, Double>> getTotalValue(String currentAddress, List<Long> networkFilters);
 
     Single<List<String>> getTickerUpdateList(List<Long> networkFilter);
+
     TokenGroup getTokenGroup(long chainId, String address, ContractType type);
 }

--- a/app/src/main/java/com/alphawallet/app/service/AWHttpService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AWHttpService.java
@@ -129,7 +129,7 @@ public class AWHttpService extends HttpService
         okhttp3.Request httpRequest =
                 new okhttp3.Request.Builder().url(url).headers(headers).post(requestBody).build();
 
-        okhttp3.Response response;
+        okhttp3.Response response = null;
 
         try
         {
@@ -151,6 +151,7 @@ public class AWHttpService extends HttpService
 
         if (response.code() / 100 == 4) //rate limited
         {
+            response.close();
             return trySecondaryNode(request);
         }
 
@@ -189,6 +190,7 @@ public class AWHttpService extends HttpService
         }
         else if (!useSecondaryNode && secondaryUrl != null)
         {
+            response.close();
             return trySecondaryNode(request);
         }
         else

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -10,7 +10,6 @@ import android.util.Pair;
 import androidx.annotation.Nullable;
 
 import com.alphawallet.app.BuildConfig;
-import com.alphawallet.app.C;
 import com.alphawallet.app.analytics.Analytics;
 import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.ContractLocator;
@@ -234,7 +233,6 @@ public class TokensService
 
         eventTimer = Single.fromCallable(() -> {
             startupPass();
-            addUnresolvedContracts(ethereumNetworkRepository.getAllKnownContracts(getNetworkFilters()));
             checkIssueTokens();
             pendingTokenMap.clear();
             return true;
@@ -542,21 +540,6 @@ public class TokensService
                 .isDisposed();
     }
 
-    private void addUnresolvedContracts(List<ContractLocator> contractCandidates)
-    {
-        if (openseaService == null) return; //no need for this if syncing
-        if (contractCandidates != null && contractCandidates.size() > 0)
-        {
-            for (ContractLocator cl : contractCandidates)
-            {
-                if (getToken(cl.chainId, cl.address) == null)
-                {
-                    addUnknownTokenToCheck(new ContractAddress(cl.chainId, cl.address));
-                }
-            }
-        }
-    }
-
     private void checkTokensBalance()
     {
         final Token t = getNextInBalanceUpdateQueue();
@@ -608,6 +591,12 @@ public class TokensService
     private void onBalanceChange(BigDecimal newBalance, Token t)
     {
         boolean balanceChange = !newBalance.equals(t.balance);
+
+        if (newBalance.equals(BigDecimal.valueOf(-2)))
+        {
+            //token deleted
+            return;
+        }
 
         if (balanceChange && BuildConfig.DEBUG)
         {
@@ -1014,53 +1003,9 @@ public class TokensService
         });
     }
 
-    public Completable lockTokenVisibility(Token token)
-    {
-        return enableToken(currentAddress, token);
-    }
-
-    /**
-     * Timings for when there can be a check for new transactions
-     * @param t
-     * @return
-     */
-    private long getTokenTimeInterval(Token t)
-    {
-        long nextTimeCheck;
-
-        if (t.isEthereum())
-        {
-            nextTimeCheck = 30*DateUtils.SECOND_IN_MILLIS; //allow base chains to be checked about every 30 seconds
-        }
-        else
-        {
-            nextTimeCheck = t.getTransactionCheckInterval();
-        }
-
-        return nextTimeCheck;
-    }
-
     public Realm getTickerRealmInstance()
     {
         return tokenRepository.getTickerRealmInstance();
-    }
-
-    public boolean shouldDisplayPopularToken(TokenCardMeta tcm)
-    {
-        //Display popular token if
-        // - explicitly enabled
-        // - user has not altered the visibility and token has positive balance (user may not be aware of visibility controls).
-        if (ethereumNetworkRepository.getIsPopularToken(tcm.getChain(), tcm.getAddress()))
-        {
-            Token token = getToken(tcm.getChain(), tcm.getAddress());
-            return (token == null)
-                    || tokenRepository.isEnabled(token)
-                    || (!tokenRepository.hasVisibilityBeenChanged(token) && token.hasPositiveBalance());
-        }
-        else
-        {
-            return true;
-        }
     }
 
     public void walletInFocus()
@@ -1258,5 +1203,17 @@ public class TokensService
     public boolean hasLockedGas(long chainId)
     {
         return ethereumNetworkRepository.hasLockedGas(chainId);
+    }
+
+    public Single<Boolean> deleteTokens(List<TokenCardMeta> metasToDelete)
+    {
+        return Single.fromCallable(() -> {
+            tokenRepository.deleteRealmTokens(new Wallet(currentAddress), metasToDelete);
+            for (TokenCardMeta tcm : metasToDelete)
+            {
+                pendingTokenMap.remove(databaseKey(tcm.getChain(), tcm.getAddress()));
+            }
+            return true;
+        });
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -837,7 +837,7 @@ public class TokensService
 
             //simply multiply the weighting by the last diff.
             float updateFactor = weighting * (float) lastCheckDiff * (check.isEnabled ? 1 : 0.25f);
-            long cutoffCheck = 30*DateUtils.SECOND_IN_MILLIS / (check.isEnabled ? 1 : 10); //normal minimum update frequency for token 30 seconds, 5 minutes for hidden token
+            long cutoffCheck = check.calculateUpdateFrequency(); //normal minimum update frequency for token 30 seconds, 5 minutes for hidden token
 
             if (!check.isEthereum() && lastUpdateDiff > DateUtils.DAY_IN_MILLIS)
             {

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -69,7 +69,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private final String BLOCK_ENTRY = "-erc20blockCheck-";
     private final String ERC20_QUERY = "tokentx";
     private final String ERC721_QUERY = "tokennfttx";
-    private final int AUX_DATABASE_ID = 26; //increment this to do a one off refresh the AUX database, in case of changed design etc
+    private final int AUX_DATABASE_ID = 27; //increment this to do a one off refresh the AUX database, in case of changed design etc
     private final String DB_RESET = BLOCK_ENTRY + AUX_DATABASE_ID;
     private final String ETHERSCAN_API_KEY;
     private final String BSC_EXPLORER_API_KEY;
@@ -423,7 +423,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
 
             fullUrl = sb.toString();
 
-            if (!Utils.isValidUrl(fullUrl))
+            if (networkInfo.isCustom && !Utils.isValidUrl(networkInfo.etherscanAPI))
             {
                 return new EtherscanTransaction[0];
             }
@@ -572,6 +572,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                             token.getInterfaceSpec() != ContractType.ERC721_UNDETERMINED )))
             {
                 token = createNewERC721Token(eventMap.get(contract).get(0), networkInfo, walletAddress, false);
+                token.setTokenWallet(walletAddress);
                 newToken = true;
                 Timber.tag(TAG).d("Discover NFT: " + ev0.tokenName + " (" + ev0.tokenSymbol + ")");
             }
@@ -594,10 +595,6 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
             if (token.isNonFungible())
             {
                 writeAssets(eventMap, token, walletAddress, contract, svs, newToken);
-            }
-            else if (newToken) // new Fungible token
-            {
-                svs.storeToken(token);
             }
             else
             {
@@ -670,7 +667,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
                 "&page=1&offset=" + TRANSFER_RESULT_MAX +
                 "&sort=asc" + getNetworkAPIToken(networkInfo);
 
-        if (!Utils.isValidUrl(fullUrl))
+        if (networkInfo.isCustom && !Utils.isValidUrl(networkInfo.etherscanAPI))
         {
             return "0";
         }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
@@ -105,13 +105,13 @@ public class TransactionsService
         //reset transaction timers
         if (transactionCheckCycle == null || transactionCheckCycle.isDisposed())
         {
-            transactionCheckCycle = Observable.interval(0, 15, TimeUnit.SECONDS)
+            transactionCheckCycle = Observable.interval(3, 15, TimeUnit.SECONDS)
                     .doOnNext(l -> checkTransactionQueue()).subscribe();
         }
 
         if (tokenTransferCheckCycle == null || tokenTransferCheckCycle.isDisposed())
         {
-            tokenTransferCheckCycle = Observable.interval(2, 17, TimeUnit.SECONDS) //attempt to not interfere with transaction check
+            tokenTransferCheckCycle = Observable.interval(1, 17, TimeUnit.SECONDS) //attempt to not interfere with transaction check
                     .doOnNext(l -> checkTransfers()).subscribe();
         }
 
@@ -411,6 +411,9 @@ public class TransactionsService
         tokensService.checkingChain(0);
         chainTransferCheckTimes.clear();
         chainTransactionCheckTimes.clear();
+
+        currentChainIndex = 0;
+        nftCheck = false;
     }
 
     public static void addTransactionHashFetch(String txHash, long chainId, String wallet)

--- a/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/WalletFragment.java
@@ -346,6 +346,7 @@ public class WalletFragment extends BaseFragment implements
             {
                 adapter.updateTokenMetas(metas.toArray(new TokenCardMeta[0]));
                 systemView.hide();
+                viewModel.checkDeleteMetas(metas);
             }
         });
     }

--- a/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/adapter/TokensAdapter.java
@@ -393,6 +393,11 @@ public class TokensAdapter extends RecyclerView.Adapter<BinderViewHolder>
     private boolean canDisplayToken(TokenCardMeta token)
     {
         if (token == null) return false;
+        if (token.balance.equals("-2"))
+        {
+            return false;
+        }
+
         //Add token to display list if it's the base currency, or if it has balance
         boolean allowThroughFilter = CustomViewSettings.tokenCanBeDisplayed(token);
         allowThroughFilter = checkTokenValue(token, allowThroughFilter);

--- a/app/src/main/java/com/alphawallet/app/util/ens/AWEnsResolver.java
+++ b/app/src/main/java/com/alphawallet/app/util/ens/AWEnsResolver.java
@@ -9,6 +9,7 @@ import com.alphawallet.app.C;
 import com.alphawallet.app.entity.UnableToResolveENS;
 import com.alphawallet.app.service.OpenSeaService;
 import com.alphawallet.app.util.Utils;
+import com.alphawallet.app.web3j.ens.EnsResolutionException;
 import com.alphawallet.token.tools.Numeric;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -98,6 +99,10 @@ public class AWEnsResolver
             catch (UnableToResolveENS resolve)
             {
                 ensName = fetchPreviouslyUsedENS(address);
+            }
+            catch (EnsResolutionException e)
+            {
+                // Expected to throw when ENS name invalid
             }
             catch (Exception e)
             {

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TransactionDetailViewModel.java
@@ -1,5 +1,7 @@
 package com.alphawallet.app.viewmodel;
 
+import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -9,9 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import com.alphawallet.app.C;
 import com.alphawallet.app.R;
-import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.ErrorEnvelope;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.SignAuthenticationCallback;
@@ -43,16 +43,14 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.concurrent.TimeUnit;
 
+import javax.inject.Inject;
+
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
-
-import static com.alphawallet.app.repository.TokenRepository.getWeb3jService;
-
-import javax.inject.Inject;
 
 @HiltViewModel
 public class TransactionDetailViewModel extends BaseViewModel {
@@ -129,7 +127,8 @@ public class TransactionDetailViewModel extends BaseViewModel {
 
     public void showMoreDetails(Context context, Transaction transaction) {
         Uri uri = buildEtherscanUri(transaction);
-        if (uri != null && Utils.isValidUrl(uri.toString())) {
+        if (uri != null)
+        {
             externalBrowserRouter.open(context, uri);
         }
     }
@@ -159,7 +158,8 @@ public class TransactionDetailViewModel extends BaseViewModel {
     public void shareTransactionDetail(Context context, Transaction transaction)
     {
         Uri shareUri = buildEtherscanUri(transaction);
-        if (shareUri != null) {
+        if (shareUri != null)
+        {
             Intent sharingIntent = new Intent(Intent.ACTION_SEND);
             sharingIntent.setType("text/plain");
             sharingIntent.putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.subject_transaction_detail));
@@ -177,10 +177,14 @@ public class TransactionDetailViewModel extends BaseViewModel {
     private Uri buildEtherscanUri(Transaction transaction)
     {
         NetworkInfo networkInfo = networkInteract.getNetworkInfo(transaction.chainId);
-        if (networkInfo != null) {
+        if (networkInfo != null && Utils.isValidUrl(networkInfo.etherscanUrl))
+        {
             return networkInfo.getEtherscanUri(transaction.hash);
         }
-        return null;
+        else
+        {
+            return null;
+        }
     }
 
     public boolean hasEtherscanDetail(Transaction tx)

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -53,6 +53,7 @@ import org.jetbrains.annotations.NotNull;
 import org.web3j.crypto.Keys;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -87,7 +88,7 @@ public class WalletViewModel extends BaseViewModel
     private final OnRampRepositoryType onRampRepository;
     private long lastBackupCheck = 0;
     private BottomSheetDialog dialog;
-    private AWWalletConnectClient awWalletConnectClient;
+    private final AWWalletConnectClient awWalletConnectClient;
 
     @Inject
     WalletViewModel(
@@ -442,5 +443,25 @@ public class WalletViewModel extends BaseViewModel
     public MutableLiveData<List<WalletConnectSessionItem>> activeWalletConnectSessions()
     {
         return awWalletConnectClient.sessionItemMutableLiveData();
+    }
+
+    public void checkDeleteMetas(List<TokenCardMeta> metas)
+    {
+        List<TokenCardMeta> metasToDelete = new ArrayList<>();
+        for (TokenCardMeta meta : metas)
+        {
+            if (meta.balance.equals("-2"))
+            {
+                metasToDelete.add(meta);
+            }
+        }
+
+        if (metasToDelete.size() > 0)
+        {
+            disposable = tokensService.deleteTokens(metasToDelete)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe();
+        }
     }
 }


### PR DESCRIPTION
This is part of an ongoing series of commits to remove unnecessary network calls, beneficial for both users and API limits.

- ensure destroyed tokens are removed correctly
- only update required tokens
- take token details from etherscan for unusual contracts (eg DGD).