### PR TITLE
Fix the sign transaction mechanism for browser and WalletConnect

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/TransactionReturn.java
+++ b/app/src/main/java/com/alphawallet/app/entity/TransactionReturn.java
@@ -25,4 +25,9 @@ public class TransactionReturn
         this.tx = tx;
         this.throwable = throwable;
     }
+
+    public String getDisplayData()
+    {
+        return hash != null ? hash.substring(0, 66) : "";
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -1899,7 +1899,7 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
 
     private void txSigned(TransactionReturn txData)
     {
-        confirmationDialog.transactionWritten(txData.hash.substring(0, 66));
+        confirmationDialog.transactionWritten(txData.getDisplayData());
         web3.onSignTransactionSuccessful(txData);
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
+++ b/app/src/main/java/com/alphawallet/app/ui/DappBrowserFragment.java
@@ -676,6 +676,7 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
         viewModel.activeNetwork().observe(getViewLifecycleOwner(), this::onNetworkChanged);
         viewModel.defaultWallet().observe(getViewLifecycleOwner(), this::onDefaultWallet);
         viewModel.transactionFinalised().observe(getViewLifecycleOwner(), this::txWritten);
+        viewModel.transactionSigned().observe(getViewLifecycleOwner(), this::txSigned);
         viewModel.transactionError().observe(getViewLifecycleOwner(), this::txError);
         activeNetwork = viewModel.getActiveNetwork();
         viewModel.findWallet();
@@ -1525,19 +1526,14 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
                                 copyToClipboard(result.getAddress());
                                 break;
                             case PAYMENT:
+                            case TRANSFER:
                                 props.put(QrScanResultType.KEY, QrScanResultType.ADDRESS_OR_EIP_681.getValue());
                                 viewModel.track(Analytics.Action.SCAN_QR_CODE_SUCCESS, props);
 
                                 //EIP681 payment request scanned, should go to send
                                 viewModel.showSend(getContext(), result);
                                 break;
-                            case TRANSFER:
-                                props.put(QrScanResultType.KEY, QrScanResultType.ADDRESS_OR_EIP_681.getValue());
-                                viewModel.track(Analytics.Action.SCAN_QR_CODE_SUCCESS, props);
 
-                                //EIP681 transfer, go to send
-                                viewModel.showSend(getContext(), result);
-                                break;
                             case FUNCTION_CALL:
                                 props.put(QrScanResultType.KEY, QrScanResultType.ADDRESS_OR_EIP_681.getValue());
                                 viewModel.track(Analytics.Action.SCAN_QR_CODE_SUCCESS, props);
@@ -1878,6 +1874,18 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
     }
 
     @Override
+    public void signTransaction(Web3Transaction tx)
+    {
+        viewModel.requestSignatureOnly(tx, wallet, activeNetwork.chainId);
+    }
+
+    @Override
+    public void completeSignTransaction(Web3Transaction w3Tx, SignatureFromKey signature)
+    {
+        viewModel.signTransaction(activeNetwork.chainId, w3Tx, signature);
+    }
+
+    @Override
     public void pinAuthorisation(boolean gotAuth)
     {
         confirmationDialog.gotAuthorisation(gotAuth);
@@ -1886,6 +1894,12 @@ public class DappBrowserFragment extends BaseFragment implements OnSignTransacti
     private void txWritten(TransactionReturn txData)
     {
         confirmationDialog.transactionWritten(txData.hash);
+        web3.onSignTransactionSuccessful(txData);
+    }
+
+    private void txSigned(TransactionReturn txData)
+    {
+        confirmationDialog.transactionWritten(txData.hash.substring(0, 66));
         web3.onSignTransactionSuccessful(txData);
     }
 

--- a/app/src/main/java/com/alphawallet/app/ui/widget/entity/ActionSheetCallback.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/entity/ActionSheetCallback.java
@@ -23,6 +23,11 @@ public interface ActionSheetCallback
     //For Hardware wallet
     void completeSendTransaction(Web3Transaction tx, SignatureFromKey signature); //return from hardware signing
 
+    default void completeSignTransaction(Web3Transaction tx, SignatureFromKey signature) //return from hardware signing - sign tx only
+    {
+
+    }
+
     void dismissed(String txHash, long callbackId, boolean actionCompleted);
 
     void notifyConfirm(String mode);

--- a/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/DappBrowserViewModel.java
@@ -74,6 +74,7 @@ public class DappBrowserViewModel extends BaseViewModel implements TransactionSe
     private final MutableLiveData<Wallet> defaultWallet = new MutableLiveData<>();
     private final MutableLiveData<TransactionReturn> transactionFinalised = new MutableLiveData<>();
     private final MutableLiveData<TransactionReturn> transactionError = new MutableLiveData<>();
+    private final MutableLiveData<TransactionReturn> transactionSigned = new MutableLiveData<>();
     private final GenericWalletInteract genericWalletInteract;
     private final AssetDefinitionService assetDefinitionService;
     private final CreateTransactionInteract createTransactionInteract;
@@ -124,6 +125,11 @@ public class DappBrowserViewModel extends BaseViewModel implements TransactionSe
     public MutableLiveData<TransactionReturn> transactionFinalised()
     {
         return transactionFinalised;
+    }
+
+    public MutableLiveData<TransactionReturn> transactionSigned()
+    {
+        return transactionSigned;
     }
 
     public MutableLiveData<TransactionReturn> transactionError()
@@ -283,9 +289,19 @@ public class DappBrowserViewModel extends BaseViewModel implements TransactionSe
         createTransactionInteract.requestSignature(finalTx, wallet, chainId, this);
     }
 
+    public void requestSignatureOnly(Web3Transaction finalTx, Wallet wallet, long chainId)
+    {
+        createTransactionInteract.requestSignTransaction(finalTx, wallet, chainId, this);
+    }
+
     public void sendTransaction(Wallet wallet, long chainId, Web3Transaction w3Tx, SignatureFromKey signatureFromKey)
     {
         createTransactionInteract.sendTransaction(wallet, chainId, w3Tx, signatureFromKey);
+    }
+
+    public void signTransaction(long chainId, Web3Transaction tx, SignatureFromKey signatureFromKey)
+    {
+        createTransactionInteract.signTransaction(chainId, tx, signatureFromKey);
     }
 
     @Override
@@ -298,6 +314,12 @@ public class DappBrowserViewModel extends BaseViewModel implements TransactionSe
     public void transactionError(TransactionReturn rtn)
     {
         transactionError.postValue(rtn);
+    }
+
+    @Override
+    public void transactionSigned(SignatureFromKey sigData, Web3Transaction w3Tx)
+    {
+        transactionSigned.postValue(new TransactionReturn(com.alphawallet.token.tools.Numeric.toHexString(sigData.signature), w3Tx));
     }
 
     public void showMyAddress(Context ctx)

--- a/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
@@ -188,7 +188,7 @@ public class TransactionDialogBuilder extends DialogFragment
         if (txData != null)
         {
             approve(txData.hash, awWalletConnectClient);
-            actionSheetDialog.transactionWritten(txData.hash.substring(0, 66));
+            actionSheetDialog.transactionWritten(txData.getDisplayData());
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
@@ -50,19 +50,19 @@ public class TransactionDialogBuilder extends DialogFragment
     private final com.walletconnect.web3.wallet.client.Wallet.Model.SessionRequest sessionRequest;
     private final com.walletconnect.web3.wallet.client.Wallet.Model.Session settledSession;
     private final AWWalletConnectClient awWalletConnectClient;
-    private final boolean signOnly;
+    private final SignType signType;
     private WalletConnectViewModel viewModel;
     private ActionSheetDialog actionSheetDialog;
     private final ActivityResultLauncher<Intent> activityResultLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
             result -> actionSheetDialog.setCurrentGasIndex(result));
 
-    public TransactionDialogBuilder(Activity activity, com.walletconnect.web3.wallet.client.Wallet.Model.SessionRequest sessionRequest, com.walletconnect.web3.wallet.client.Wallet.Model.Session settledSession, AWWalletConnectClient awWalletConnectClient, boolean signOnly)
+    public TransactionDialogBuilder(Activity activity, com.walletconnect.web3.wallet.client.Wallet.Model.SessionRequest sessionRequest, com.walletconnect.web3.wallet.client.Wallet.Model.Session settledSession, AWWalletConnectClient awWalletConnectClient, SignType signType)
     {
         this.activity = activity;
         this.sessionRequest = sessionRequest;
         this.settledSession = settledSession;
         this.awWalletConnectClient = awWalletConnectClient;
-        this.signOnly = signOnly;
+        this.signType = signType;
 
         initViewModel();
     }
@@ -71,6 +71,7 @@ public class TransactionDialogBuilder extends DialogFragment
     {
         viewModel = new ViewModelProvider((ViewModelStoreOwner) activity)
                 .get(WalletConnectViewModel.class);
+        viewModel.resetTxSignedMutable();
         viewModel.transactionFinalised().observe(this, this::txWritten);
         viewModel.transactionSigned().observe(this, this::txSigned);
         viewModel.transactionError().observe(this, this::txError);
@@ -85,7 +86,7 @@ public class TransactionDialogBuilder extends DialogFragment
         }.getType();
         List<WCEthereumTransaction> list = new Gson().fromJson(sessionRequest.getRequest().getParams(), listType);
         WCEthereumTransaction wcTx = list.get(0);
-        final Web3Transaction w3Tx = new Web3Transaction(wcTx, wcTx.hashCode(), signOnly ? SignType.SIGN_TX : SignType.SEND_TX);
+        final Web3Transaction w3Tx = new Web3Transaction(wcTx, wcTx.hashCode(), signType);
         final Wallet fromWallet = viewModel.findWallet(wcTx.getFrom());
         final Token token = viewModel.getTokensService().getTokenOrBase(WalletConnectHelper.getChainId(Objects.requireNonNull(sessionRequest.getChainId())), w3Tx.recipient.toString());
         actionSheetDialog = new ActionSheetDialog(activity, w3Tx, token, "", w3Tx.recipient.toString(), viewModel.getTokensService(), new ActionSheetCallback()
@@ -118,15 +119,13 @@ public class TransactionDialogBuilder extends DialogFragment
             public void completeSendTransaction(Web3Transaction tx, SignatureFromKey signature)
             {
                 //This is the return from the hardware sign
-                //it could be either a send transaction or a sign transaction.
-                if (signOnly)
-                {
-                    txSigned(signature);
-                }
-                else
-                {
-                    viewModel.sendTransaction(fromWallet, token.tokenInfo.chainId, tx, signature);
-                }
+                viewModel.sendTransaction(fromWallet, token.tokenInfo.chainId, tx, signature);
+            }
+
+            @Override
+            public void completeSignTransaction(Web3Transaction tx, SignatureFromKey signature)
+            {
+                viewModel.signTransaction(token.tokenInfo.chainId, tx, signature);
             }
 
             @Override
@@ -156,7 +155,7 @@ public class TransactionDialogBuilder extends DialogFragment
             }
         });
         actionSheetDialog.setSigningWallet(fromWallet.address);
