### PR TITLE
3029 change the title of the wallet tab to show the truncated wallet address if enswallet name is not available

### DIFF
--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -5,7 +5,6 @@ import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static com.alphawallet.app.assertions.Should.shouldNotSee;
 import static com.alphawallet.app.assertions.Should.shouldSee;
 import static com.alphawallet.app.steps.Steps.createNewWallet;
 import static com.alphawallet.app.steps.Steps.getWalletAddress;

--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -1,41 +1,52 @@
 package com.alphawallet.app;
 
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.alphawallet.app.assertions.Should.shouldNotSee;
 import static com.alphawallet.app.assertions.Should.shouldSee;
-import static com.alphawallet.app.steps.Steps.GANACHE_URL;
-import static com.alphawallet.app.steps.Steps.addNewNetwork;
-import static com.alphawallet.app.steps.Steps.assertBalanceIs;
 import static com.alphawallet.app.steps.Steps.createNewWallet;
-import static com.alphawallet.app.steps.Steps.ensureTransactionConfirmed;
 import static com.alphawallet.app.steps.Steps.getWalletAddress;
 import static com.alphawallet.app.steps.Steps.gotoWalletPage;
-import static com.alphawallet.app.steps.Steps.importWalletFromSettingsPage;
-import static com.alphawallet.app.steps.Steps.selectTestNet;
-import static com.alphawallet.app.steps.Steps.sendBalanceTo;
-import static com.alphawallet.app.steps.Steps.switchToWallet;
-import static org.junit.Assert.fail;
-
-import android.os.Build;
+import static com.alphawallet.app.steps.Steps.input;
+import static com.alphawallet.app.util.Helper.click;
 
 import com.alphawallet.app.util.Helper;
 
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class WalletNameTest extends BaseE2ETest
 {
-    @Test
-    public void should_show_formatted_address_by_default() {
-        createNewWallet();
-        String address = getWalletAddress();
-        gotoWalletPage();
+    public void shouldSeeFormattedAddress(String address) {
         shouldSee(address.substring(0, 6) + "..." + address.substring(address.length() - 4)); // 0xabcd...wxyz
     }
 
     @Test
     public void should_show_custom_name_instead_of_address()
     {
+        createNewWallet();
+        String address = getWalletAddress();
+
+        gotoWalletPage();
+        shouldSeeFormattedAddress(address);
+
+        renameWalletTo("TestWallet");
+        shouldSee("TestWallet");
+
+        renameWalletTo("");
+        shouldSeeFormattedAddress(address);
+    }
+
+    private void renameWalletTo(String name)
+    {
+        click(withId(R.id.action_my_wallet));
+        click(withSubstring("Rename this Wallet"));
+        onView(withId(R.id.edit_text)).perform(replaceText(name));
+        input(R.id.input_name, name);
+        click(withText("Save Name"));
+        Helper.wait(2);
     }
 
     @Test

--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -20,10 +20,6 @@ import org.junit.Test;
 
 public class WalletNameTest extends BaseE2ETest
 {
-    public void shouldSeeFormattedAddress(String address) {
-        shouldSee(address.substring(0, 6) + "..." + address.substring(address.length() - 4)); // 0xabcd...wxyz
-    }
-
     @Test
     public void should_show_custom_name_instead_of_address()
     {
@@ -40,6 +36,20 @@ public class WalletNameTest extends BaseE2ETest
         shouldSeeFormattedAddress(address);
     }
 
+    @Test
+    public void should_show_custom_name_instead_of_ENS_name()
+    {
+        watchWalletWithENS("vitalik.eth");
+        // Should see ENS name instead of address
+        shouldSee("vitalik.eth");
+        renameWalletTo("Vitalik");
+        gotoWalletPage();
+        shouldSee("Vitalik");
+        renameWalletTo("");
+        gotoWalletPage();
+        shouldSee("vitalik.eth");
+    }
+
     private void renameWalletTo(String name)
     {
         click(withId(R.id.action_my_wallet));
@@ -50,15 +60,7 @@ public class WalletNameTest extends BaseE2ETest
         Helper.wait(2);
     }
 
-    @Test
-    public void should_show_ENS_name_instead_of_address()
-    {
-        watchWalletWithENS("vitalik.eth");
-        shouldSee("vitalik.eth");
-    }
-
-    @Test
-    public void should_show_custom_name_instead_of_ENS_name()
-    {
+    private void shouldSeeFormattedAddress(String address) {
+        shouldSee(address.substring(0, 6) + "..." + address.substring(address.length() - 4)); // 0xabcd...wxyz
     }
 }

--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -1,0 +1,50 @@
+package com.alphawallet.app;
+
+import static com.alphawallet.app.assertions.Should.shouldSee;
+import static com.alphawallet.app.steps.Steps.GANACHE_URL;
+import static com.alphawallet.app.steps.Steps.addNewNetwork;
+import static com.alphawallet.app.steps.Steps.assertBalanceIs;
+import static com.alphawallet.app.steps.Steps.createNewWallet;
+import static com.alphawallet.app.steps.Steps.ensureTransactionConfirmed;
+import static com.alphawallet.app.steps.Steps.getWalletAddress;
+import static com.alphawallet.app.steps.Steps.gotoWalletPage;
+import static com.alphawallet.app.steps.Steps.importWalletFromSettingsPage;
+import static com.alphawallet.app.steps.Steps.selectTestNet;
+import static com.alphawallet.app.steps.Steps.sendBalanceTo;
+import static com.alphawallet.app.steps.Steps.switchToWallet;
+import static org.junit.Assert.fail;
+
+import android.os.Build;
+
+import com.alphawallet.app.util.Helper;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WalletNameTest extends BaseE2ETest
+{
+    @Test
+    public void should_show_formatted_address_by_default() {
+        createNewWallet();
+        String address = getWalletAddress();
+        gotoWalletPage();
+        shouldSee(address.substring(0, 6) + "..." + address.substring(address.length() - 4)); // 0xabcd...wxyz
+    }
+
+    @Test
+    public void should_show_custom_name_instead_of_address()
+    {
+    }
+
+    @Test
+    public void should_show_ENS_name_instead_of_address()
+    {
+    }
+
+    @Test
+    public void should_show_custom_name_instead_of_ENS_name()
+    {
+    }
+}

--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -42,9 +42,11 @@ public class WalletNameTest extends BaseE2ETest
         watchWalletWithENS("vitalik.eth");
         // Should see ENS name instead of address
         shouldSee("vitalik.eth");
+
         renameWalletTo("Vitalik");
         gotoWalletPage();
         shouldSee("Vitalik");
+
         renameWalletTo("");
         gotoWalletPage();
         shouldSee("vitalik.eth");
@@ -60,7 +62,8 @@ public class WalletNameTest extends BaseE2ETest
         Helper.wait(2);
     }
 
-    private void shouldSeeFormattedAddress(String address) {
+    private void shouldSeeFormattedAddress(String address)
+    {
         shouldSee(address.substring(0, 6) + "..." + address.substring(address.length() - 4)); // 0xabcd...wxyz
     }
 }

--- a/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/WalletNameTest.java
@@ -11,6 +11,7 @@ import static com.alphawallet.app.steps.Steps.createNewWallet;
 import static com.alphawallet.app.steps.Steps.getWalletAddress;
 import static com.alphawallet.app.steps.Steps.gotoWalletPage;
 import static com.alphawallet.app.steps.Steps.input;
+import static com.alphawallet.app.steps.Steps.watchWalletWithENS;
 import static com.alphawallet.app.util.Helper.click;
 
 import com.alphawallet.app.util.Helper;
@@ -52,6 +53,8 @@ public class WalletNameTest extends BaseE2ETest
     @Test
     public void should_show_ENS_name_instead_of_address()
     {
+        watchWalletWithENS("vitalik.eth");
+        shouldSee("vitalik.eth");
     }
 
     @Test

--- a/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
+++ b/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
@@ -256,7 +256,7 @@ public class Steps
         pressBack();
     }
 
-    private static void input(int id, String text)
+    public static void input(int id, String text)
     {
         onView(allOf(withId(R.id.edit_text), isDescendantOfA(withId(id)))).perform(replaceText(text));
     }


### PR DESCRIPTION
- Show formatted address by default
- Show custom name instead of address
- Show ENS name instead of address
- Should show custom name instead of ENS name
