### PR TITLE
Ensure base icons are updated correctly

### DIFF
--- a/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
+++ b/app/src/main/java/com/alphawallet/app/widget/TokenIcon.java
@@ -187,11 +187,6 @@ public class TokenIcon extends ConstraintLayout
      */
     public void bindData(Token token, @NotNull AssetDefinitionService assetDefinition)
     {
-        if (token == null || (this.token != null && this.token.equals(token))) //stop update flicker
-        {
-            return;
-        }
-
         this.token = token;
 
         if (token.isEthereum())


### PR DESCRIPTION
The icon flickering on base icons due to glide load times was fixed previously by writing the icon directly to the image. This older restriction was preventing the chain icons from displaying under some conditions.