-        if (signOnly)
+        if (signType == SignType.SIGN_TX)
         {
             actionSheetDialog.setSignOnly();
         }
@@ -184,10 +183,13 @@ public class TransactionDialogBuilder extends DialogFragment
         actionSheetDialog.transactionWritten(txData.hash);
     }
 
-    private void txSigned(SignatureFromKey sigData)
+    private void txSigned(TransactionReturn txData)
     {
-        approve(Numeric.toHexString(sigData.signature), awWalletConnectClient);
-        actionSheetDialog.transactionWritten(Numeric.toHexString(sigData.signature).substring(0, 66));
+        if (txData != null)
+        {
+            approve(txData.hash, awWalletConnectClient);
+            actionSheetDialog.transactionWritten(txData.hash.substring(0, 66));
+        }
     }
 
     private void txError(TransactionReturn txError)
@@ -205,20 +207,6 @@ public class TransactionDialogBuilder extends DialogFragment
     private void approve(String hashData, AWWalletConnectClient awWalletConnectClient)
     {
         new Handler(Looper.getMainLooper()).postDelayed(() ->
-                awWalletConnectClient.approve(sessionRequest, hashData), 5000);
-    }
-
-    @Override
-    public void onCancel(@NonNull DialogInterface dialog)
-    {
-        super.onCancel(dialog);
-        awWalletConnectClient.reject(sessionRequest);
-    }
-
-    @Override
-    public void onDismiss(@NonNull DialogInterface dialog)
-    {
-        super.onDismiss(dialog);
-        awWalletConnectClient.reject(sessionRequest);
+                awWalletConnectClient.approve(sessionRequest, hashData), 1000);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/walletconnect/WalletConnectV2SessionRequestHandler.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/WalletConnectV2SessionRequestHandler.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 
+import com.alphawallet.app.entity.walletconnect.SignType;
 import com.alphawallet.app.ui.widget.entity.ActionSheetCallback;
 import com.alphawallet.app.walletconnect.entity.BaseRequest;
 import com.alphawallet.app.walletconnect.entity.EthSignRequest;
