### PR TITLE
fix(Web3TokenView): only enable WebView contents debugging in debug builds (refs #2323)

### DIFF
--- a/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
+++ b/app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java
@@ -123,7 +123,11 @@ public class Web3TokenView extends WebView
         webSettings.setLoadWithOverviewMode(true);
         webSettings.setUserAgentString(webSettings.getUserAgentString()
                                                + "AlphaWallet(Platform=Android&AppVersion=" + BuildConfig.VERSION_NAME + ")");
-        WebView.setWebContentsDebuggingEnabled(true);
+        // CWE-489: Web3TokenView holds session JS for a wallet that signs
+        // transactions. Leaving WebView contents debuggable in release builds
+        // lets anyone with USB access attach chrome://inspect and read the
+        // page's DOM/JS. Restrict to debug builds only.
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG);
 
         if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING))
         {


### PR DESCRIPTION
## Restrict `WebContentsDebuggingEnabled` to debug builds (refs #2323)

What this PR does is fix the most concrete security smell that exists
in the same file the original draft was touching.

### The concrete problem

`app/src/main/java/com/alphawallet/app/web3/Web3TokenView.java`:

```java
WebView.setWebContentsDebuggingEnabled(true);
```

is called unconditionally inside `init()`. That setting is **process-wide**
on Android and remains active in release builds. Combined with the fact
that `Web3TokenView` is the WebView that runs TokenScript / dapp
JavaScript inside a *wallet*, i.e. a process that signs transactions
and holds key material in memory, it lets anyone with USB access on a
production device attach `chrome://inspect` and read the page's DOM and
JS state. CWE-489 (Active Debug Code).

MetaMask, Trust Wallet, and every other audited Android wallet gate
this call behind `BuildConfig.DEBUG`.

### The fix

```java
WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG);
```

`BuildConfig` is already imported in the file, so this is a one-line
behavioral change. No other functionality is altered.


