### PR TITLE
Fixes for reported bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -337,7 +337,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.0-alpha02'
     androidTestImplementation 'androidx.test:core:1.4.1-alpha05'
     androidTestUtil 'androidx.test:orchestrator:1.4.2-alpha02'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.hamcrest:hamcrest:2.1'
 
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2', {
         exclude group: "com.android.support", module: "support-annotations"
@@ -348,7 +348,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
     androidTestImplementation 'androidx.browser:browser:1.4.0'
 
     implementation 'com.trustwallet:wallet-core:2.6.4'

--- a/app/src/androidTest/java/com/alphawallet/app/ImportWalletWithSeedPhraseTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/ImportWalletWithSeedPhraseTest.java
@@ -11,7 +11,7 @@ import static com.alphawallet.app.steps.Steps.getWalletAddress;
 import static com.alphawallet.app.util.Helper.click;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.junit.Assert.fail;
 
 import android.os.Build;

--- a/app/src/androidTest/java/com/alphawallet/app/SelectNetworkTest.java
+++ b/app/src/androidTest/java/com/alphawallet/app/SelectNetworkTest.java
@@ -19,7 +19,7 @@ import static com.alphawallet.app.util.Helper.click;
 import static com.alphawallet.app.util.Helper.clickListItem;
 import static com.alphawallet.app.util.Helper.clickStaticListItem;
 
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.CoreMatchers.allOf;
 
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.contrib.RecyclerViewActions;

--- a/app/src/androidTest/java/com/alphawallet/app/assertions/Should.java
+++ b/app/src/androidTest/java/com/alphawallet/app/assertions/Should.java
@@ -8,8 +8,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.alphawallet.app.util.Helper.waitUntil;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import android.widget.TextView;

--- a/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
+++ b/app/src/androidTest/java/com/alphawallet/app/steps/Steps.java
@@ -27,8 +27,8 @@ import static com.alphawallet.app.util.Helper.waitForLoadingComplete;
 import static com.alphawallet.app.util.Helper.waitUntil;
 import static com.alphawallet.app.util.Helper.waitUntilThenBack;
 import static com.alphawallet.app.util.RootUtil.isDeviceRooted;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
 import android.view.KeyEvent;
@@ -159,13 +159,14 @@ public class Steps
         onView(withHint("0")).perform(replaceText(amountStr));
         onView(withHint(R.string.recipient_address)).perform(replaceText(receiverAddress));
         click(withId(R.string.action_next));
-        Helper.wait(1);
+        Helper.wait(6);
         try
         {
             click(withId(R.string.action_confirm));
         }
         catch (Error | Exception e)
         {
+            Helper.wait(2);
             waitForLoadingComplete("Calculating Gas Limit");
             click(withId(R.string.action_confirm));
         }

--- a/app/src/androidTest/java/com/alphawallet/app/util/Helper.java
+++ b/app/src/androidTest/java/com/alphawallet/app/util/Helper.java
@@ -28,15 +28,13 @@ import androidx.test.espresso.util.HumanReadables;
 import androidx.test.espresso.util.TreeIterables;
 
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
+import org.hamcrest.CoreMatchers;
 
 import java.util.concurrent.TimeoutException;
 import com.alphawallet.app.R;
+import com.walletconnect.android.Core;
 
 import junit.framework.AssertionFailedError;
-
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 
 import java.util.concurrent.TimeoutException;
 
@@ -175,14 +173,14 @@ public class Helper
 
     public static void click(Matcher<View> matcher, int timeoutInSeconds)
     {
-        onView(isRoot()).perform(Helper.waitUntil(Matchers.allOf(matcher, isDisplayed()), timeoutInSeconds));
+        onView(isRoot()).perform(Helper.waitUntil(CoreMatchers.allOf(matcher, isDisplayed()), timeoutInSeconds));
         onView(matcher).perform(ViewActions.click(doNothing())); // if click executed as long press, do nothing and retry clicking
     }
 
     public static void click(Matcher<View> matcher)
     {
 //        Helper.wait(1); //slight pause
-        onView(isRoot()).perform(Helper.waitUntil(Matchers.allOf(matcher, isDisplayed())));
+        onView(isRoot()).perform(Helper.waitUntil(CoreMatchers.allOf(matcher, isDisplayed())));
         onView(matcher).perform(ViewActions.click(doNothing())); // if click executed as long press, do nothing and retry clicking
     }
 

