### PR TITLE
Improve Transactions Sync

### DIFF
--- a/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/EtherscanTransaction.java
@@ -25,11 +25,12 @@ public class EtherscanTransaction
     String cumulativeGasUsed;
     String gasUsed;
     int confirmations;
+    String functionName;
 
     public Transaction createTransaction(String walletAddress, long chainId)
     {
         Transaction tx = new Transaction(hash, isError, blockNumber, timeStamp, nonce, from, to, value, gas, gasPrice, input,
-                                         gasUsed, chainId, contractAddress);
+                                         gasUsed, chainId, contractAddress, functionName);
 
         if (walletAddress != null)
         {

--- a/app/src/main/java/com/alphawallet/app/entity/Transaction.java
+++ b/app/src/main/java/com/alphawallet/app/entity/Transaction.java
@@ -55,6 +55,7 @@ public class Transaction implements Parcelable
     public final String input;
     public final String error;
     public final long chainId;
+    public final String functionName;
 
     public boolean isConstructor = false;
     public TransactionInput transactionInput = null;
@@ -82,6 +83,7 @@ public class Transaction implements Parcelable
         chainId = 0;
         maxFeePerGas = "";
         maxPriorityFee = "";
+        functionName = "";
     }
 
     public boolean isPending()
@@ -131,6 +133,7 @@ public class Transaction implements Parcelable
         this.isConstructor = isConstructor;
         this.maxFeePerGas = "";
         this.maxPriorityFee = "";
+        this.functionName = "";
     }
 
     public Transaction(Web3Transaction tx, long chainId, String wallet)
@@ -151,6 +154,7 @@ public class Transaction implements Parcelable
         this.isConstructor = tx.isConstructor();
         this.maxFeePerGas = tx.maxFeePerGas.toString();
         this.maxPriorityFee = tx.maxPriorityFeePerGas.toString();
+        this.functionName = "";
     }
 
     public Transaction(CovalentTransaction cTx, long chainId, long transactionTime)
@@ -181,6 +185,7 @@ public class Transaction implements Parcelable
         this.chainId = chainId;
         this.maxFeePerGas = "";
         this.maxPriorityFee = "";
+        this.functionName = "";
     }
 
     public Transaction(org.web3j.protocol.core.methods.response.Transaction ethTx, long chainId, boolean isSuccess, long timeStamp)
@@ -221,10 +226,11 @@ public class Transaction implements Parcelable
         this.chainId = chainId;
         this.maxFeePerGas = ethTx.getMaxFeePerGas();
         this.maxPriorityFee = ethTx.getMaxPriorityFeePerGas();
+        this.functionName = "";
     }
 
     public Transaction(String hash, String isError, String blockNumber, long timeStamp, int nonce, String from, String to,
-                       String value, String gas, String gasPrice, String input, String gasUsed, long chainId, String contractAddress)
+                       String value, String gas, String gasPrice, String input, String gasUsed, long chainId, String contractAddress, String functionName)
     {
         //Is it a constructor?
         if (!TextUtils.isEmpty(contractAddress))
@@ -253,6 +259,7 @@ public class Transaction implements Parcelable
         this.chainId = chainId;
         this.maxFeePerGas = "";
         this.maxPriorityFee = "";
+        this.functionName = functionName;
     }
 
     public Transaction(String hash, String isError, String blockNumber, long timeStamp, int nonce, String from, String to,
@@ -284,6 +291,7 @@ public class Transaction implements Parcelable
         this.input = input;
         this.gasUsed = gasUsed;
         this.chainId = chainId;
+        this.functionName = "";
     }
 
     protected Transaction(Parcel in)
@@ -303,6 +311,7 @@ public class Transaction implements Parcelable
         chainId = in.readLong();
         maxFeePerGas = in.readString();
         maxPriorityFee = in.readString();
+        functionName = in.readString();
     }
 
     public static final Creator<Transaction> CREATOR = new Creator<Transaction>()
@@ -344,6 +353,7 @@ public class Transaction implements Parcelable
         dest.writeLong(chainId);
         dest.writeString(maxFeePerGas);
         dest.writeString(maxPriorityFee);
+        dest.writeString(functionName);
     }
 
     public boolean isRelated(String contractAddress, String walletAddress)