@@ -51,7 +52,7 @@ public class WalletConnectV2SessionRequestHandler
         boolean isSendTransaction = "eth_sendTransaction".equals(method);
         if (isSendTransaction || isSignTransaction)
         {
-            TransactionDialogBuilder transactionDialogBuilder = new TransactionDialogBuilder(activity, sessionRequest, settledSession, client, isSignTransaction);
+            TransactionDialogBuilder transactionDialogBuilder = new TransactionDialogBuilder(activity, sessionRequest, settledSession, client, isSignTransaction ? SignType.SIGN_TX : SignType.SEND_TX);
             FragmentManager fragmentManager = ((AppCompatActivity) activity).getSupportFragmentManager();
             transactionDialogBuilder.show(fragmentManager, "wc_call");
             return;

--- a/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
@@ -332,6 +332,7 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
     {
         //sign only, and return signature to process
         mode = ActionSheetMode.SIGN_TRANSACTION;
+        toolbar.setTitle(R.string.dialog_title_sign_transaction);
     }
 
     public void onDestroy()
@@ -351,14 +352,14 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
             addressDetail.setVisibility(View.GONE);
         }
 
-        if (candidateTransaction.value.equals(BigInteger.ZERO))
-        {
-            amountDisplay.setVisibility(View.GONE);
-        }
-        else
+        if (candidateTransaction.value.compareTo(BigInteger.ZERO) > 0 || candidateTransaction.isBaseTransfer())
         {
             amountDisplay.setVisibility(View.VISIBLE);
             amountDisplay.setAmountUsingToken(candidateTransaction.value, tokensService.getServiceToken(token.tokenInfo.chainId), tokensService);
+        }
+        else
+        {
+            amountDisplay.setVisibility(View.GONE);
         }
     }
 
