### PR TITLE
Fix for ERC-1559 transaction sign issue

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
+++ b/app/src/main/java/com/alphawallet/app/widget/ActionSheetDialog.java
@@ -337,6 +337,7 @@ public class ActionSheetDialog extends ActionSheet implements StandardFunctionIn
         //sign only, and return signature to process
         mode = ActionSheetMode.SIGN_TRANSACTION;
         toolbar.setTitle(R.string.dialog_title_sign_transaction);
+        use1559Transactions = !candidateTransaction.isLegacyTransaction(); // If doing a sign-only transaction (not send) we must respect ERC-1559 or legacy.
     }
 
     public void onDestroy()


### PR DESCRIPTION
Reproduce:

1. Ensure EIP-1559 transactions are switched on (settings/advanced).
2. Open the WC2 test site on desktop:  https://react-app.walletconnect.com/
3. Connect to any chain
4. Click on 'eth_signTransaction'. Sign the transaction.
5. See error message.

This fix respects if the transaction it receives to sign was EIP-1559 or legacy - the signing mechanism is different for each.