--- a/app/src/main/java/com/alphawallet/app/entity/transactionAPI/TransferFetchType.java
+++ b/app/src/main/java/com/alphawallet/app/entity/transactionAPI/TransferFetchType.java
@@ -5,6 +5,7 @@ package com.alphawallet.app.entity.transactionAPI;
  */
 public enum TransferFetchType
 {
+    ETHEREUM("eth"), // dummy type for storing token reads
     ERC_20("tokentx"),
     ERC_721("tokennfttx"),
     ERC_1155("token1155tx");

--- a/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
+++ b/app/src/main/java/com/alphawallet/app/repository/EthereumNetworkBase.java
@@ -311,11 +311,11 @@ public abstract class EthereumNetworkBase implements EthereumNetworkRepositoryTy
             put(KLAYTN_ID, new NetworkInfo(C.KLAYTN_NAME, C.KLAYTN_SYMBOL,
                 USE_KLAYTN_RPC,
                 "https://scope.klaytn.com/tx/", KLAYTN_ID, KLAYTN_RPC,
-                "https://klaytn-mainnet.blockscout.com/api?"));
+                ""));
             put(KLAYTN_BAOBAB_ID, new NetworkInfo(C.KLAYTN_BAOBAB_NAME, C.KLAYTN_SYMBOL,
                 USE_KLAYTN_BAOBAB_RPC,
                 "https://baobab.scope.klaytn.com/tx/", KLAYTN_BAOBAB_ID, KLAYTN_BAOBAB_RPC,
-                "https://klaytn-testnet.blockscout.com/api?"));
+                ""));
             put(IOTEX_MAINNET_ID, new NetworkInfo(C.IOTEX_NAME, C.IOTEX_SYMBOL,
                     IOTEX_MAINNET_RPC_URL,
                     "https://iotexscan.io/tx/", IOTEX_MAINNET_ID, IOTEX_MAINNET_RPC_FALLBACK_URL,

--- a/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TokenRepository.java
@@ -547,6 +547,7 @@ public class TokenRepository implements TokenRepositoryType {
     private BigDecimal updateERC1155Balance(Token token, Wallet wallet)
     {
         BigDecimal newBalance;
+        token.setTokenWallet(wallet.address);
         try (Realm realm = getRealmInstance(wallet))
         {
             newBalance = token.updateBalance(realm);

--- a/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/TransactionRepository.java
@@ -157,7 +157,7 @@ public class TransactionRepository implements TransactionRepositoryType
             {
                 newTx = new Transaction(txHash, "0", "0", System.currentTimeMillis() / 1000, itx.getNonce().intValue(), from.address,
                         itx.getTo(), itx.getValue().toString(10), "0", itx.getGasPrice().toString(10), itx.getData(),
-                        itx.getGasLimit().toString(10), chainId, contractAddr);
+                        itx.getGasLimit().toString(10), chainId, contractAddr, ""); //TODO: Function Name
             }
 
             inDiskCache.putTransaction(from, newTx);
@@ -174,7 +174,7 @@ public class TransactionRepository implements TransactionRepositoryType
 
             Transaction newTx = new Transaction(txHash, "0", "0", System.currentTimeMillis() / 1000, nonce.intValue(), from.address,
                     toAddress, value.toString(10), "0", gasPrice.toString(10), data,
-                    gasLimit.toString(10), chainId, "");
+                    gasLimit.toString(10), chainId, "", ""); //TODO: Function Name
             //newTx.completeSetup(from.address);
             inDiskCache.putTransaction(from, newTx);
             transactionsService.markPending(newTx);

--- a/app/src/main/java/com/alphawallet/app/repository/entity/RealmAuxData.java
+++ b/app/src/main/java/com/alphawallet/app/repository/entity/RealmAuxData.java
@@ -329,4 +329,24 @@ public class RealmAuxData extends RealmObject
                 .equalTo("tokenAddress", token.getAddress())
                 .limit(historyCount);
     }
+
+    public void setBaseChainBlock(long blockRead)
+    {
+        this.functionId = Long.toString(blockRead);
+    }
+
+    public long getBaseChainBlock()
+    {
+        long baseBlock;
+        try
+        {
+            baseBlock = TextUtils.isEmpty(this.functionId) ? 0 : Long.parseLong(this.functionId);
+        }
+        catch (NumberFormatException e)
+        {
+            baseBlock = 0;
+        }
+
+        return baseBlock;
+    }
 }

--- a/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
+++ b/app/src/main/java/com/alphawallet/app/service/TransactionsService.java
@@ -55,8 +55,8 @@ public class TransactionsService
     private final TransactionsNetworkClientType transactionsClient;
     private final TransactionLocalSource transactionsCache;
     private int currentChainIndex;
-    private boolean nftCheck;
     private boolean firstCycle;
+    private boolean firstTxCycle;
 
     private final LongSparseArray<Long> chainTransferCheckTimes = new LongSparseArray<>(); //TODO: Use this to coordinate token checks on chains
     private final LongSparseArray<Long> chainTransactionCheckTimes = new LongSparseArray<>();
@@ -102,8 +102,8 @@ public class TransactionsService
         if (TextUtils.isEmpty(tokensService.getCurrentAddress())) return;
 
         currentChainIndex = 0;
-        nftCheck = false;
         firstCycle = true;
+        firstTxCycle = true;
 
         transactionsClient.checkRequiresAuxReset(tokensService.getCurrentAddress());
 
@@ -111,11 +111,7 @@ public class TransactionsService
             fetchTransactionDisposable.dispose();
         fetchTransactionDisposable = null;
         //reset transaction timers
-        if (transactionCheckCycle == null || transactionCheckCycle.isDisposed())
-        {
-            transactionCheckCycle = Observable.interval(START_CHECK_DELAY, CHECK_CYCLE, TimeUnit.SECONDS)
-                    .doOnNext(l -> checkTransactionQueue()).subscribe();
-        }
+        startTransactionCheckCycle(START_CHECK_DELAY);
 
         readTransferCycle();
 
@@ -123,6 +119,15 @@ public class TransactionsService
         {
             pendingTransactionCheckCycle = Observable.interval(CHECK_CYCLE, CHECK_CYCLE, TimeUnit.SECONDS)
                     .doOnNext(l -> checkPendingTransactions()).subscribe();
+        }
+    }
+
+    private void startTransactionCheckCycle(long checkCycleTime)
+    {
+        if (transactionCheckCycle == null || transactionCheckCycle.isDisposed())
+        {
+            transactionCheckCycle = Observable.interval(START_CHECK_DELAY, checkCycleTime, TimeUnit.SECONDS)
+                    .doOnNext(l -> checkTransactionQueue()).subscribe();
         }
     }
 
