### PR TITLE
Removed textIsSelectable property

### DIFF
--- a/app/src/main/res/layout/item_wallet_summary_manage.xml
+++ b/app/src/main/res/layout/item_wallet_summary_manage.xml
@@ -74,7 +74,6 @@
                 android:layout_marginEnd="@dimen/tiny_8"
                 android:layout_weight="0.7"
                 android:lines="1"
-                android:textIsSelectable="true"
                 android:visibility="gone"
                 app:autoSizeTextType="uniform"
                 tools:text="123,567,890.1234" />
@@ -89,7 +88,6 @@
                 android:gravity="end|center_vertical"
                 android:lines="1"
                 android:textColor="@color/positive"
-                android:textIsSelectable="true"
                 android:visibility="gone"
                 app:autoSizeTextType="uniform"
                 tools:text="+123.45%" />


### PR DESCRIPTION
- Closes #3173

Issue wasn't a delay per se, but tapping on a certain area within the container fails at times. This is due to `textIsSelectable` property of the balance/balance change textbox interfering with the click gesture. 