### PR TITLE
[WC v1]  Fixed signTypedData_v4 routing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/walletconnect/AWWalletConnectClient.java
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/AWWalletConnectClient.java
@@ -109,7 +109,7 @@ public class AWWalletConnectClient implements Web3Wallet.WalletDelegate
     public void onSessionRequest(@NonNull Model.SessionRequest sessionRequest)
     {
         String method = sessionRequest.getRequest().getMethod();
-        if ("eth_signTypedData_v4".equals(method))
+        if (method.startsWith("eth_signTypedData"))
         {
             method = "eth_signTypedData";
         }

--- a/app/src/main/java/com/alphawallet/app/walletconnect/WCClient.kt
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/WCClient.kt
@@ -390,9 +390,8 @@ open class WCClient : WebSocketListener() {
             WCMethod.ETH_PERSONAL_SIGN -> {
                 signRequest(request, WCEthereumSignMessage.WCSignType.PERSONAL_MESSAGE)
             }
-            WCMethod.ETH_SIGN_TYPE_DATA -> {
-                signRequest(request, WCEthereumSignMessage.WCSignType.TYPED_MESSAGE)
-            }
+            WCMethod.ETH_SIGN_TYPE_DATA,
+            WCMethod.ETH_SIGN_TYPE_DATA_V3,
             WCMethod.ETH_SIGN_TYPE_DATA_V4 -> {
                 signRequest(request, WCEthereumSignMessage.WCSignType.TYPED_MESSAGE)
             }

--- a/app/src/main/java/com/alphawallet/app/walletconnect/WCClient.kt
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/WCClient.kt
@@ -393,6 +393,9 @@ open class WCClient : WebSocketListener() {
             WCMethod.ETH_SIGN_TYPE_DATA -> {
                 signRequest(request, WCEthereumSignMessage.WCSignType.TYPED_MESSAGE)
             }
+            WCMethod.ETH_SIGN_TYPE_DATA_V4 -> {
+                signRequest(request, WCEthereumSignMessage.WCSignType.TYPED_MESSAGE)
+            }
             WCMethod.ETH_SIGN_TRANSACTION -> {
                 val param = gson.fromJson<List<WCEthereumTransaction>>(request.params)
                     .firstOrNull() ?: throw InvalidJsonRpcParamsException(request.id)

--- a/app/src/main/java/com/alphawallet/app/walletconnect/entity/Enums.kt
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/entity/Enums.kt
@@ -25,6 +25,9 @@ enum class WCMethod {
     @SerializedName("eth_signTypedData")
     ETH_SIGN_TYPE_DATA,
 
+    @SerializedName("eth_signTypedData_v4")
+    ETH_SIGN_TYPE_DATA_V4,
+
     @SerializedName("eth_signTransaction")
     ETH_SIGN_TRANSACTION,
 

--- a/app/src/main/java/com/alphawallet/app/walletconnect/entity/Enums.kt
+++ b/app/src/main/java/com/alphawallet/app/walletconnect/entity/Enums.kt
@@ -25,6 +25,9 @@ enum class WCMethod {
     @SerializedName("eth_signTypedData")
     ETH_SIGN_TYPE_DATA,
 
+    @SerializedName("eth_signTypedData_v3")
+    ETH_SIGN_TYPE_DATA_V3,
+
     @SerializedName("eth_signTypedData_v4")
     ETH_SIGN_TYPE_DATA_V4,
 


### PR DESCRIPTION
- Closes #3139 
- Closes #3087

`eth_signTypedData_v4` messages are not routed properly because of a missing enum, hence the signing dialog does not appear.