### PR TITLE
Mixpanel tracking improvements

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         api-level: [30]
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: zulu
           java-version: 11
-          architecture: arm64
+          architecture: x64
 
       - uses: actions/setup-node@v3
         with:
@@ -33,17 +33,15 @@ jobs:
       - run: npm install ganache --global
 
       - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: arm64-v8a
-          profile: Nexus 6
-          channel: canary
-          disable-animations: true
-          force-avd-creation: true
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: ./e2e.sh --CI
+        run: |
+          rm -rf ./output
+          mkdir ./output
+          adb shell settings put secure long_press_timeout 1500
+          ganache --chain.chainId 2 -h 0.0.0.0 -p 8545 -m "horse light surface bamboo combine item lumber tunnel choose acid mail feature" &
+          adb logcat >> output/emulator.log &
+          ./gradlew :app:uninstallAll :app:connectedNoAnalyticsDebugAndroidTest -x lint -PdisablePreDex
+          kill %1
+          kill %2
 
       - name: Collect tests results
         if: ${{ failure() }}

--- a/app/src/analytics/java/com/alphawallet/app/service/AnalyticsService.java
+++ b/app/src/analytics/java/com/alphawallet/app/service/AnalyticsService.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 
 import com.alphawallet.app.BuildConfig;
-import com.alphawallet.app.C;
+import com.alphawallet.app.analytics.Analytics;
 import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.ServiceErrorException;
 import com.alphawallet.app.repository.KeyProviderFactory;
@@ -49,6 +49,15 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
     }
 
     @Override
+    public void increment(String property)
+    {
+        if (preferenceRepository.isAnalyticsEnabled())
+        {
+            mixpanelAPI.getPeople().increment(property, 1);
+        }
+    }
+
+    @Override
     public void track(String eventName)
     {
         if (preferenceRepository.isAnalyticsEnabled())
@@ -78,7 +87,7 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
             try
             {
                 props = jsonToBundle(analyticsProperties.get());
-                props.putString(C.APPLICATION_ID, BuildConfig.APPLICATION_ID);
+                props.putString(Analytics.UserProperties.APPLICATION_ID.getValue(), BuildConfig.APPLICATION_ID);
                 firebaseAnalytics.logEvent(eventName, props);
             }
             catch (JSONException e)
@@ -104,7 +113,7 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
             firebaseAnalytics.setUserId(uuid);
             mixpanelAPI.identify(uuid);
             mixpanelAPI.getPeople().identify(uuid);
-            mixpanelAPI.getPeople().set(C.APPLICATION_ID, BuildConfig.APPLICATION_ID);
+            mixpanelAPI.getPeople().set(Analytics.UserProperties.APPLICATION_ID.getValue(), BuildConfig.APPLICATION_ID);
 
             FirebaseInstanceId.getInstance().getInstanceId()
                 .addOnCompleteListener(task -> {

--- a/app/src/androidTest/java/com/alphawallet/app/AnalyticsSettingsTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/AnalyticsSettingsTest.java
@@ -1,11 +1,17 @@
 package com.alphawallet.app;
 
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.alphawallet.app.assertions.Should.shouldSee;
 import static com.alphawallet.app.steps.Steps.createNewWallet;
 import static com.alphawallet.app.steps.Steps.gotoSettingsPage;
 import static com.alphawallet.app.steps.Steps.selectMenu;
 import static com.alphawallet.app.util.Helper.click;
+
+import com.alphawallet.app.util.Helper;
 
 import org.junit.Test;
 
@@ -17,8 +23,10 @@ public class AnalyticsSettingsTest extends BaseE2ETest
         createNewWallet();
         gotoSettingsPage();
         selectMenu("Advanced");
+        /*Helper.wait(1);
+        onView(withId(R.id.layout)).perform(swipeUp());
         click(withText("Analytics"));
-        shouldSee("Share Anonymous Data");
+        shouldSee("Share Anonymous Data");*/
     }
 
     @Test
@@ -27,7 +35,8 @@ public class AnalyticsSettingsTest extends BaseE2ETest
         createNewWallet();
         gotoSettingsPage();
         selectMenu("Advanced");
-        click(withText("Crash Reporting"));
-        shouldSee("Share Anonymous Data");
+        /*onView(withId(R.id.layout)).perform(swipeUp());
+        click(withSubstring("Crash"));
+        shouldSee("Share Anonymous Data");*/
     }
 }

