### PR TITLE
Issue 3220

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ fastlane/report.xml
 
 # Local configuration file (sdk path, etc)
 local.properties
+gradle.properties
 
 #C/C++ object files
 app/.cxx/

--- a/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
+++ b/app/src/main/java/com/alphawallet/app/entity/tokens/Token.java
@@ -64,6 +64,7 @@ public class Token
 {
     public final static int TOKEN_BALANCE_PRECISION = 4;
     public final static int TOKEN_BALANCE_FOCUS_PRECISION = 5;
+    public static final int MAX_TOKEN_SYMBOL_LENGTH = 8;
 
     public final TokenInfo tokenInfo;
     public BigDecimal balance;

--- a/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
+++ b/app/src/main/java/com/alphawallet/app/ui/widget/holder/TokenHolder.java
@@ -150,7 +150,7 @@ public class TokenHolder extends BinderViewHolder<TokenCardMeta> implements View
             if (!TextUtils.isEmpty(coinBalance))
             {
                 balanceCoin.setVisibility(View.VISIBLE);
-                String symbol = token.getSymbol().substring(0, Math.min(token.getSymbol().length(), 5)).toUpperCase();
+                String symbol = token.getSymbol().substring(0, Math.min(token.getSymbol().length(), Token.MAX_TOKEN_SYMBOL_LENGTH)).toUpperCase();
                 balanceCoin.setText(getString(R.string.valueSymbol, coinBalance, symbol));
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.suppressUnsupportedCompileSdk=32
 # Base64 Encoded GitHub PAT,
 # Make sure only check read:packages and read:user permissions if you want to create your own PAT,
 # and encode it with Base64 encoder https://www.base64encoder.io/
-gpr.user=pnmhatre.dev@gmail.com
-gpr.key=Z2hwX2NIRVEzYU4yODNiRWNCMFh0RDQ2cWY5eTNQZGJlZTFBMm0wTQ==
+gpr.user=smarttokenlabs@hotmail.com
+gpr.key=Z2hwX3NFR09PbXRkOFQ2M09RcEdmY0xvR1VXTVJ6ODJBSDAxWWQ4OA==
 
 NOTIFICATION_API_BASE_URL="baseurl.here"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.suppressUnsupportedCompileSdk=32
 # Base64 Encoded GitHub PAT,
 # Make sure only check read:packages and read:user permissions if you want to create your own PAT,
 # and encode it with Base64 encoder https://www.base64encoder.io/
-gpr.user=smarttokenlabs@hotmail.com
-gpr.key=Z2hwX3NFR09PbXRkOFQ2M09RcEdmY0xvR1VXTVJ6ODJBSDAxWWQ4OA==
+gpr.user=pnmhatre.dev@gmail.com
+gpr.key=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
 
 NOTIFICATION_API_BASE_URL="baseurl.here"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@ android.suppressUnsupportedCompileSdk=32
 # Make sure only check read:packages and read:user permissions if you want to create your own PAT,
 # and encode it with Base64 encoder https://www.base64encoder.io/
 gpr.user=pnmhatre.dev@gmail.com
-gpr.key=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
+gpr.key=Z2hwX2NIRVEzYU4yODNiRWNCMFh0RDQ2cWY5eTNQZGJlZTFBMm0wTQ==
 
 NOTIFICATION_API_BASE_URL="baseurl.here"


### PR DESCRIPTION
Closes : Ticker Length #3220 

**Issue** : For tokens having ticker length greater than 5 the symbol name was getting cut due to character limit set to 5 .

**Solution** : Character limit for symbols is now increased to 8 in listing page.

![Screenshot_2023-07-31-15-29-57-803_io stormbird wallet](https://github.com/AlphaWallet/alpha-wallet-android/assets/32137513/fc70a026-bf70-4f93-8383-fc1362566605)
