### PR TITLE
Pick up ERC1155 from transfer APIs

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanEvent.java
@@ -1,11 +1,14 @@
 package com.alphawallet.app.entity;
 
+import android.text.TextUtils;
+
 import com.alphawallet.app.repository.TokenRepository;
 import com.alphawallet.token.tools.Numeric;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
+import java.util.List;
 
 /**
  * Created by JB on 21/10/2020.
@@ -24,9 +27,12 @@ public class EtherscanEvent
     public String tokenID;
     public String value;
     public String tokenName;
+    public String tokenValue;
     public String tokenSymbol;
     public String tokenDecimal;
     public String input;
+    public String[] tokenIDs;
+    public String[] values;
     String gas;
     String gasPrice;
     String gasUsed;
@@ -61,5 +67,27 @@ public class EtherscanEvent
 
         return new Transaction(hash, "0", blockNumber, timeStamp, nonce, from, contractAddress, "0", gas, gasPrice, input,
                 gasUsed, networkInfo.chainId, false);
+    }
+
+    public boolean isERC1155(List<EtherscanEvent> contractEventList)
+    {
+        for (EtherscanEvent ev : contractEventList)
+        {
+            if (!TextUtils.isEmpty(ev.tokenValue) || (ev.tokenIDs != null && ev.tokenIDs.length > 0))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    //This is a hack to avoid the transfer event being blank
+    public void patchFirstTokenID()
+    {
+        if (tokenID == null && tokenIDs != null && tokenIDs.length > 0)
+        {
+            tokenID = tokenIDs[0];
+        }
     }
 }

--- a/app/src/main/java/com/alphawallet/app/entity/EventSync.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EventSync.java
@@ -174,7 +174,7 @@ public class EventSync
 
     public boolean handleEthLogError(Response.Error error, DefaultBlockParameter startBlock, DefaultBlockParameter endBlock, SyncDef sync, Realm realm)
     {
-        if (error.getCode() == -32005 || error.getCode() == -32600)
+        if (error.getMessage().contains("block range")) //trigger on block range error
         {
             long newStartBlock;
             long newEndBlock;

--- a/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
+++ b/app/src/main/java/com/alphawallet/app/entity/NetworkInfo.java
@@ -1,15 +1,19 @@
 package com.alphawallet.app.entity;
 
+import static com.alphawallet.app.repository.EthereumNetworkBase.COVALENT;
+
 import android.net.Uri;
+import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 
-import static com.alphawallet.app.repository.EthereumNetworkBase.COVALENT;
-
+import com.alphawallet.app.entity.transactionAPI.TransferFetchType;
 import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.util.Utils;
 
-public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
+public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo
+{
+    private final String ETHERSCAN_API = ".etherscan.";
     private final String BLOCKSCOUT_API = "blockscout";
     private final String MATIC_API = "polygonscan";
     private final String PALM_API = "explorer.palm";
@@ -52,10 +56,20 @@ public class NetworkInfo extends com.alphawallet.ethereum.NetworkInfo {
         else return this.name;
     }
 
-    public boolean usesSeparateNFTTransferQuery()
+    public TransferFetchType[] getTransferQueriesUsed()
     {
-        return (etherscanAPI != null && !etherscanAPI.contains(BLOCKSCOUT_API)
-                && !etherscanAPI.contains(COVALENT) && !etherscanAPI.contains(PALM_API));
+        if (etherscanAPI.contains(COVALENT) || TextUtils.isEmpty(etherscanAPI))
+        {
+            return new TransferFetchType[0];
+        }
+        else if (etherscanAPI.contains(MATIC_API) || etherscanAPI.contains(ETHERSCAN_API))
+        {
+            return new TransferFetchType[]{ TransferFetchType.tokentx, TransferFetchType.tokennfttx, TransferFetchType.token1155tx };
+        }
+        else
+        {
+            return new TransferFetchType[]{ TransferFetchType.tokentx }; // assume it only supports tokenTx, eg Blockscout, Palm
+        }
     }
 
     @Nullable

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/ERC1155Token.java
@@ -87,6 +87,20 @@ public class ERC1155Token extends Token
     }
 
     @Override
+    public boolean hasPositiveBalance()
+    {
+        for (NFTAsset asset : assets.values())
+        {
+            if (asset.getBalance().compareTo(BigDecimal.ZERO) > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
     public NFTAsset getAssetForToken(BigInteger tokenId)
     {
         return assets.get(tokenId);
@@ -155,7 +169,13 @@ public class ERC1155Token extends Token
     @Override
     public BigDecimal getBalanceRaw()
     {
-        return new BigDecimal(assets.size());
+        BigDecimal balance = BigDecimal.ZERO;
+        for (NFTAsset asset : assets.values())
+        {
+            balance = balance.add(asset.getBalance());
+        }
+
+        return balance;
     }
 
     @Override
@@ -683,7 +703,7 @@ public class ERC1155Token extends Token
             Timber.e(e);
         }
 
-        return new BigDecimal(assets.keySet().size());
+        return getBalanceRaw(); //new BigDecimal(assets.keySet().size());
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/entity/transactionAPI/TransferFetchType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/transactionAPI/TransferFetchType.java
@@ -1,0 +1,11 @@
+package com.alphawallet.app.entity.transactionAPI;
+
+/**
+ * Created by JB on 10/02/2023.
+ */
+public enum TransferFetchType
+{
+    tokentx,
+    tokennfttx,
+    token1155tx
+}

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -89,7 +89,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import io.reactivex.Single;

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -334,10 +334,14 @@ public class TokenRepository implements TokenRepositoryType {
     }
 
     @Override