@@ -272,8 +277,39 @@ public class TransactionsService
                                 .subscribeOn(Schedulers.io())
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(transactions -> onUpdateTransactions(transactions, t), this::onTxError);
+
+                checkFirstCycleCompletion();
             }
         }
+    }
+
+    private void checkFirstCycleCompletion()
+    {
+        if (firstTxCycle && hasCompletedFirstCycle())
+        {
+            Timber.tag(TAG).d("Completed first cycle of checks");
+            if (transactionCheckCycle != null && !transactionCheckCycle.isDisposed())
+            {
+                transactionCheckCycle.dispose();
+            }
+            transactionCheckCycle = null;
+            firstTxCycle = false;
+            startTransactionCheckCycle(CHECK_CYCLE);
+        }
+    }
+
+    private boolean hasCompletedFirstCycle()
+    {
+        for (int i = 0; i < chainTransactionCheckTimes.size(); i++)
+        {
+            long checkTime = chainTransactionCheckTimes.valueAt(i);
+            if (checkTime < ethereumNetworkRepository.getAvailableNetworkList().length + 1)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private Token getRequiresTransactionUpdate()
@@ -286,6 +322,11 @@ public class TransactionsService
 
         for (long chainId : chains)
         {
+            NetworkInfo thisInfo = ethereumNetworkRepository.getNetworkByChain(chainId);
+            if (TextUtils.isEmpty(thisInfo.etherscanAPI))
+            {
+                continue;
+            }
             long checkTime = chainTransactionCheckTimes.get(chainId, 0L);
             if (checkTime == 0L)
             {
@@ -299,7 +340,7 @@ public class TransactionsService
         }
 
         //check lowest value
-        if ((System.currentTimeMillis() - oldestCheck) > 45* DateUtils.SECOND_IN_MILLIS)
+        if ((System.currentTimeMillis() - oldestCheck) > 45 * DateUtils.SECOND_IN_MILLIS)
         {
             chainTransactionCheckTimes.put(checkChainId, System.currentTimeMillis());
             return tokensService.getServiceToken(checkChainId);
@@ -438,7 +479,6 @@ public class TransactionsService
         chainTransactionCheckTimes.clear();
 
         currentChainIndex = 0;
-        nftCheck = false;
     }
 
     public static void addTransactionHashFetch(String txHash, long chainId, String wallet)
@@ -524,7 +564,7 @@ public class TransactionsService
         if (txData.second.compareTo(BigInteger.ZERO) > 0)
         {
             return EventUtils.getBlockDetails(txData.first.getResult().getBlockHash(), web3j)
-                    .map(blockReceipt -> new Pair<>(txData.first, blockReceipt.getBlock().getTimestamp().longValue()));
+                        .map(blockReceipt -> new Pair<>(txData.first, blockReceipt.getBlock().getTimestamp().longValue()));
         }
         else
         {
@@ -585,6 +625,15 @@ public class TransactionsService
                         }
                     }, Timber::w).isDisposed();
         }
