### PR TITLE
ERC1559 Enabled by default

### DIFF
--- a/app/src/main/java/com/alphawallet/app/repository/SharedPreferenceRepository.java
+++ b/app/src/main/java/com/alphawallet/app/repository/SharedPreferenceRepository.java
@@ -199,7 +199,7 @@ public class SharedPreferenceRepository implements PreferenceRepositoryType {
     @Override
     public boolean getUse1559Transactions()
     {
-        return pref.getBoolean(EXPERIMENTAL_1559_TX, false);
+        return pref.getBoolean(EXPERIMENTAL_1559_TX, true);
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/AdvancedSettingsActivity.java
@@ -126,7 +126,7 @@ public class AdvancedSettingsActivity extends BaseActivity
             .withType(SettingsItemView.Type.TOGGLE)
             .withIcon(R.drawable.ic_icons_settings_1559)
             .withTitle(R.string.experimental_1559)
-            .withSubtitle(R.string.experimental_1559_tx_sub)
+//            .withSubtitle(R.string.experimental_1559_tx_sub)
             .withListener(this::on1559TransactionsClicked)
             .build();
 


### PR DESCRIPTION
Solves : #3202 

1. **1559 Transactions** will be enabled by default.
2. Experimental subtitle is hidden from **1559 Transactions** in advanced settings.

### File: SharedPreferenceRepository.java

```java
# Original Code
@Override
    public boolean getUse1559Transactions()
    {
        return pref.getBoolean(EXPERIMENTAL_1559_TX, false);
    }
```
```java
#Modified Code
@Override
    public boolean getUse1559Transactions()
    {
        return pref.getBoolean(EXPERIMENTAL_1559_TX, true);
    }
```