-    public void updateAssets(String wallet, Token erc721Token, List<BigInteger> additions, List<BigInteger> removals)
+    public void updateAssets(String wallet, Token nftToken, List<BigInteger> additions, List<BigInteger> removals)
     {
-        erc721Token.balance = checkUint256Balance(new Wallet(wallet), erc721Token.tokenInfo.chainId, erc721Token.getAddress());
-        localSource.updateNFTAssets(wallet, erc721Token,
+        if (nftToken.isERC721())
+        {
+            nftToken.balance = checkUint256Balance(new Wallet(wallet), nftToken.tokenInfo.chainId, nftToken.getAddress());
+        }
+
+        localSource.updateNFTAssets(wallet, nftToken,
                 additions, removals);
     }
 

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -1322,6 +1322,11 @@ public class TokenRepository implements TokenRepositoryType {
                     DefaultBlockParameterName.LATEST).send();
 
             String value = ethCall.getValue();
+            if (value.equals("0x"))
+            {
+                return new ArrayList<>();
+            }
+
             List<Type> values = FunctionReturnDecoder.decode(value, function.getOutputParameters());
             Object o;
             if (values.isEmpty())

--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -322,14 +322,12 @@ public class TokensRealmSource implements TokenLocalSource {
 
     private void setTokenUpdateTime(RealmToken realmToken, Token token)
     {
-        long tokenBalance = token.balance.longValue();
-
         realmToken.setLastTxTime(System.currentTimeMillis());
         realmToken.setAssetUpdateTime(System.currentTimeMillis());
 
-        if (realmToken.getBalance() == null || !realmToken.getBalance().equals(String.valueOf(tokenBalance)))
+        if (realmToken.getBalance() == null || !realmToken.getBalance().equals(token.getBalanceRaw().toString()))
         {
-            realmToken.setBalance(String.valueOf(tokenBalance));
+            token.setRealmBalance(realmToken);
         }
     }
 
@@ -377,6 +375,7 @@ public class TokensRealmSource implements TokenLocalSource {
 
         //switch visibility if required
         checkTokenVisibility(realmToken, token, balanceCount);
+        token.setRealmBalance(realmToken);
     }
 
     private void checkTokenVisibility(RealmToken realmToken, Token token, BigDecimal balanceCount)
@@ -391,8 +390,6 @@ public class TokensRealmSource implements TokenLocalSource {
             token.tokenInfo.isEnabled = false;
             realmToken.setEnabled(false);
         }
-
-        realmToken.setBalance(balanceCount.toString());
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
@@ -6,9 +6,6 @@ import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.tokens.TokenInfo;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransfer.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmTransfer.java
@@ -1,28 +1,6 @@
 package com.alphawallet.app.repository.entity;
 
-import android.content.Context;
-import android.text.TextUtils;
-
-import com.alphawallet.app.R;
-import com.alphawallet.app.entity.Transaction;
-import com.alphawallet.app.entity.tokens.Token;
-import com.alphawallet.app.repository.EventResult;
-import com.alphawallet.app.ui.widget.entity.ENSHandler;
-import com.alphawallet.app.ui.widget.entity.StatusType;
-
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import io.realm.Realm;
 import io.realm.RealmObject;
-import io.realm.RealmQuery;
-import io.realm.RealmResults;
-import io.realm.Sort;
-
-import static com.alphawallet.app.repository.TokensRealmSource.EVENT_CARDS;
 
 /**
  * Created by JB on 17/12/2020.

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClient.java
@@ -69,7 +69,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     //Note: if user wants to view transactions older than this, we fetch from etherscan on demand.
     //Generally this would only happen when watching extremely active accounts for curiosity
     private final String BLOCK_ENTRY = "-erc20blockCheck-";
-    private final int AUX_DATABASE_ID = 22; //increment this to do a one off refresh the AUX database, in case of changed design etc
+    private final int AUX_DATABASE_ID = 30; //increment this to do a one off refresh the AUX database, in case of changed design etc
     private final String DB_RESET = BLOCK_ENTRY + AUX_DATABASE_ID;
     private final String ETHERSCAN_API_KEY;
     private final String BSC_EXPLORER_API_KEY;
@@ -1160,7 +1160,7 @@ public class TransactionsNetworkClient implements TransactionsNetworkClientType
     private ERC1155Token createNewERC1155Token(EtherscanEvent ev, NetworkInfo networkInfo, String walletAddress)
     {
         TokenInfo info = new TokenInfo(ev.contractAddress, ev.tokenName, ev.tokenSymbol, 0, false, networkInfo.chainId);
-        ERC1155Token newToken = new ERC1155Token(info, null,0, networkInfo.getShortName());
+        ERC1155Token newToken = new ERC1155Token(info, null, 0, networkInfo.getShortName());
         newToken.setTokenWallet(walletAddress);
         return newToken;
     }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
@@ -3,12 +3,13 @@ package com.alphawallet.app.service;
 import com.alphawallet.app.entity.NetworkInfo;
 import com.alphawallet.app.entity.Transaction;
 import com.alphawallet.app.entity.TransactionMeta;
+import com.alphawallet.app.entity.transactionAPI.TransferFetchType;
 
 import io.reactivex.Single;
 
 public interface TransactionsNetworkClientType {
     Single<Transaction[]> storeNewTransactions(TokensService svs, NetworkInfo networkInfo, String tokenAddress, long lastBlock);
     Single<TransactionMeta[]> fetchMoreTransactions(TokensService svs, NetworkInfo network, long lastTxTime);
-    Single<Integer> readTransfers(String currentAddress, NetworkInfo networkByChain, TokensService tokensService, boolean nftCheck);
+    Single<Integer> readTransfers(String currentAddress, NetworkInfo networkByChain, TokensService tokensService, TransferFetchType tfType);
     void checkRequiresAuxReset(String walletAddr);
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsNetworkClientType.java
@@ -7,9 +7,13 @@ import com.alphawallet.app.entity.transactionAPI.TransferFetchType;
 
 import io.reactivex.Single;
 
-public interface TransactionsNetworkClientType {
+public interface TransactionsNetworkClientType
+{
     Single<Transaction[]> storeNewTransactions(TokensService svs, NetworkInfo networkInfo, String tokenAddress, long lastBlock);
+
     Single<TransactionMeta[]> fetchMoreTransactions(TokensService svs, NetworkInfo network, long lastTxTime);
+
     Single<Integer> readTransfers(String currentAddress, NetworkInfo networkByChain, TokensService tokensService, TransferFetchType tfType);
+
     void checkRequiresAuxReset(String walletAddr);
 }

--- a/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NFTAssetDetailActivity.java
@@ -333,6 +333,21 @@ public class NFTAssetDetailActivity extends BaseActivity implements StandardFunc
         tivNetwork.setValue(token.getNetworkName());
 
         tivContractAddress.setCopyableValue(token.tokenInfo.address);
+
+        switch (token.getInterfaceSpec())
+        {
+            case ERC721_LEGACY:
+            case ERC721:
+            case ERC721_ENUMERABLE:
+                tivTokenStandard.setValue(getString(R.string.erc721));
+                break;
+            case ERC1155:
+                tivTokenStandard.setValue(getString(R.string.erc1155));
+                break;
+            case ERC721_UNDETERMINED:
+            default:
+                break;
+        }
     }
 
     private void loadAssetFromMetadata(NFTAsset asset)

--- a/app/src/main/java/com/alphawallet/app/ui/NetworkToggleActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/NetworkToggleActivity.java
@@ -146,8 +146,7 @@ public class NetworkToggleActivity extends NetworkBaseActivity
             filterList.addAll(Arrays.asList(testNetAdapter.getSelectedItems()));
         }
         boolean hasClicked = mainNetAdapter.hasSelectedItems() || testNetAdapter.hasSelectedItems();
-        boolean shouldBlankUserSelection = (mainNetAdapter.getSelectedItems().length == 0)
-                || (testnetSwitch.isChecked() && testNetAdapter.getSelectedItems().length == 0);
+        boolean shouldBlankUserSelection = filterList.size() == 0; //This is only set when we want to automatically discover all tokens. If user sets all networks blank it auto-fills them
 
         viewModel.setFilterNetworks(filterList, hasClicked, shouldBlankUserSelection);
         setResult(RESULT_OK, new Intent());

--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -358,7 +358,6 @@ public class Web3TokenView extends WebView
         public void onPageFinished(WebView view, String url)
         {
             super.onPageFinished(view, url);
-            unencodedPage = null;
             if (assetHolder != null)
                 assetHolder.onPageRendered(view);
         }
@@ -367,6 +366,7 @@ public class Web3TokenView extends WebView
         public void onPageCommitVisible(WebView view, String url)
         {
             super.onPageCommitVisible(view, url);
+            unencodedPage = null;
             if (assetHolder != null)
                 assetHolder.onPageLoaded(view);
         }

--- a/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/NFTImageView.java
@@ -1,5 +1,6 @@
 package com.alphawallet.app.widget;
 
+import static com.alphawallet.app.util.Utils.isIPFS;
 import static com.alphawallet.app.util.Utils.loadFile;
 import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
 
@@ -139,7 +140,7 @@ public class NFTImageView extends RelativeLayout
         String anim = asset.getAnimation();
         fallbackIcon.setupFallbackTextIcon(asset.getName());
 
-        if (anim != null && !isGlb(anim) && !isAudio(anim))
+        if (anim != null && !isGlb(anim) && !isAudio(anim) && !isIPFS(anim)) //IPFS anims don't seem to render correctly
         {
             if (!shouldLoad(anim)) return;
             //attempt to load animation


### PR DESCRIPTION
Refactor the way ERC1155 tokens are picked up. This also required a little re-work of some other areas to ensure it works correctly.

Etherscan and other TX APIs added a new ```token1155tx``` action so the simple boolean NFt toggle needed to be removed and handled a different way.

Fixes #3062 