+    }
+
+    public Single<Transaction> fetchTransaction(String currentAddress, String hash, long chainId)
+    {
+        return doTransactionFetch(hash, chainId)
+                .map(fetchedTx -> {
+                    transactionsCache.putTransaction(new Wallet(currentAddress), fetchedTx);
+                    return fetchedTx;
+                });
     }
 
     private boolean checkTransactionReceipt(String txHash, long chainId) throws IOException

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -44,7 +44,9 @@ import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.OnLifecycleEvent;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
@@ -103,7 +105,7 @@ import timber.log.Timber;
 
 @AndroidEntryPoint
 public class HomeActivity extends BaseNavigationActivity implements View.OnClickListener, HomeCommsInterface,
-        FragmentMessenger, Runnable, ActionSheetCallback, LifecycleObserver, PagerCallback
+        FragmentMessenger, Runnable, ActionSheetCallback, LifecycleEventObserver, PagerCallback
 {
     @Inject
     AWWalletConnectClient awWalletConnectClient;
@@ -147,34 +149,36 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         updatePrompt = true;
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    private void onMoveToForeground()
-    {
-        Timber.tag("LIFE").d("AlphaWallet into foreground");
-        if (viewModel != null)
-        {
-            viewModel.checkTransactionEngine();
-            viewModel.sendMsgPumpToWC(this);
-        }
-        isForeground = true;
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    private void onMoveToBackground()
-    {
-        Timber.tag("LIFE").d("AlphaWallet into background");
-        if (viewModel != null && !tokenClicked) viewModel.stopTransactionUpdate();
-        if (viewModel != null) viewModel.outOfFocus();
-        isForeground = false;
-    }
-
     @Override
-    public void onTrimMemory(int level)
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event)
     {
-        super.onTrimMemory(level);
-        if (!isForeground)
+        switch (event)
         {
-            onMoveToBackground();
+            case ON_CREATE:
+                break;
+            case ON_START:
+                Timber.tag("LIFE").d("AlphaWallet into foreground");
+                if (viewModel != null)
+                {
+                    viewModel.checkTransactionEngine();
+                    viewModel.sendMsgPumpToWC(this);
+                }
+                isForeground = true;
+                break;
+            case ON_RESUME:
+                break;
+            case ON_PAUSE:
+                break;
+            case ON_STOP:
+                Timber.tag("LIFE").d("AlphaWallet into background");
+                if (viewModel != null && !tokenClicked) viewModel.stopTransactionUpdate();
+                if (viewModel != null) viewModel.outOfFocus();
+                isForeground = false;
+                break;
+            case ON_DESTROY:
+                break;
+            case ON_ANY:
+                break;
         }
     }
 


### PR DESCRIPTION
- Add individual transaction fetch for notifications.
- Simplify transaction sync, ensure latest transactions are always synced (these are most important).
- Add Etherscan 'function name' fetch (implement on a separate PR).
- Remove associated deprecated code for switching on/off transaction fetch when phone is paged out.