--- a/app/src/androidTest/java/com/alphawallet/app/util/ScrollToActionImproved.java
+++ b/app/src/androidTest/java/com/alphawallet/app/util/ScrollToActionImproved.java
@@ -5,8 +5,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 
 import android.graphics.Rect;
 import android.view.View;

--- a/app/src/main/java/com/alphawallet/app/App.java
+++ b/app/src/main/java/com/alphawallet/app/App.java
@@ -15,6 +15,7 @@ import androidx.preference.PreferenceManager;
 import com.alphawallet.app.util.ReleaseTree;
 import com.alphawallet.app.walletconnect.AWWalletConnectClient;
 
+import java.util.EmptyStackException;
 import java.util.Stack;
 
 import javax.inject.Inject;
@@ -40,7 +41,15 @@ public class App extends Application
 
     public Activity getTopActivity()
     {
-        return activityStack.peek();
+        try
+        {
+            return activityStack.peek();
+        }
+        catch (EmptyStackException e)
+        {
+            //
+            return null;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
+++ b/app/src/main/java/com/alphawallet/app/service/AssetDefinitionService.java
@@ -918,6 +918,11 @@ public class AssetDefinitionService implements ParseResult, AttributeInterface
 
     public TokenScriptFile getTokenScriptFile(Token token)
     {
+        if (token == null)
+        {
+            return new TokenScriptFile(context);
+        }
+
         String fileName = token.getTSKey() + TS_EXTENSION;
         //first try debug file
         TokenScriptFile tsf = new TokenScriptFile(context, getDebugPath(fileName));

--- a/app/src/main/java/com/alphawallet/app/service/WalletConnectV2Service.java
+++ b/app/src/main/java/com/alphawallet/app/service/WalletConnectV2Service.java
@@ -44,6 +44,7 @@ public class WalletConnectV2Service extends Service
         PendingIntent pendingIntent = PendingIntent.getActivity(getApplicationContext(), 0, intent, PendingIntent.FLAG_IMMUTABLE);
         Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_logo)
+                .setOnlyAlertOnce(true)
                 .setContentTitle(getString(R.string.notify_wallet_connect_title))
                 .setContentText(getString(R.string.notify_wallet_connect_content))
                 .setContentIntent(pendingIntent)

--- a/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/HomeActivity.java
@@ -341,7 +341,15 @@ public class HomeActivity extends BaseNavigationActivity implements View.OnClick
         }
 
         Intent i = new Intent(this, PriceAlertsService.class);
-        startService(i);
+        try
+        {
+            startService(i); //cannot start the service while the app is in background mode.
+                             //TODO: Improve this patch using JobScheduler
+        }
+        catch (Exception e)
+        {
+            Timber.w(e);
+        }
     }
 
     private void onUpdateAvailable(String availableVersion)

--- a/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
+++ b/app/src/main/java/com/alphawallet/app/ui/MyAddressActivity.java
@@ -235,7 +235,7 @@ public class MyAddressActivity extends BaseActivity implements AmountReadyCallba
 
         displayAddress = Keys.toChecksumAddress(wallet.address);
         setTitle(getString(R.string.my_wallet_address));
-        copyAddress.setText(displayAddress);
+        copyAddress.setFixedText(displayAddress);
         currentMode = AddressMode.MODE_ADDRESS;
         if (getCurrentFocus() != null) {
             KeyboardUtils.hideKeyboard(getCurrentFocus());

--- a/app/src/main/java/com/alphawallet/app/util/Utils.java
+++ b/app/src/main/java/com/alphawallet/app/util/Utils.java
@@ -1,6 +1,5 @@
 package com.alphawallet.app.util;
 
-import static com.alphawallet.app.service.AssetDefinitionService.getEASContract;
 import static com.alphawallet.ethereum.EthereumNetworkBase.AVALANCHE_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.BINANCE_MAIN_ID;
 import static com.alphawallet.ethereum.EthereumNetworkBase.CLASSIC_ID;
@@ -37,9 +36,9 @@ import com.alphawallet.app.util.pattern.Patterns;
 import com.alphawallet.app.web3j.StructuredDataEncoder;
 import com.alphawallet.token.entity.ProviderTypedData;
 import com.alphawallet.token.entity.Signable;
+import com.google.gson.Gson;
 import com.google.zxing.client.android.Intents;
 import com.journeyapps.barcodescanner.ScanOptions;
-import com.google.gson.Gson;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
@@ -56,7 +55,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -581,6 +579,15 @@ public class Utils
         {
             return "0x";
         }
+    }
+
+    public static String splitAddress(String address)
+    {
+        address = Keys.toChecksumAddress(address);
+        int split = address.length()/2;
+        String front = address.substring(0, split);
+        String back = address.substring(split);
+        return front + " " + back;
     }
 
     public static String formatTxHash(String txHash)
