### PR TITLE
fix: secure SSL handling and Web3 provider injection timing

### DIFF
--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -379,7 +379,11 @@ public class Web3TokenView extends WebView
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error)
         {
             System.out.println("YOLESS: " + error.toString());
-            handler.proceed(); // Ignore SSL certificate errors
+            // Security fix: reject invalid SSL certificates by default.
+            // handler.proceed() was removed to prevent accepting untrusted certificates.
+            // For development/testing with self-signed certs, consider using
+            // network_security_config.xml instead.
+            handler.cancel(); // Ignore SSL certificate errors
         }
     }
 

--- a/app/src/main/java/com/alphawallet/app/web3/Web3View.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3View.java
@@ -15,6 +15,7 @@ import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewCompat;
 import androidx.webkit.WebViewFeature;
 
 import com.alphawallet.app.BuildConfig;
@@ -31,8 +32,11 @@ import com.alphawallet.token.entity.Signable;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import timber.log.Timber;
 
@@ -205,6 +209,16 @@ public class Web3View extends WebView {
         if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING))
         {
             WebSettingsCompat.setAlgorithmicDarkeningAllowed(getSettings(), true);
+        }
+
+        // Inject Web3 provider at document start so window.ethereum is available
+        // before any page scripts run. This fixes CSP timing issues where sites
+        // like exchange.idex.io fail to detect the provider.
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT))
+        {
+            String providerJs = webViewClient.getJsInjectorClient().providerJs(getContext());
+            Set<String> origins = new HashSet<>(Collections.singletonList("*"));
+            WebViewCompat.addDocumentStartJavaScript(this, providerJs, origins);
         }
     }
 


### PR DESCRIPTION
## Security Fixes (Issue #2286)

Resolves #2286

### Problem

Two security/functionality issues in the WebView layer:

1. **Insecure SSL handling** (`Web3TokenView.java`): `onReceivedSslError()` called `handler.proceed()`, blindly accepting invalid SSL certificates. This enables man-in-the-middle attacks — critical for a crypto wallet.

2. **Web3 provider injection timing** (`Web3View.java`): The `window.ethereum` provider was injected in `onPageStarted()` via `evaluateJavascript()`. While this bypasses CSP, it has a **timing problem**: page scripts can execute before the async `evaluateJavascript()` completes, causing `@metamask/detect-provider` to fail with "Unable to detect window.ethereum" on sites like `exchange.idex.io`.

### Changes Made

#### `app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java`
- **SSL fix**: Replaced `handler.proceed()` with `handler.cancel()` in `onReceivedSslError()` to reject invalid certificates by default.

#### `app/src/main/java/com/alphawallet/app/web3/Web3View.java`
- **CSP/timing fix**: Added `WebViewCompat.addDocumentStartJavaScript()` in `init()` to inject the Web3 provider script at document start, **before** any page scripts run.
- This uses the AndroidX WebKit API (already a dependency at v1.12.0) which is the recommended approach for early script injection.
- The existing `evaluateJavascript()` calls in `onPageStarted()` are kept for the init/configuration script that requires wallet address and chain ID context.
- Added feature check (`WebViewFeature.DOCUMENT_START_SCRIPT`) for backward compatibility.

### Testing Notes
- SSL fix: TokenScript views will now correctly reject invalid certificates instead of silently accepting them.
- CSP fix: Sites with strict Content Security Policy headers should now detect `window.ethereum` reliably, since the provider is injected synchronously at document start.
- The `evaluateJavascript()` fallback in `onPageStarted()` remains for the init script and for WebView implementations that don't support `DOCUMENT_START_SCRIPT`.
