### PR TITLE
Add contract mappings for root token binding

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/TokensMappingRepositoryType.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokensMappingRepositoryType.java
@@ -2,8 +2,11 @@ package com.alphawallet.app.repository;
 
 import com.alphawallet.app.entity.ContractType;
 import com.alphawallet.app.entity.tokendata.TokenGroup;
+import com.alphawallet.token.entity.ContractAddress;
 
 public interface TokensMappingRepositoryType
 {
     TokenGroup getTokenGroup(long chainId, String address, ContractType type);
+
+    ContractAddress getBaseToken(long chainId, String address);
 }


### PR DESCRIPTION
Add the binding from derivative tokens to the base token eg:

Contract X -> QuatlooStablecoin on Mainnet
Contract Y -> QuatlooStablecoin on Arbitrum

If you call ```getBaseToken(ARBITRUM_ID, Contract Y)``` it would return Contract X. 

In the ```TokenInfoFragment``` we could display the relationship between QuatlooStablecoins on Arbitrum and Mainnet - that they are the same token with the same value but on different chains.

TODO: Need to check the status of these bindings - previously we didn't add this because we were not 100% sure about these relationships in the tokens.json. This may have changed - ask the maintainer of tokens.json.