### PR TITLE
Optimise & simplify token display updates

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensRealmSource.java
@@ -323,7 +323,6 @@ public class TokensRealmSource implements TokenLocalSource {
     private void setTokenUpdateTime(RealmToken realmToken, Token token)
     {
         realmToken.setLastTxTime(System.currentTimeMillis());
-        realmToken.setAssetUpdateTime(System.currentTimeMillis());
 
         if (realmToken.getBalance() == null || !realmToken.getBalance().equals(token.getBalanceRaw().toString()))
         {

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmToken.java
@@ -78,20 +78,23 @@ public class RealmToken extends RealmObject {
         this.addedTime = addedTime;
     }
 
-    public long getAssetUpdateTime() {
-        return updatedTime;
-    }
-    public void setAssetUpdateTime(long updatedTime) {
-        this.updatedTime = updatedTime;
-    }
-
     public String getBalance() {
         return balance;
     }
 
-    public void setBalance(String balance) {
+    public void setBalance(String balance)
+    {
+        if (!balance.equals(this.balance))
+        {
+            this.updatedTime = System.currentTimeMillis();
+        }
         this.balance = balance;
         addedTime = System.currentTimeMillis();
+    }
+
+    public long getBalanceUpdateTime()
+    {
+        return this.updatedTime;
     }
 
     public boolean getEnabled() {


### PR DESCRIPTION
This PR works together with the recent fix for the TokenID collision issue.

Now, only tokens that have had their balance changed are updated.

Bonus is that it removes a Realm listener which was being flagged by the profiler. Shame because in theory the Realm listener approach is the most elegant solution.