### PR TITLE
fix: WalletConnect v2 transaction request with null data

### DIFF
--- a/app/src/main/java/com/alphawallet/app/walletconnect/entity/EthereumModels.kt
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/entity/EthereumModels.kt
@@ -28,7 +28,7 @@ data class WCEthereumTransaction(
         val gas: String?,
         val gasLimit: String?,
         val value: String?,
-        val data: String
+        val data: String?
 )
 
 val ethTransactionSerializer = jsonDeserializer<List<WCEthereumTransaction>> {


### PR DESCRIPTION
Make WCEthereumTransaction.data field nullable to prevent NPE when calling hashCode.