### PR TITLE
Hotfix for walletconnect v2 signing update

### DIFF
--- a/app/src/main/java/com/alphawallet/app/viewmodel/WalletConnectViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/WalletConnectViewModel.java
@@ -808,11 +808,6 @@ public class WalletConnectViewModel extends BaseViewModel implements Transaction
         transactionSigned.postValue(new TransactionReturn(Numeric.toHexString(sigData.signature), w3Tx));
     }
 
-    public void resetTxSignedMutable()
-    {
-        transactionSigned.postValue(null);
-    }
-
     public void signTransaction(long chainId, Web3Transaction tx, SignatureFromKey signatureFromKey)
     {
         createTransactionInteract.signTransaction(chainId, tx, signatureFromKey);
@@ -821,5 +816,11 @@ public class WalletConnectViewModel extends BaseViewModel implements Transaction
     public boolean isActiveNetwork(long chainId)
     {
         return ethereumNetworkRepository.getSelectedFilters().contains(chainId);
+    }
+
+    public void blankLiveData()
+    {
+        transactionFinalised.postValue(null);
+        transactionSigned.postValue(null);
     }
 }

--- a/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/TransactionDialogBuilder.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -72,7 +73,7 @@ public class TransactionDialogBuilder extends DialogFragment
     {
         viewModel = new ViewModelProvider((ViewModelStoreOwner) activity)
                 .get(WalletConnectViewModel.class);
-        viewModel.resetTxSignedMutable();
+        viewModel.blankLiveData();
         viewModel.transactionFinalised().observe(this, this::txWritten);
         viewModel.transactionSigned().observe(this, this::txSigned);
         viewModel.transactionError().observe(this, this::txError);
@@ -82,6 +83,7 @@ public class TransactionDialogBuilder extends DialogFragment
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState)
     {
+        viewModel.blankLiveData();
         Type listType = new TypeToken<ArrayList<WCEthereumTransaction>>()
         {
         }.getType();
@@ -181,8 +183,11 @@ public class TransactionDialogBuilder extends DialogFragment
 
     private void txWritten(TransactionReturn txData)
     {
-        approve(txData.hash, awWalletConnectClient);
-        actionSheetDialog.transactionWritten(txData.hash);
+        if (txData != null)
+        {
+            approve(txData.hash, awWalletConnectClient);
+            actionSheetDialog.transactionWritten(txData.hash);
+        }
     }
 
     private void txSigned(TransactionReturn txData)


### PR DESCRIPTION
Hotfix for walletconnect v2 signing:

- allow signing on any chain when chainId is not specified in the message.
- fix for live mutable persistence.