@@ -672,14 +673,26 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
                 {
                     confirmationWidget.startProgressCycle(4);
                 }
-                if (mode == ActionSheetMode.SEND_TRANSACTION)
+
+                switch (mode)
                 {
-                    actionSheetCallback.sendTransaction(formTransaction());
+                    case SEND_TRANSACTION:
+                    case SEND_TRANSACTION_DAPP:
+                    case SEND_TRANSACTION_WC:
+                    case SPEEDUP_TRANSACTION:
+                    case CANCEL_TRANSACTION:
+                        actionSheetCallback.sendTransaction(formTransaction());
+                        break;
+                    case SIGN_TRANSACTION:
+                        actionSheetCallback.signTransaction(formTransaction());
+                        break;
+                    case MESSAGE:
+                    case SIGN_MESSAGE:
+                    case WALLET_CONNECT_REQUEST:
+                    case NODE_STATUS_INFO:
+                        break;
                 }
-                else
-                {
-                    actionSheetCallback.signTransaction(formTransaction());
-                }
+
                 actionSheetCallback.notifyConfirm(mode.getValue());
             }
 
@@ -701,7 +714,14 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
                 {
                     functionBar.setVisibility(View.GONE);
                     confirmationWidget.startProgressCycle(4);
-                    actionSheetCallback.completeSendTransaction(establishedTransaction, signature);
+                    if (mode == ActionSheetMode.SIGN_TRANSACTION)
+                    {
+                        actionSheetCallback.completeSignTransaction(establishedTransaction, signature);
+                    }
+                    else
+                    {
+                        actionSheetCallback.completeSendTransaction(establishedTransaction, signature);
+                    }
                 }
                 else
                 {

--- a/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
@@ -415,7 +415,9 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
         showAmount(getTransactionAmount().toBigInteger());
     }
 
+
     @Override
+    @SuppressWarnings("checkstyle:MissingSwitchDefault")
     public void handleClick(String action, int id)
     {
         if (walletType == WalletType.HARDWARE)
@@ -519,6 +521,7 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
         }
     }
 
+    @SuppressWarnings("checkstyle:MissingSwitchDefault")
     private void showTransactionSuccess()
     {
         switch (mode)
@@ -581,6 +584,7 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
         });
     }
 
+    @SuppressWarnings("checkstyle:MissingSwitchDefault")
     public void completeSignRequest(boolean gotAuth)
     {
         if (signCallback != null)
@@ -599,7 +603,6 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
                     break;
 
                 case SIGN_MESSAGE:
-                    actionCompleted = true;
                     //display success and hand back to calling function
                     confirmationWidget.startProgressCycle(1);
                     signCallback.gotAuthorisation(gotAuth);
@@ -649,6 +652,7 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
     /**
      * Either Send or Sign (WalletConnect only) the transaction
      */
+    @SuppressWarnings("checkstyle:MissingSwitchDefault")
     private void handleTransactionOperation()
     {
         if (walletType != WalletType.HARDWARE)


### PR DESCRIPTION
Fixing an issue with sign transaction across browser & WalletConnect. The sign transaction system needed to return the full transaction RLP code rather than just the signature. This has never worked correctly.

Closes #3094 

TODO: DappBrowser still does not handle 'Sign Transaction only'. *I think* to handle this we will need to add an additional shim in the init.js provider which is identical to the 'processTransaction' hook, only called 'processSignTransaction'. This hooks into the sign transaction code in the AlphaWallet Provider (alphawallet.js). I have added all the methods to handle signing only in DappBrowserFragment and DappBrowserViewModel.