### PR TITLE
Ensure Added Tokens are correctly marked as visible

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -31,6 +31,7 @@ import com.alphawallet.app.ui.widget.entity.TokenTransferData;
 import com.alphawallet.app.util.BalanceUtils;
 import com.alphawallet.app.util.Utils;
 import com.alphawallet.app.viewmodel.BaseViewModel;
+import com.alphawallet.token.entity.ContractAddress;
 import com.alphawallet.token.entity.TicketRange;
 import com.alphawallet.token.entity.TokenScriptResult;
 
@@ -171,6 +172,11 @@ public class Token
         {
             realmToken.setBalance("0");
         }
+    }
+
+    public ContractAddress getContractAddress()
+    {
+        return new ContractAddress(tokenInfo.chainId, tokenInfo.address);
     }
 
     //Used for custom balance updates

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/TokenCardMeta.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/TokenCardMeta.java
@@ -17,6 +17,7 @@ import com.alphawallet.app.repository.EthereumNetworkBase;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.TokensRealmSource;
 import com.alphawallet.app.service.AssetDefinitionService;
+import com.alphawallet.token.entity.ContractAddress;
 
 /**
  * Created by JB on 12/07/2020.
@@ -90,6 +91,11 @@ public class TokenCardMeta implements Comparable<TokenCardMeta>, Parcelable
     public long getNameWeight()
     {
         return nameWeight;
+    }
+
+    public ContractAddress getContractAddress()
+    {
+        return new ContractAddress(getChain(), getAddress());
     }
 
     public static long groupWeight(TokenGroup group)

--- a/app/src/main/java/com/alphawallet/app/interact/ChangeTokenEnableInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/ChangeTokenEnableInteract.java
@@ -1,23 +1,24 @@
 package com.alphawallet.app.interact;
 
-import com.alphawallet.app.repository.TokenRepositoryType;
-import com.alphawallet.app.entity.tokens.Token;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.repository.TokenRepositoryType;
+import com.alphawallet.token.entity.ContractAddress;
 
 import io.reactivex.Completable;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
 
-public class ChangeTokenEnableInteract {
+public class ChangeTokenEnableInteract
+{
     private final TokenRepositoryType tokenRepository;
 
-    public ChangeTokenEnableInteract(TokenRepositoryType tokenRepository) {
+    public ChangeTokenEnableInteract(TokenRepositoryType tokenRepository)
+    {
         this.tokenRepository = tokenRepository;
     }
 
-    public Completable setEnable(Wallet wallet, Token token, boolean enabled) {
-        tokenRepository.setEnable(wallet, token, enabled);
-        tokenRepository.setVisibilityChanged(wallet, token);
-        return Completable.fromAction(() -> { });
+    public Completable setEnable(Wallet wallet, ContractAddress cAddr, boolean enabled)
+    {
+        tokenRepository.setEnable(wallet, cAddr, enabled);
+        tokenRepository.setVisibilityChanged(wallet, cAddr);
+        return Completable.fromAction(() -> {});
     }
 }

--- a/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenLocalSource.java
@@ -30,7 +30,7 @@ public interface TokenLocalSource
 
     Token fetchToken(long chainId, Wallet wallet, String address);
 
-    void setEnable(Wallet wallet, Token token, boolean isEnabled);
+    void setEnable(Wallet wallet, ContractAddress cAddr, boolean isEnabled);
 
     String getTokenImageUrl(long chainId, String address);
 
@@ -68,9 +68,7 @@ public interface TokenLocalSource
 
     TokenTicker getCurrentTicker(String key);
 
-    void setVisibilityChanged(Wallet wallet, Token token);
-
-    boolean hasVisibilityBeenChanged(Token token);
+    void setVisibilityChanged(Wallet wallet, ContractAddress cAddr);
 
     boolean getEnabled(Token token);
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -361,15 +361,15 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
-    public void setEnable(Wallet wallet, Token token, boolean isEnabled)
+    public void setEnable(Wallet wallet, ContractAddress cAddr, boolean isEnabled)
     {
-        localSource.setEnable(wallet, token, isEnabled);
+        localSource.setEnable(wallet, cAddr, isEnabled);
     }
 
     @Override
-    public void setVisibilityChanged(Wallet wallet, Token token)
+    public void setVisibilityChanged(Wallet wallet, ContractAddress cAddr)
     {
-        localSource.setVisibilityChanged(wallet, token);
+        localSource.setVisibilityChanged(wallet, cAddr);
     }
 
     @Override
@@ -1147,12 +1147,6 @@ public class TokenRepository implements TokenRepositoryType {
     public boolean isEnabled(Token token)
     {
         return localSource.getEnabled(token);
-    }
-
-    @Override
-    public boolean hasVisibilityBeenChanged(Token token)
-    {
-        return localSource.hasVisibilityBeenChanged(token);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepositoryType.java
@@ -33,9 +33,9 @@ public interface TokenRepositoryType
 
     Single<Token> checkInterface(Token tokens, Wallet wallet);
 
-    void setEnable(Wallet wallet, Token token, boolean isEnabled);
+    void setEnable(Wallet wallet, ContractAddress cAddr, boolean isEnabled);
 
-    void setVisibilityChanged(Wallet wallet, Token token);
+    void setVisibilityChanged(Wallet wallet, ContractAddress cAddr);
 
     Single<TokenInfo> update(String address, long chainId, ContractType type);
 
@@ -92,8 +92,6 @@ public interface TokenRepositoryType
     Single<Integer> fixFullNames(Wallet wallet, AssetDefinitionService svs);
 
     boolean isEnabled(Token newToken);
-
-    boolean hasVisibilityBeenChanged(Token token);
 
     Single<Pair<Double, Double>> getTotalValue(String currentAddress, List<Long> networkFilters);
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -237,12 +237,13 @@ public class TokensRealmSource implements TokenLocalSource {
     }
 
     @Override
-    public void setEnable(Wallet wallet, Token token, boolean isEnabled) {
+    public void setEnable(Wallet wallet, ContractAddress cAddr, boolean isEnabled)
+    {
         try (Realm realm = realmManager.getRealmInstance(wallet))
         {
             realm.executeTransactionAsync(r -> {
                 RealmToken realmToken = r.where(RealmToken.class)
-                        .equalTo("address", databaseKey(token))
+                        .equalTo("address", cAddr.getAddressKey())
                         .findFirst();
 
                 if (realmToken != null)
@@ -384,34 +385,14 @@ public class TokensRealmSource implements TokenLocalSource {
             deleteAssets(realm, token, deleteList);
         }
     }
-
     @Override
-    public boolean hasVisibilityBeenChanged(Token token)
-    {
-        boolean hasBeenChanged = false;
-        try (Realm realm = realmManager.getRealmInstance(new Wallet(token.getWallet().toLowerCase())))
-        {
-            RealmToken realmToken = realm.where(RealmToken.class)
-                    .equalTo("address", databaseKey(token))
-                    .findFirst();
-
-            if (realmToken != null)
-            {
-                hasBeenChanged = realmToken.isVisibilityChanged();
-            }
-        }
-
-        return hasBeenChanged;
-    }
-
-    @Override
-    public void setVisibilityChanged(Wallet wallet, Token token)
+    public void setVisibilityChanged(Wallet wallet, ContractAddress cAddr)
     {
         try (Realm realm = realmManager.getRealmInstance(wallet))
         {
             realm.executeTransactionAsync(r -> {
                 RealmToken realmToken = r.where(RealmToken.class)
-                        .equalTo("address", databaseKey(token))
+                        .equalTo("address", cAddr.getAddressKey())
                         .findFirst();
 
                 if (realmToken != null)
@@ -425,32 +406,26 @@ public class TokensRealmSource implements TokenLocalSource {
             //
         }
     }
-
     public static String databaseKey(long chainId, String address)
     {
         return address.toLowerCase() + "-" + chainId;
     }
-
     public static String databaseKey(Token token)
     {
         return databaseKey(token.tokenInfo.chainId, token.tokenInfo.address.toLowerCase());
     }
-
     public static String eventActivityKey(String txHash, String activityName)
     {
         return txHash + "-" + activityName + EVENT_CARDS;
     }
-
     public static String eventActivityKey(String txHash, String activityName, int extendedId)
     {
         return txHash + "-" + activityName + EVENT_CARDS + "-" + extendedId;
     }
-
     public static String eventBlockKey(long chainId, String eventAddress, String namedType, String filter)
     {
         return eventAddress.toLowerCase() + "-" + chainId + "-" + namedType + "-" + filter + "-eventBlock";
     }
-
     @Override
     public boolean updateTokenBalance(Wallet wallet, Token token, BigDecimal balance, List<BigInteger> balanceArray)
     {

--- a/app/src/main/java/com/alphawallet/app/service/TokensService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TokensService.java
@@ -998,19 +998,19 @@ public class TokensService
         //ensure locked tokens are displaying
         Observable.fromIterable(CustomViewSettings.getLockedTokens())
                 .forEach(info -> addToken(info, wallet)
-                        .flatMapCompletable(token -> enableToken(wallet, token))
+                        .flatMapCompletable(token -> enableToken(wallet, token.getContractAddress()))
                         .subscribeOn(Schedulers.io())
                         .observeOn(Schedulers.io())
                         .subscribe())
                         .isDisposed();
     }
 
-    private Completable enableToken(String walletAddr, Token token)
+    public Completable enableToken(String walletAddr, ContractAddress cAddr)
     {
         return Completable.fromAction(() -> {
             final Wallet wallet = new Wallet(walletAddr);
-            tokenRepository.setEnable(wallet, token, true);
-            tokenRepository.setVisibilityChanged(wallet, token);
+            tokenRepository.setEnable(wallet, cAddr, true);
+            tokenRepository.setVisibilityChanged(wallet, cAddr);
         });
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AddTokenActivity.java
@@ -353,6 +353,8 @@ public class AddTokenActivity extends BaseActivity implements AddressReadyCallba
             }
         }
 
+        viewModel.markTokensEnabled(selected);
+
         if (mainNetActive && onlyTestNet) // only testnet tokens selected and we're not showing testnet
         {
             //Will need to make these chains active on the callback

--- a/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/AddTokenViewModel.java
@@ -15,6 +15,7 @@ import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.QRResult;
 import com.alphawallet.app.entity.Wallet;
 import com.alphawallet.app.entity.tokens.Token;
+import com.alphawallet.app.entity.tokens.TokenCardMeta;
 import com.alphawallet.app.entity.tokens.TokenInfo;
 import com.alphawallet.app.interact.FetchTransactionsInteract;
 import com.alphawallet.app.interact.GenericWalletInteract;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
+import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
@@ -360,5 +362,21 @@ public class AddTokenViewModel extends BaseViewModel
         ethereumNetworkRepository.setFilterNetworkList(uniqueList.toArray(new Long[0]));
         ethereumNetworkRepository.commitPrefs();
         tokensService.setupFilter(true);
+    }
+
+    /**
+     * Set all selected tokens enabled and visible.
+     * Note that we need to update the 'visibility changed' setting to mark the token as having explicitly been set visible.
+     * @param selected list of selected TCMs
+     */
+    public void markTokensEnabled(List<TokenCardMeta> selected)
+    {
+        if (wallet.getValue() == null) return;
+        Observable.fromIterable(selected)
+                .forEach(tcm -> tokensService.enableToken(wallet.getValue().address, tcm.getContractAddress())
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(Schedulers.io())
+                        .subscribe())
+                .isDisposed();
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/TokenManagementViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/TokenManagementViewModel.java
@@ -59,7 +59,7 @@ public class TokenManagementViewModel extends BaseViewModel {
     }
 
     public void setTokenEnabled(Wallet wallet, Token token, boolean enabled) {
-        changeTokenEnableInteract.setEnable(wallet, token, enabled);
+        changeTokenEnableInteract.setEnable(wallet, token.getContractAddress(), enabled);
     }
 
     public AssetDefinitionService getAssetDefinitionService()

--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletViewModel.java
@@ -248,7 +248,7 @@ public class WalletViewModel extends BaseViewModel
 
     public void setTokenEnabled(Token token, boolean enabled)
     {
-        changeTokenEnableInteract.setEnable(defaultWallet.getValue(), token, enabled);
+        changeTokenEnableInteract.setEnable(defaultWallet.getValue(), token.getContractAddress(), enabled);
         token.tokenInfo.isEnabled = enabled;
     }
 


### PR DESCRIPTION
Fixes #3045 

The app has two settings for token visibility:

```enabled``` and ```visibilityChanged```. 
```enabled``` means the app is watching the token but can hide it if it's zero balance. 
```visibilityChanged``` means the user explicitly locked to token as either ```enabled``` = true or ```enabled``` = false.

In this case, the ```visibilityChanged``` and ```enabled``` settings weren't getting updated; it worked correctly for non-zero balances because scanning for the token makes the app aware of that token and it subsequently checks the balance.

TODO: refactor this to use a single enum with:

```
token_disabled,  //never show, don't check token balance
show_token_if_non_zero, //check token balance and show if it becomes positive
always_show_token //show regardless (only if user changes visibility settings)
```