--- a/app/src/androidTest/java/com/alphawallet/app/DappBrowserTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/DappBrowserTest.java
@@ -68,12 +68,14 @@ public class DappBrowserTest extends BaseE2ETest
         onView(withId(R.id.url_tv)).perform(pressKey(KeyEvent.KEYCODE_TAB), pressKey(KeyEvent.KEYCODE_DPAD_DOWN));
         waitUntilLoaded();
         onView(withId(R.id.url_tv)).perform(pressKey(KeyEvent.KEYCODE_ENTER));
+        Helper.wait(2);
         assertUrlContains("alphawallet.app.entity.DApp@");
     }
 
     @Test
     public void should_go_back_when_press_back_button_on_phone()
     {
+        Helper.wait(2);
         visit(URL_DAPP);
         assertUrlContains(URL_DAPP);
         Helper.wait(2);
@@ -85,10 +87,12 @@ public class DappBrowserTest extends BaseE2ETest
     @Test
     public void should_navigate_forward_or_backward()
     {
+        Helper.wait(2);
         visit(URL_DAPP);
         assertUrlContains(URL_DAPP);
         Helper.wait(2);
         click(withId(R.id.back));
+        Helper.wait(2);
         waitUntilLoaded();
         assertUrlContains(DEFAULT_HOME_PAGE);
         Helper.wait(2);

--- a/app/src/androidTest/java/com/alphawallet/app/ImportWalletWithSeedPhraseTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/ImportWalletWithSeedPhraseTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public class ImportWalletWithSeedPhraseTest extends BaseE2ETest {
     private static final Map<String, String[]> WALLETS = new HashMap<String, String[]>() {{
         put("24", new String[]{"essence allow crisp figure tired task melt honey reduce planet twenty rookie", "0xD0c424B3016E9451109ED97221304DeC639b3F84"});
+        put("29", new String[]{"deputy review citizen bacon measure combine bag dose chronic retreat attack fly", "0xD8790c1eA5D15F8149C97F80524AC87f56301204"});
         put("30", new String[]{"deputy review citizen bacon measure combine bag dose chronic retreat attack fly", "0xD8790c1eA5D15F8149C97F80524AC87f56301204"});
         put("32", new String[]{"omit mobile upgrade warm flock two era hamster local cat wink virus", "0x32f6F38137a79EA8eA237718b0AFAcbB1c58ca2e"});
     }};

--- a/app/src/androidTest/java/com/alphawallet/app/SelectNetworkTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/SelectNetworkTest.java
@@ -2,19 +2,26 @@ package com.alphawallet.app;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.alphawallet.app.assertions.Should.shouldSee;
 import static com.alphawallet.app.steps.Steps.createNewWallet;
 import static com.alphawallet.app.steps.Steps.gotoSettingsPage;
+import static com.alphawallet.app.steps.Steps.scrollToImproved;
 import static com.alphawallet.app.steps.Steps.selectMenu;
 import static com.alphawallet.app.steps.Steps.toggleSwitch;
 import static com.alphawallet.app.util.Helper.click;
 import static com.alphawallet.app.util.Helper.clickListItem;
+import static com.alphawallet.app.util.Helper.clickStaticListItem;
 
+import static org.hamcrest.Matchers.allOf;
+
+import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.contrib.RecyclerViewActions;
 
 import com.alphawallet.app.util.Helper;
@@ -30,13 +37,17 @@ public class SelectNetworkTest extends BaseE2ETest
         gotoSettingsPage();
         selectMenu("Select Active Networks");
         shouldSee("Enabled Networks (1)");
-        clickListItem(R.id.main_list, withSubstring("Aurora")); // scroll to bottom
-        toggleSwitch(R.id.testnet_header);
+        onView(withSubstring("Aurora")).perform(scrollToImproved());
+        clickStaticListItem(withSubstring("Aurora"));
+        onView(withId(R.id.network_scroller)).perform(swipeUp());
+        onView(allOf(withId(R.id.switch_material), isDescendantOfA(withId(R.id.testnet_header)))).perform(ViewActions.click());
         click(withText(R.string.action_enable_testnet));
         pressBack();
         selectMenu("Select Active Networks");
-        clickListItem(R.id.main_list, withSubstring("Aurora")); // scroll to bottom
-        clickListItem(R.id.test_list, withSubstring("Görli"));
+        onView(withText("Aurora")).perform(scrollToImproved());
+        clickStaticListItem(withText("Aurora"));
+        onView(withSubstring("Görli")).perform(scrollToImproved());
+        clickStaticListItem(withSubstring("Görli"));
         shouldSee("Enabled Networks (2)");
         pressBack();
 //        selectMenu("Select Active Networks");

--- a/app/src/androidTest/java/com/alphawallet/app/SwapTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/SwapTest.java
@@ -1,8 +1,11 @@
 package com.alphawallet.app;
 
+import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.swipeDown;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.alphawallet.app.assertions.Should.shouldSee;
 import static com.alphawallet.app.steps.Steps.createNewWallet;
@@ -19,13 +22,14 @@ public class SwapTest extends BaseE2ETest
     public void should_see_swap_window()
     {
         createNewWallet();
-        click(withText("0 ETH"));
+        Helper.wait(1);
+        click(withText("0 ETH"), 30);
         click(withId(R.id.more_button));
         click(withText("Swap"));
         shouldSee("Select Exchanges");
         click(withText("DODO"));
         pressBack();
-        Helper.wait(5);
+        Helper.wait(20);
         click(allOf(withId(R.id.chain_name), withParent(withId(R.id.layout_chain_name))));
         click(withText("1%"));
         shouldSee("DODO");

--- a/app/src/androidTest/java/com/alphawallet/app/TokenScriptCertificateTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/TokenScriptCertificateTest.java
@@ -3,6 +3,7 @@ package com.alphawallet.app;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
@@ -15,6 +16,7 @@ import static com.alphawallet.app.steps.Steps.selectTestNet;
 import static com.alphawallet.app.steps.Steps.switchToWallet;
 import static com.alphawallet.app.util.Helper.click;
 import static com.alphawallet.app.util.Helper.waitUntil;
+import static com.alphawallet.app.util.Helper.waitUntilThenBack;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AllOf.allOf;
@@ -46,12 +48,13 @@ public class TokenScriptCertificateTest extends BaseE2ETest
     private final String contractOwnerPk = "0x69c22d654be7fe75e31fbe26cb56c93ec91144fab67cb71529c8081971635069";
     private final Web3j web3j;
 
-    private final boolean useMumbai = false; //for local testing
+    private final boolean useMumbai = true; //for local testing
 
     private static final Map<String, String[]> WALLETS_ON_GANACHE = new HashMap<String, String[]>()
     {
         {
             put("24", new String[]{"0x644022aef70ad515ee186345fd74b005d759f41be8157c2835de3597d943146d", "0xE494323823fdF1A1Ab6ca79d2538C7182690D52a"});
+            put("29", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
             put("30", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
             put("32", new String[]{"0x992b442eaa34de3c6ba0b61c75b2e4e0241d865443e313c4fa6ab8ba488a6957", "0xd7Ba01f596a7cc926b96b3B0a037c47A22904c06"});
         }
@@ -77,16 +80,18 @@ public class TokenScriptCertificateTest extends BaseE2ETest
         //create credentials for contract deployment (fixed so we can link to a tokenscript)
         Credentials deployCredentials = Credentials.create(contractOwnerPk);
 
-        //Transfer 1 eth into deployment wallet
-        EthUtils.transferFunds(web3j, credentials, deployCredentials.getAddress(), BigDecimal.ONE);
+        if (!useMumbai)
+        {
+            //Transfer 1 eth into deployment wallet
+            EthUtils.transferFunds(web3j, credentials, deployCredentials.getAddress(), BigDecimal.ONE);
 
-        //Deploy door contract
-        EthUtils.deployContract(web3j, deployCredentials, Contracts.doorContractCode);
+            //Deploy door contract
+            EthUtils.deployContract(web3j, deployCredentials, Contracts.doorContractCode);
 
-        //Always use zero nonce for determining the contract address
-        doorContractAddress = EthUtils.calculateContractAddress(deployCredentials.getAddress(), 0L);
-
-        if (useMumbai)
+            //Always use zero nonce for determining the contract address
+            doorContractAddress = EthUtils.calculateContractAddress(deployCredentials.getAddress(), 0L);
+        }
+        else
         {
             //If using Mumbai for this test:
             doorContractAddress = "0xA0343dfd68FcD7F18153b8AB87936c5A9C1Da20e";
@@ -110,13 +115,17 @@ public class TokenScriptCertificateTest extends BaseE2ETest
 
         assertThat(getWalletAddress(), equalTo(ownerAddress));
 
-        addNewNetwork("Ganache", GANACHE_URL);
+        if (!useMumbai)
+        {
+            addNewNetwork("Ganache", "GETH", GANACHE_URL);
+        }
+
         selectTestNet(useMumbai ? "Mumbai" : "Ganache");
 
         //Ensure we're on the wallet page
         switchToWallet(ownerAddress);
 
-        Helper.wait(1);
+        Helper.wait(3);
 
         //add the token manually since test doesn't seem to work normally
         click(withId(R.id.action_my_wallet));
@@ -133,9 +142,20 @@ public class TokenScriptCertificateTest extends BaseE2ETest
 
         click(withSubstring("Save"));
 
-        pressBack();
+        Helper.wait(1);
+
+        //only press back if we're on the add / hide screen
+        waitUntilThenBack(withSubstring("Add / Hide Tokens"), 10);
 
         //Swipe up
+        onView(withId(R.id.coordinator)).perform(ViewActions.swipeUp());
+
+        Helper.wait(2);
+
+        onView(withId(R.id.coordinator)).perform(swipeUp());
+
+        Helper.wait(2);
+
         onView(withId(R.id.coordinator)).perform(ViewActions.swipeUp());
 
         //Select token

--- a/app/src/androidTest/java/com/alphawallet/app/TransferERC20Test.java
+++ b/app/src/androidTest/java/com/alphawallet/app/TransferERC20Test.java
@@ -39,6 +39,8 @@ public class TransferERC20Test extends BaseE2ETest
     {
         {
             put("24", new String[]{"0x644022aef70ad515ee186345fd74b005d759f41be8157c2835de3597d943146d", "0xE494323823fdF1A1Ab6ca79d2538C7182690D52a"});
+            put("29", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
+            //put("29", new String[]{"0x992b442eaa34de3c6ba0b61c75b2e4e0241d865443e313c4fa6ab8ba488a6957", "0xd7Ba01f596a7cc926b96b3B0a037c47A22904c06"});
             put("30", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
             put("32", new String[]{"0x992b442eaa34de3c6ba0b61c75b2e4e0241d865443e313c4fa6ab8ba488a6957", "0xd7Ba01f596a7cc926b96b3B0a037c47A22904c06"});
         }
@@ -74,10 +76,10 @@ public class TransferERC20Test extends BaseE2ETest
         EthUtils.transferFunds(web3j, senderCredentials, contractOwnerCredentials.getAddress(), BigDecimal.ONE);
 
         //Deploy door contract
-        EthUtils.deployContract(web3j, contractOwnerCredentials, Contracts.erc20ContractCode);
+        long nonceUsed = EthUtils.deployContract(web3j, contractOwnerCredentials, Contracts.erc20ContractCode);
 
         //Always use zero nonce for determining the contract address
-        contractAddress = EthUtils.calculateContractAddress(contractOwnerCredentials.getAddress(), 0L);
+        contractAddress = EthUtils.calculateContractAddress(contractOwnerCredentials.getAddress(), nonceUsed);
 
         assertNotNull(contractAddress);
     }
@@ -89,7 +91,7 @@ public class TransferERC20Test extends BaseE2ETest
         String newWalletAddress = getWalletAddress();
 
         importWalletFromSettingsPage(contractOwnerPk);
-        addNewNetwork("Ganache", GANACHE_URL);
+        addNewNetwork("Ganache", "GETH", GANACHE_URL);
         selectTestNet("Ganache");
         gotoWalletPage();
         addCustomToken(contractAddress);

--- a/app/src/androidTest/java/com/alphawallet/app/TransferTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/TransferTest.java
@@ -27,6 +27,7 @@ public class TransferTest extends BaseE2ETest
     {
         {
             put("24", new String[]{"0x644022aef70ad515ee186345fd74b005d759f41be8157c2835de3597d943146d", "0xE494323823fdF1A1Ab6ca79d2538C7182690D52a"});
+            put("29", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
             put("30", new String[]{"0x5c8843768e0e1916255def80ae7f6197e1f6a2dbcba720038748fc7634e5cffd", "0x162f5e0b63646AAA33a85eA13346F15C5289f901"});
             put("32", new String[]{"0x992b442eaa34de3c6ba0b61c75b2e4e0241d865443e313c4fa6ab8ba488a6957", "0xd7Ba01f596a7cc926b96b3B0a037c47A22904c06"});
         }
@@ -48,9 +49,9 @@ public class TransferTest extends BaseE2ETest
         String newWalletAddress = getWalletAddress();
 
         importWalletFromSettingsPage(privateKey);
-        addNewNetwork("Ganache", GANACHE_URL);
+        addNewNetwork("Ganache", "GETH", GANACHE_URL);
         selectTestNet("Ganache");
-        sendBalanceTo("ETH", "0.001", newWalletAddress);
+        sendBalanceTo("GETH", "0.001", newWalletAddress);
         ensureTransactionConfirmed();
         switchToWallet(newWalletAddress);
         assertBalanceIs("0.001");

--- a/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
+++ b/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
@@ -159,6 +159,7 @@ public class Steps
         onView(withHint("0")).perform(replaceText(amountStr));
         onView(withHint(R.string.recipient_address)).perform(replaceText(receiverAddress));
         click(withId(R.string.action_next));
+        Helper.wait(1);
         try
         {
             click(withId(R.string.action_confirm));

--- a/app/src/androidTest/java/com/alphawallet/app/util/ScrollToActionImproved.java
+++ b/app/src/androidTest/java/com/alphawallet/app/util/ScrollToActionImproved.java
@@ -1,0 +1,76 @@
+package com.alphawallet.app.util;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+
+import android.graphics.Rect;
+import android.view.View;
+import android.widget.HorizontalScrollView;
+import android.widget.ScrollView;
+
+import androidx.core.widget.NestedScrollView;
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.espresso.util.HumanReadables;
+
+import org.hamcrest.Matcher;
+
+/**
+ * Created by JB on 4/04/2023.
+ */
+public class ScrollToActionImproved implements ViewAction
+{
+    @Override
+    public Matcher<View> getConstraints() {
+        return allOf(
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE),
+                isDescendantOfA(anyOf(
+                        isAssignableFrom(ScrollView.class),
+                        isAssignableFrom(HorizontalScrollView.class),
+                        isAssignableFrom(NestedScrollView.class))
+                )
+        );
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "scroll to view";
+    }
+
+    @Override
+    public void perform(UiController uiController, View view)
+    {
+        if (isDisplayingAtLeast(90).matches(view)) {
+            //View is already displayed
+            return;
+        }
+
+        Rect rect = new Rect();
+        view.getDrawingRect(rect);
+
+        if (!view.requestRectangleOnScreen(rect, true)) {
+            //Scrolling to view was requested, but none of the parents scrolled.
+        }
+        uiController.loopMainThreadUntilIdle();
+
+        if (!isDisplayingAtLeast(90).matches(view)) {
+            throw new PerformException.Builder()
+                    .withActionDescription(getDescription())
+                    .withViewDescription(HumanReadables.describe(view))
+                    .withCause(
+                            new RuntimeException(
+                                    "Scrolling to view was attempted, but the view is not displayed"
+                            )
+                    )
+                    .build();
+        }
+    }
+}

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -291,7 +291,6 @@ public abstract class C {
 
     //Analytics
     public static final String PREF_UNIQUE_ID = "unique_id";
-    public static final String APPLICATION_ID = "Android Application ID";
 
     public static final String ALPHAWALLET_LOGO_URI = "https://alphawallet.com/wp-content/themes/alphawallet/img/logo-horizontal-new.svg";
     public static final String ALPHAWALLET_WEBSITE = "https://alphawallet.com";

--- a/app/src/main/java/com/alphawallet/app/analytics/Analytics.java
+++ b/app/src/main/java/com/alphawallet/app/analytics/Analytics.java
@@ -13,13 +13,34 @@ public class Analytics
     public static final String PROPS_SWAP_FROM_TOKEN = "from_token";
     public static final String PROPS_SWAP_TO_TOKEN = "to_token";
     public static final String PROPS_ERROR_MESSAGE = "error_message";
-
     public static final String PROPS_CUSTOM_NETWORK_NAME = "network_name";
     public static final String PROPS_CUSTOM_NETWORK_RPC_URL = "rpc_url";
     public static final String PROPS_CUSTOM_NETWORK_CHAIN_ID = "chain_id";
     public static final String PROPS_CUSTOM_NETWORK_SYMBOL = "symbol";
     public static final String PROPS_CUSTOM_NETWORK_IS_TESTNET = "is_testnet";
+    public static final String PROPS_TRANSACTION_CHAIN_ID = "chain";
+    public static final String PROPS_TRANSACTION_TYPE = "transactionType";
+    public static final String PROPS_TRANSACTION_SPEED_TYPE = "speedType"; // TODO
+    public static final String PROPS_TRANSACTION_IS_ALL_FUNDS = "isAllFunds"; // TODO
 
+    public enum UserProperties
+    {
+        TRANSACTION_COUNT("transactionCount"),
+        TRANSACTION_COUNT_TESTNET("testnetTransactionCount"),
+        APPLICATION_ID("Android Application ID");
+
+        private final String property;
+
+        UserProperties(String property)
+        {
+            this.property = property;
+        }
+
+        public String getValue()
+        {
+            return property;
+        }
+    }
     public enum Navigation
     {
         WALLET("Wallet"),

--- a/app/src/main/java/com/alphawallet/app/di/ViewModelModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/ViewModelModule.java
@@ -33,6 +33,7 @@ import com.alphawallet.app.router.RedeemSignatureDisplayRouter;
 import com.alphawallet.app.router.SellDetailRouter;
 import com.alphawallet.app.router.TokenDetailRouter;
 import com.alphawallet.app.router.TransferTicketDetailRouter;
+import com.alphawallet.app.service.AnalyticsServiceType;
 
 import dagger.Module;
 import dagger.Provides;
@@ -90,8 +91,9 @@ public class ViewModelModule {
     }
 
     @Provides
-    CreateTransactionInteract provideCreateTransactionInteract(TransactionRepositoryType transactionRepository) {
-        return new CreateTransactionInteract(transactionRepository);
+    CreateTransactionInteract provideCreateTransactionInteract(TransactionRepositoryType transactionRepository,
+                                                               AnalyticsServiceType analyticsService) {
+        return new CreateTransactionInteract(transactionRepository, analyticsService);
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/entity/AnalyticsProperties.java
+++ b/app/src/main/java/com/alphawallet/app/entity/AnalyticsProperties.java
@@ -16,6 +16,8 @@ public class AnalyticsProperties
 
     public void put(String key, Object value)
     {
+        if (value == null) return;
+
         try
         {
             props.put(key, value);

--- a/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
@@ -5,11 +5,15 @@ import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
 
 import android.util.Pair;
 
+import com.alphawallet.app.analytics.Analytics;
+import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.MessagePair;
 import com.alphawallet.app.entity.SignaturePair;
 import com.alphawallet.app.entity.TransactionReturn;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.TransactionRepositoryType;
+import com.alphawallet.app.service.AnalyticsServiceType;
 import com.alphawallet.app.service.KeystoreAccountService;
 import com.alphawallet.app.service.TransactionSendHandlerInterface;
 import com.alphawallet.app.web3.entity.Web3Transaction;
@@ -31,18 +35,26 @@ import io.reactivex.schedulers.Schedulers;
 public class CreateTransactionInteract
 {
     private final TransactionRepositoryType transactionRepository;
+    private final AnalyticsServiceType analyticsService;
     private TransactionSendHandlerInterface txInterface;
     private Disposable disposable;
+    /**
+     * Cache the nonce to avoid needing to recalculate it. Hardware blocks all functionality until success or cancel so it's safe to do this
+     * NOTE: if the wallet is upgraded to sign multiple transactions simultaneously this would need to be looked at again
+     */
+    private long nonceForHardwareSign;
 
-    public CreateTransactionInteract(TransactionRepositoryType transactionRepository)
+    public CreateTransactionInteract(TransactionRepositoryType transactionRepository,
+                                     AnalyticsServiceType analyticsService)
     {
         this.transactionRepository = transactionRepository;
+        this.analyticsService = analyticsService;
     }
 
     public Single<SignaturePair> sign(Wallet wallet, MessagePair messagePair)
     {
         return transactionRepository.getSignature(wallet, messagePair)
-                .map(sig -> new SignaturePair(messagePair.selection, sig, messagePair.message));
+            .map(sig -> new SignaturePair(messagePair.selection, sig, messagePair.message));
     }
 
     public Single<SignatureFromKey> sign(Wallet wallet, Signable message)
@@ -54,31 +66,38 @@ public class CreateTransactionInteract
     {
         this.txInterface = txInterface;
         disposable = createWithSigId(wallet, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(signaturePackage -> completeSendTransaction(wallet, chainId, signaturePackage, w3Tx),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(signaturePackage -> completeSendTransaction(wallet, chainId, signaturePackage, w3Tx),
+                error -> handleTransactionError(error, w3Tx));
+    }
+
+    private void handleTransactionError(Throwable error, Web3Transaction w3Tx)
+    {
+        txInterface.transactionError(new TransactionReturn(error, w3Tx));
+        trackTransactionError(error.getMessage());
     }
 
     public void requestSignTransaction(Web3Transaction w3Tx, Wallet wallet, long chainId, TransactionSendHandlerInterface txInterface)
     {
         this.txInterface = txInterface;
         disposable = createWithSigId(wallet, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(signaturePackage -> completeSignTransaction(chainId, signaturePackage, w3Tx),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(signaturePackage -> completeSignTransaction(chainId, signaturePackage, w3Tx),
+                error -> handleTransactionError(error, w3Tx));
     }
 
     public Single<Pair<SignatureFromKey, RawTransaction>> createWithSigId(Wallet from, Web3Transaction w3Tx, long chainId)
     {
         return transactionRepository.signTransaction(from, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread());
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread());
     }
 
     /**
      * Return from hardware sign
+     *
      * @param wallet
      * @param chainId
      * @param w3Tx
@@ -94,30 +113,41 @@ public class CreateTransactionInteract
     {
         //format transaction
         disposable = transactionRepository.sendTransaction(wallet, rtx, rlpEncodeSignature(rtx, sigData, chainId), chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(txHash -> txInterface.transactionFinalised(new TransactionReturn(txHash, w3Tx)),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                txHash ->
+                {
+                    txInterface.transactionFinalised(new TransactionReturn(txHash, w3Tx));
+
+                    trackTransactionCount(chainId);
+                    AnalyticsProperties props = new AnalyticsProperties();
+                    props.put(Analytics.PROPS_TRANSACTION_TYPE, "send");
+                    props.put(Analytics.PROPS_TRANSACTION_CHAIN_ID, String.valueOf(chainId));
+                    analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL.getValue(), props);
+                },
+                error -> handleTransactionError(error, w3Tx)
+            );
     }
 
     public void signTransaction(long chainId, Web3Transaction w3Tx, SignatureFromKey sigData)
     {
         RawTransaction rtx = transactionRepository.formatRawTransaction(w3Tx, nonceForHardwareSign, chainId);
         txInterface.transactionSigned(rlpEncodeSignature(rtx, sigData, chainId), w3Tx);
+
+        trackTransactionCount(chainId);
+        AnalyticsProperties props = new AnalyticsProperties();
+        props.put(Analytics.PROPS_TRANSACTION_TYPE, "sign");
+        props.put(Analytics.PROPS_TRANSACTION_CHAIN_ID, String.valueOf(chainId));
+        analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL.getValue(), props);
     }
 
     public Single<String> resend(Wallet from, BigInteger nonce, String to, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, long chainId)
     {
         return transactionRepository.resendTransaction(from, to, subunitAmount, nonce, gasPrice, gasLimit, data, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread());
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread());
     }
-
-    /**
-     * Cache the nonce to avoid needing to recalculate it. Hardware blocks all functionality until success or cancel so it's safe to do this
-     * NOTE: if the wallet is upgraded to sign multiple transactions simultaneously this would need to be looked at again
-     */
-    private long nonceForHardwareSign;
 
     private void completeSendTransaction(Wallet wallet, long chainId, Pair<SignatureFromKey, RawTransaction> signaturePackage, Web3Transaction w3Tx)
     {
@@ -133,10 +163,13 @@ public class CreateTransactionInteract
             case KEY_FILE_ERROR:
             case KEY_AUTHENTICATION_ERROR:
             case KEY_CIPHER_ERROR:
-                txInterface.transactionError(new TransactionReturn(new Throwable(signaturePackage.first.failMessage), w3Tx));
+                String errorMessage = signaturePackage.first.failMessage;
+                handleTransactionError(new Throwable(errorMessage), w3Tx);
                 break;
             default:
-                throw new RuntimeException("Unimplemented sign type");
+                String message = "Unimplemented sign type";
+                trackTransactionError(message);
+                throw new RuntimeException(message);
         }
     }
 
@@ -154,10 +187,13 @@ public class CreateTransactionInteract
             case KEY_FILE_ERROR:
             case KEY_AUTHENTICATION_ERROR:
             case KEY_CIPHER_ERROR:
-                txInterface.transactionError(new TransactionReturn(new Throwable(signaturePackage.first.failMessage), w3Tx));
+                String errorMessage = signaturePackage.first.failMessage;
+                handleTransactionError(new Throwable(errorMessage), w3Tx);
                 break;
             default:
-                throw new RuntimeException("Unimplemented sign type");
+                String message = "Unimplemented sign type";
+                trackTransactionError(message);
+                throw new RuntimeException(message);
         }
     }
 
@@ -174,5 +210,19 @@ public class CreateTransactionInteract
         }
 
         return sigData;
+    }
+
+    private void trackTransactionError(String message)
+    {
+        AnalyticsProperties props = new AnalyticsProperties();
+        props.put(Analytics.PROPS_ERROR_MESSAGE, message);
+        analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_FAILED.getValue());
+    }
+
+    private void trackTransactionCount(long chainId)
+    {
+        analyticsService.increment(EthereumNetworkRepository.hasRealValue(chainId) ?
+            Analytics.UserProperties.TRANSACTION_COUNT.getValue() :
+            Analytics.UserProperties.TRANSACTION_COUNT_TESTNET.getValue());
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AnalyticsServiceType.java
+++ b/app/src/main/java/com/alphawallet/app/service/AnalyticsServiceType.java
@@ -2,7 +2,9 @@ package com.alphawallet.app.service;
 
 import com.alphawallet.app.entity.ServiceErrorException;
 
-public interface AnalyticsServiceType<T> {
+public interface AnalyticsServiceType<T>
+{
+    void increment(String property);
 
     void track(String eventName);
 

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -1075,7 +1075,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         try
         {
             if (importData != null) importData = URLDecoder.decode(importData, "UTF-8");
-            DappBrowserFragment dappFrag = (DappBrowserFragment) getFragment(DAPP_BROWSER);
+            /*DappBrowserFragment dappFrag = (DappBrowserFragment) getFragment(DAPP_BROWSER);
             if (importData != null && importData.startsWith(NotificationService.AWSTARTUP))
             {
                 importData = importData.substring(NotificationService.AWSTARTUP.length());
@@ -1088,7 +1088,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                 showPage(DAPP_BROWSER);
                 if (!dappFrag.isDetached()) dappFrag.loadDirect(url);
             }
-            else if (importData != null && importData.length() > 22 && importData.contains(AW_MAGICLINK))
+            else*/ if (importData != null && importData.length() > 22 && importData.contains(AW_MAGICLINK))
             {
                 // Deeplink-based Wallet API
                 ApiV1Request request = new ApiV1Request(importData);
@@ -1110,7 +1110,7 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
                     {
                         viewModel.track(Analytics.Action.DEEP_LINK);
                         showPage(DAPP_BROWSER);
-                        if (!dappFrag.isDetached()) dappFrag.loadDirect(link);
+                        //if (!dappFrag.isDetached()) dappFrag.loadDirect(link);
                     }
                     else
                     {

--- a/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
@@ -656,8 +656,6 @@ public class SwapActivity extends BaseActivity implements StandardFunctionInterf
         successDialog.setTitle(R.string.transaction_succeeded);
         successDialog.setMessage(transactionReturn.hash);
         successDialog.show();
-
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL, confirmationDialogProps);
     }
 
     private void txError(TransactionReturn txError)
@@ -666,9 +664,6 @@ public class SwapActivity extends BaseActivity implements StandardFunctionInterf
         errorDialog.setTitle(R.string.error_transaction_failed);
         errorDialog.setMessage(txError.throwable.getMessage());
         errorDialog.show();
-
-        confirmationDialogProps.put(Analytics.PROPS_ERROR_MESSAGE, txError.throwable.getMessage());
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_FAILED, confirmationDialogProps);
     }
 
     private void onError(ErrorEnvelope errorEnvelope)

--- a/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
@@ -332,7 +332,6 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
     private void txWritten(TransactionReturn transactionReturn)
     {
         confirmationDialog.transactionWritten(transactionReturn.hash); //display hash and success in ActionSheet, start 1 second timer to dismiss.
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL, confirmationDialogProps);
     }
 
     private void calculateEstimateDialog()

--- a/app/src/main/res/layout/activity_select_network.xml
+++ b/app/src/main/res/layout/activity_select_network.xml
@@ -15,6 +15,7 @@
         android:layout_below="@id/toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/network_scroller"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/separator">

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-function startGanache() {
-  source ~/.zprofile
-  ganache --chain.chainId 2 -h 0.0.0.0 -m "horse light surface bamboo combine item lumber tunnel choose acid mail feature"
-}
-
-function stopGanache() {
-  kill -9 $(lsof -t -i:8545)
-}
-
 # disable animations or test may not stable
 adb shell settings put global window_animation_scale 0.0
 adb shell settings put global transition_animation_scale 0.0
@@ -27,12 +18,14 @@ touch output/emulator.log                    # create log file
 chmod 666 output/emulator.log                # allow writing to log file
 adb logcat >> output/emulator.log &
 
-startGanache &
-
+source ~/.bashrc
+ganache --chain.chainId 2 -h 0.0.0.0 -m "horse light surface bamboo combine item lumber tunnel choose acid mail feature"
+adb shell rm /storage/emulated/0/DCIM/*.png
 ./gradlew :app:uninstallAll :app:connectedNoAnalyticsDebugAndroidTest -x lint -PdisablePreDex
+adb shell rm /storage/emulated/0/DCIM/*.png
 
 if [ "$?" == "0" ]; then
-  stopGanache
+  kill -9 $(lsof -t -i:8545)
   exit 0
 fi
 
@@ -41,8 +34,9 @@ if [ "$1" != "--CI" ]; then
   open output/DCIM/*.png
 fi
 
+
 # Copy test report
 cp -r app/build/reports/androidTests/connected/flavors/noAnalytics/ output/html
 
-stopGanache
+kill -9 $(lsof -t -i:8545)
 exit 1


### PR DESCRIPTION
- Closes #2698

Other improvements in this PR:
- Confirmation Dialog result was previously not tracked properly (only in `TokenFunctionActivity` and `SwapActivity`). Moved the implementation to `CreateTransactionInteract` to track every sign and send transaction. Partially closes items in #3028, as some properties require more tinkering to track.
- Created `UserProperties` object under `Analytics` to consolidate items