### PR TITLE
Mixpanel tracking improvements

### DIFF
--- a/app/src/analytics/java/com/alphawallet/app/service/AnalyticsService.java
+++ b/app/src/analytics/java/com/alphawallet/app/service/AnalyticsService.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 
 import com.alphawallet.app.BuildConfig;
-import com.alphawallet.app.C;
+import com.alphawallet.app.analytics.Analytics;
 import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.ServiceErrorException;
 import com.alphawallet.app.repository.KeyProviderFactory;
@@ -49,6 +49,15 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
     }
 
     @Override
+    public void increment(String property)
+    {
+        if (preferenceRepository.isAnalyticsEnabled())
+        {
+            mixpanelAPI.getPeople().increment(property, 1);
+        }
+    }
+
+    @Override
     public void track(String eventName)
     {
         if (preferenceRepository.isAnalyticsEnabled())
@@ -78,7 +87,7 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
             try
             {
                 props = jsonToBundle(analyticsProperties.get());
-                props.putString(C.APPLICATION_ID, BuildConfig.APPLICATION_ID);
+                props.putString(Analytics.UserProperties.APPLICATION_ID.getValue(), BuildConfig.APPLICATION_ID);
                 firebaseAnalytics.logEvent(eventName, props);
             }
             catch (JSONException e)
@@ -104,7 +113,7 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T>
             firebaseAnalytics.setUserId(uuid);
             mixpanelAPI.identify(uuid);
             mixpanelAPI.getPeople().identify(uuid);
-            mixpanelAPI.getPeople().set(C.APPLICATION_ID, BuildConfig.APPLICATION_ID);
+            mixpanelAPI.getPeople().set(Analytics.UserProperties.APPLICATION_ID.getValue(), BuildConfig.APPLICATION_ID);
 
             FirebaseInstanceId.getInstance().getInstanceId()
                 .addOnCompleteListener(task -> {

--- a/app/src/main/java/com/alphawallet/app/C.java
+++ b/app/src/main/java/com/alphawallet/app/C.java
@@ -291,7 +291,6 @@ public abstract class C {
 
     //Analytics
     public static final String PREF_UNIQUE_ID = "unique_id";
-    public static final String APPLICATION_ID = "Android Application ID";
 
     public static final String ALPHAWALLET_LOGO_URI = "https://alphawallet.com/wp-content/themes/alphawallet/img/logo-horizontal-new.svg";
     public static final String ALPHAWALLET_WEBSITE = "https://alphawallet.com";

--- a/app/src/main/java/com/alphawallet/app/analytics/Analytics.java
+++ b/app/src/main/java/com/alphawallet/app/analytics/Analytics.java
@@ -13,13 +13,34 @@ public class Analytics
     public static final String PROPS_SWAP_FROM_TOKEN = "from_token";
     public static final String PROPS_SWAP_TO_TOKEN = "to_token";
     public static final String PROPS_ERROR_MESSAGE = "error_message";
-
     public static final String PROPS_CUSTOM_NETWORK_NAME = "network_name";
     public static final String PROPS_CUSTOM_NETWORK_RPC_URL = "rpc_url";
     public static final String PROPS_CUSTOM_NETWORK_CHAIN_ID = "chain_id";
     public static final String PROPS_CUSTOM_NETWORK_SYMBOL = "symbol";
     public static final String PROPS_CUSTOM_NETWORK_IS_TESTNET = "is_testnet";
+    public static final String PROPS_TRANSACTION_CHAIN_ID = "chain";
+    public static final String PROPS_TRANSACTION_TYPE = "transactionType";
+    public static final String PROPS_TRANSACTION_SPEED_TYPE = "speedType"; // TODO
+    public static final String PROPS_TRANSACTION_IS_ALL_FUNDS = "isAllFunds"; // TODO
 
+    public enum UserProperties
+    {
+        TRANSACTION_COUNT("transactionCount"),
+        TRANSACTION_COUNT_TESTNET("testnetTransactionCount"),
+        APPLICATION_ID("Android Application ID");
+
+        private final String property;
+
+        UserProperties(String property)
+        {
+            this.property = property;
+        }
+
+        public String getValue()
+        {
+            return property;
+        }
+    }
     public enum Navigation
     {
         WALLET("Wallet"),

--- a/app/src/main/java/com/alphawallet/app/di/ViewModelModule.java
+++ b/app/src/main/java/com/alphawallet/app/di/ViewModelModule.java
@@ -33,6 +33,7 @@ import com.alphawallet.app.router.RedeemSignatureDisplayRouter;
 import com.alphawallet.app.router.SellDetailRouter;
 import com.alphawallet.app.router.TokenDetailRouter;
 import com.alphawallet.app.router.TransferTicketDetailRouter;
+import com.alphawallet.app.service.AnalyticsServiceType;
 
 import dagger.Module;
 import dagger.Provides;
@@ -90,8 +91,9 @@ public class ViewModelModule {
     }
 
     @Provides
-    CreateTransactionInteract provideCreateTransactionInteract(TransactionRepositoryType transactionRepository) {
-        return new CreateTransactionInteract(transactionRepository);
+    CreateTransactionInteract provideCreateTransactionInteract(TransactionRepositoryType transactionRepository,
+                                                               AnalyticsServiceType analyticsService) {
+        return new CreateTransactionInteract(transactionRepository, analyticsService);
     }
 
     @Provides

--- a/app/src/main/java/com/alphawallet/app/entity/AnalyticsProperties.java
+++ b/app/src/main/java/com/alphawallet/app/entity/AnalyticsProperties.java
@@ -16,6 +16,8 @@ public class AnalyticsProperties
 
     public void put(String key, Object value)
     {
+        if (value == null) return;
+
         try
         {
             props.put(key, value);

--- a/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
+++ b/app/src/main/java/com/alphawallet/app/interact/CreateTransactionInteract.java
@@ -5,11 +5,15 @@ import static com.alphawallet.app.entity.CryptoFunctions.sigFromByteArray;
 
 import android.util.Pair;
 
+import com.alphawallet.app.analytics.Analytics;
+import com.alphawallet.app.entity.AnalyticsProperties;
 import com.alphawallet.app.entity.MessagePair;
 import com.alphawallet.app.entity.SignaturePair;
 import com.alphawallet.app.entity.TransactionReturn;
 import com.alphawallet.app.entity.Wallet;
+import com.alphawallet.app.repository.EthereumNetworkRepository;
 import com.alphawallet.app.repository.TransactionRepositoryType;
+import com.alphawallet.app.service.AnalyticsServiceType;
 import com.alphawallet.app.service.KeystoreAccountService;
 import com.alphawallet.app.service.TransactionSendHandlerInterface;
 import com.alphawallet.app.web3.entity.Web3Transaction;
@@ -31,18 +35,26 @@ import io.reactivex.schedulers.Schedulers;
 public class CreateTransactionInteract
 {
     private final TransactionRepositoryType transactionRepository;
+    private final AnalyticsServiceType analyticsService;
     private TransactionSendHandlerInterface txInterface;
     private Disposable disposable;
+    /**
+     * Cache the nonce to avoid needing to recalculate it. Hardware blocks all functionality until success or cancel so it's safe to do this
+     * NOTE: if the wallet is upgraded to sign multiple transactions simultaneously this would need to be looked at again
+     */
+    private long nonceForHardwareSign;
 
-    public CreateTransactionInteract(TransactionRepositoryType transactionRepository)
+    public CreateTransactionInteract(TransactionRepositoryType transactionRepository,
+                                     AnalyticsServiceType analyticsService)
     {
         this.transactionRepository = transactionRepository;
+        this.analyticsService = analyticsService;
     }
 
     public Single<SignaturePair> sign(Wallet wallet, MessagePair messagePair)
     {
         return transactionRepository.getSignature(wallet, messagePair)
-                .map(sig -> new SignaturePair(messagePair.selection, sig, messagePair.message));
+            .map(sig -> new SignaturePair(messagePair.selection, sig, messagePair.message));
     }
 
     public Single<SignatureFromKey> sign(Wallet wallet, Signable message)
@@ -54,31 +66,38 @@ public class CreateTransactionInteract
     {
         this.txInterface = txInterface;
         disposable = createWithSigId(wallet, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(signaturePackage -> completeSendTransaction(wallet, chainId, signaturePackage, w3Tx),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(signaturePackage -> completeSendTransaction(wallet, chainId, signaturePackage, w3Tx),
+                error -> handleTransactionError(error, w3Tx));
+    }
+
+    private void handleTransactionError(Throwable error, Web3Transaction w3Tx)
+    {
+        txInterface.transactionError(new TransactionReturn(error, w3Tx));
+        trackTransactionError(error.getMessage());
     }
 
     public void requestSignTransaction(Web3Transaction w3Tx, Wallet wallet, long chainId, TransactionSendHandlerInterface txInterface)
     {
         this.txInterface = txInterface;
         disposable = createWithSigId(wallet, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(signaturePackage -> completeSignTransaction(chainId, signaturePackage, w3Tx),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(signaturePackage -> completeSignTransaction(chainId, signaturePackage, w3Tx),
+                error -> handleTransactionError(error, w3Tx));
     }
 
     public Single<Pair<SignatureFromKey, RawTransaction>> createWithSigId(Wallet from, Web3Transaction w3Tx, long chainId)
     {
         return transactionRepository.signTransaction(from, w3Tx, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread());
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread());
     }
 
     /**
      * Return from hardware sign
+     *
      * @param wallet
      * @param chainId
      * @param w3Tx
@@ -94,30 +113,41 @@ public class CreateTransactionInteract
     {
         //format transaction
         disposable = transactionRepository.sendTransaction(wallet, rtx, rlpEncodeSignature(rtx, sigData, chainId), chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(txHash -> txInterface.transactionFinalised(new TransactionReturn(txHash, w3Tx)),
-                        error -> txInterface.transactionError(new TransactionReturn(error, w3Tx)));
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                txHash ->
+                {
+                    txInterface.transactionFinalised(new TransactionReturn(txHash, w3Tx));
+
+                    trackTransactionCount(chainId);
+                    AnalyticsProperties props = new AnalyticsProperties();
+                    props.put(Analytics.PROPS_TRANSACTION_TYPE, "send");
+                    props.put(Analytics.PROPS_TRANSACTION_CHAIN_ID, String.valueOf(chainId));
+                    analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL.getValue(), props);
+                },
+                error -> handleTransactionError(error, w3Tx)
+            );
     }
 
     public void signTransaction(long chainId, Web3Transaction w3Tx, SignatureFromKey sigData)
     {
         RawTransaction rtx = transactionRepository.formatRawTransaction(w3Tx, nonceForHardwareSign, chainId);
         txInterface.transactionSigned(rlpEncodeSignature(rtx, sigData, chainId), w3Tx);
+
+        trackTransactionCount(chainId);
+        AnalyticsProperties props = new AnalyticsProperties();
+        props.put(Analytics.PROPS_TRANSACTION_TYPE, "sign");
+        props.put(Analytics.PROPS_TRANSACTION_CHAIN_ID, String.valueOf(chainId));
+        analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL.getValue(), props);
     }
 
     public Single<String> resend(Wallet from, BigInteger nonce, String to, BigInteger subunitAmount, BigInteger gasPrice, BigInteger gasLimit, byte[] data, long chainId)
     {
         return transactionRepository.resendTransaction(from, to, subunitAmount, nonce, gasPrice, gasLimit, data, chainId)
-                .subscribeOn(Schedulers.computation())
-                .observeOn(AndroidSchedulers.mainThread());
+            .subscribeOn(Schedulers.computation())
+            .observeOn(AndroidSchedulers.mainThread());
     }
-
-    /**
-     * Cache the nonce to avoid needing to recalculate it. Hardware blocks all functionality until success or cancel so it's safe to do this
-     * NOTE: if the wallet is upgraded to sign multiple transactions simultaneously this would need to be looked at again
-     */
-    private long nonceForHardwareSign;
 
     private void completeSendTransaction(Wallet wallet, long chainId, Pair<SignatureFromKey, RawTransaction> signaturePackage, Web3Transaction w3Tx)
     {
@@ -133,10 +163,13 @@ public class CreateTransactionInteract
             case KEY_FILE_ERROR:
             case KEY_AUTHENTICATION_ERROR:
             case KEY_CIPHER_ERROR:
-                txInterface.transactionError(new TransactionReturn(new Throwable(signaturePackage.first.failMessage), w3Tx));
+                String errorMessage = signaturePackage.first.failMessage;
+                handleTransactionError(new Throwable(errorMessage), w3Tx);
                 break;
             default:
-                throw new RuntimeException("Unimplemented sign type");
+                String message = "Unimplemented sign type";
+                trackTransactionError(message);
+                throw new RuntimeException(message);
         }
     }
 
@@ -154,10 +187,13 @@ public class CreateTransactionInteract
             case KEY_FILE_ERROR:
             case KEY_AUTHENTICATION_ERROR:
             case KEY_CIPHER_ERROR:
-                txInterface.transactionError(new TransactionReturn(new Throwable(signaturePackage.first.failMessage), w3Tx));
+                String errorMessage = signaturePackage.first.failMessage;
+                handleTransactionError(new Throwable(errorMessage), w3Tx);
                 break;
             default:
-                throw new RuntimeException("Unimplemented sign type");
+                String message = "Unimplemented sign type";
+                trackTransactionError(message);
+                throw new RuntimeException(message);
         }
     }
 
@@ -174,5 +210,19 @@ public class CreateTransactionInteract
         }
 
         return sigData;
+    }
+
+    private void trackTransactionError(String message)
+    {
+        AnalyticsProperties props = new AnalyticsProperties();
+        props.put(Analytics.PROPS_ERROR_MESSAGE, message);
+        analyticsService.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_FAILED.getValue());
+    }
+
+    private void trackTransactionCount(long chainId)
+    {
+        analyticsService.increment(EthereumNetworkRepository.hasRealValue(chainId) ?
+            Analytics.UserProperties.TRANSACTION_COUNT.getValue() :
+            Analytics.UserProperties.TRANSACTION_COUNT_TESTNET.getValue());
     }
 }

--- a/app/src/main/java/com/alphawallet/app/service/AnalyticsServiceType.java
+++ b/app/src/main/java/com/alphawallet/app/service/AnalyticsServiceType.java
@@ -2,7 +2,9 @@ package com.alphawallet.app.service;
 
 import com.alphawallet.app.entity.ServiceErrorException;
 
-public interface AnalyticsServiceType<T> {
+public interface AnalyticsServiceType<T>
+{
+    void increment(String property);
 
     void track(String eventName);
 

--- a/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/SwapActivity.java
@@ -656,8 +656,6 @@ public class SwapActivity extends BaseActivity implements StandardFunctionInterf
         successDialog.setTitle(R.string.transaction_succeeded);
         successDialog.setMessage(transactionReturn.hash);
         successDialog.show();
-
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL, confirmationDialogProps);
     }
 
     private void txError(TransactionReturn txError)
@@ -666,9 +664,6 @@ public class SwapActivity extends BaseActivity implements StandardFunctionInterf
         errorDialog.setTitle(R.string.error_transaction_failed);
         errorDialog.setMessage(txError.throwable.getMessage());
         errorDialog.show();
-
-        confirmationDialogProps.put(Analytics.PROPS_ERROR_MESSAGE, txError.throwable.getMessage());
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_FAILED, confirmationDialogProps);
     }
 
     private void onError(ErrorEnvelope errorEnvelope)

--- a/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/TokenFunctionActivity.java
@@ -332,7 +332,6 @@ public class TokenFunctionActivity extends BaseActivity implements StandardFunct
     private void txWritten(TransactionReturn transactionReturn)
     {
         confirmationDialog.transactionWritten(transactionReturn.hash); //display hash and success in ActionSheet, start 1 second timer to dismiss.
-        viewModel.track(Analytics.Navigation.ACTION_SHEET_FOR_TRANSACTION_CONFIRMATION_SUCCESSFUL, confirmationDialogProps);
     }
 
     private void calculateEstimateDialog()

--- a/app/src/noAnalytics/java/com/alphawallet/app/service/AnalyticsService.java
+++ b/app/src/noAnalytics/java/com/alphawallet/app/service/AnalyticsService.java
@@ -12,6 +12,12 @@ public class AnalyticsService<T> implements AnalyticsServiceType<T> {
     }
 
     @Override
+    public void increment(String property)
+    {
+        //No code
+    }
+
+    @Override
     public void track(String eventName)
     {
         //No code


### PR DESCRIPTION
- Closes #2698

Other improvements in this PR:
- Confirmation Dialog result was previously not tracked properly (only in `TokenFunctionActivity` and `SwapActivity`). Moved the implementation to `CreateTransactionInteract` to track every sign and send transaction. Partially closes items in #3028, as some properties require more tinkering to track.
- Created `UserProperties` object under `Analytics` to consolidate items