### PR TITLE
fix: WalletConnect v2 transaction request with null payload.

### DIFF
--- a/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -135,7 +136,9 @@ public class TransactionDialogBuilder extends DialogFragment
         actionSheetDialog.setCanceledOnTouchOutside(false);
         actionSheetDialog.waitForEstimate();
 
-        viewModel.calculateGasEstimate(fromWallet, Numeric.hexStringToByteArray(w3Tx.payload),
+        byte[] payload = w3Tx.payload != null ? Numeric.hexStringToByteArray(w3Tx.payload) : null;
+
+        viewModel.calculateGasEstimate(fromWallet, payload,
                         WalletConnectHelper.getChainId(Objects.requireNonNull(sessionRequest.getChainId())), w3Tx.recipient.toString(), new BigDecimal(w3Tx.value), w3Tx.gasLimit)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
This fixes an error seen when using WalletConnect v2. V2 seems to send a null payload instead of an empty string.

This caused Alphawallet to crash when invoking: `Numeric.hexStringToByteArray(w3Tx.payload)`