@@ -1280,5 +1287,43 @@ public class Utils
             Timber.e(e);
             return "";
         }
+    }
+
+    public static boolean isDefaultName(String name, Context ctx)
+    {
+        //wallet.name = getString(R.string.wallet_name_template, walletCount);
+        String walletStr = ctx.getString(R.string.wallet_name_template, 1);
+        String walletSplit[] = walletStr.split(" ");
+        walletStr = walletSplit[0];
+        if (!TextUtils.isEmpty(name) && name.startsWith(walletStr) && walletSplit.length == 2)
+        {
+            //check last part is a number
+            int walletNum = getWalletNum(walletSplit);
+            return walletNum > 0;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private static int getWalletNum(String[] walletSplit)
+    {
+        if (walletSplit.length != 2)
+        {
+            return 0;
+        }
+
+        String walletNum = walletSplit[1];
+        try
+        {
+            return Integer.parseInt(walletNum);
+        }
+        catch (Exception e)
+        {
+            //
+        }
+
+        return 0;
     }
 }

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -769,9 +769,9 @@ public class HomeViewModel extends BaseViewModel
 
     public void sendMsgPumpToWC(Context context)
     {
-
-        Timber.d("Start WC service");
-        WCUtils.startServiceLocal(context, null, WalletConnectActions.MSG_PUMP);
+        //NB: WalletConnect v1 has been deprecated
+        //Timber.d("Start WC service");
+        //WCUtils.startServiceLocal(context, null, WalletConnectActions.MSG_PUMP);
     }
 
     // Restart walletconnect sessions if required

--- a/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/alphawallet/app/viewmodel/HomeViewModel.java
@@ -303,7 +303,8 @@ public class HomeViewModel extends BaseViewModel
     private void updateWalletTitle(Context context, Wallet wallet)
     {
         transactionsService.changeWallet(wallet);
-        if (!TextUtils.isEmpty(wallet.name))
+        boolean usingDefaultName = Utils.isDefaultName(wallet.name, context);
+        if (!TextUtils.isEmpty(wallet.name) && !usingDefaultName)
         {
             walletName.postValue(wallet.name);
         }

--- a/app/src/main/java/com/alphawallet/app/widget/CopyTextView.java
+++ b/app/src/main/java/com/alphawallet/app/widget/CopyTextView.java
@@ -87,6 +87,26 @@ public class CopyTextView extends LinearLayout
         return originalText;
     }
 
+    public void setFixedText(CharSequence text)
+    {
+        originalText = text.toString();
+
+        setVisibility(TextUtils.isEmpty(originalText) ? View.GONE : View.VISIBLE);
+
+        if (Utils.isAddressValid(originalText))
+        {
+            button.setText(Utils.splitAddress(originalText));
+        }
+        else if (Utils.isTxHashValid(originalText))
+        {
+            button.setText(Utils.formatTxHash(originalText, 10));
+        }
+        else
+        {
+            button.setText(originalText);
+        }
+    }
+
     public void setText(CharSequence text)
     {
         originalText = text.toString();


### PR DESCRIPTION
- Crash when getting top activity if app isn't running (WalletConnect V2)
- Crash when attempting to start price alert service (note this is a band-aid, it doesn't have any negative side effects only that a service (price alerts) that caused the app to crash on that device now simply may no longer function).
- Remove WalletConnect V1 connection monitoring (which was causing issues on some phones).
- Add notification alert limiting for already active notifications.