### PR TITLE
fix(web3): sanitize chain RPC URL before injecting into in-app browser (UXSS)

### DIFF
--- a/app/src/main/java/com/alphawallet/app/web3/JsInjectorClient.java
+++ b/app/src/main/java/com/alphawallet/app/web3/JsInjectorClient.java
@@ -30,11 +30,20 @@ import static com.alphawallet.ethereum.EthereumNetworkBase.MAINNET_ID;
 
 public class JsInjectorClient {
 
+    private static final String TAG = "JsInjectorClient";
     private static final String DEFAULT_CHARSET = "utf-8";
     private static final String DEFAULT_MIME_TYPE = "text/html";
     private final static String JS_TAG_TEMPLATE = "<script type=\"text/javascript\">%1$s%2$s</script>";
     final String SCRIPT_TAG = "<script";
     final String CDATA_TAG = "<![cdata[";
+
+    /**
+     * Characters that must never appear in an RPC URL we splice into a JS string
+     * literal. Their presence is a strong indicator of an attempted
+     * universal-XSS injection (see issue #2686).
+     */
+    private static final Pattern UNSAFE_URL_CHARS =
+            Pattern.compile("[\"'\\\\<>\\r\\n\\t\\u0000-\\u001f]");
 
     private long chainId;
     private Address walletAddress;
@@ -60,14 +69,58 @@ public class JsInjectorClient {
     public void setChainId(long chainId)
     {
         this.chainId = chainId;
-        this.rpcUrl = EthereumNetworkRepository.getDefaultNodeURL(chainId);
+        this.rpcUrl = sanitizeRpcUrl(EthereumNetworkRepository.getDefaultNodeURL(chainId));
     }
 
     // Set ChainId for TokenScript inject
     public void setTSChainId(long chainId)
     {
         this.chainId = chainId;
-        this.rpcUrl = EthereumNetworkRepository.getDefaultNodeURL(chainId);
+        this.rpcUrl = sanitizeRpcUrl(EthereumNetworkRepository.getDefaultNodeURL(chainId));
+    }
+
+    /**
+     * Validate and normalize an RPC URL before it is spliced into the
+     * JavaScript that is injected into every loaded page. Returns an empty
+     * string when the URL is missing, unparseable, not http(s), or contains
+     * any character that has meaning inside a JS string literal. This blocks
+     * the UXSS attack described in issue #2686, where a malicious chain
+     * registered via {@code wallet_addEthereumChain} could break out of the
+     * RPC-URL string in the template and inject arbitrary JavaScript.
+     */
+    static String sanitizeRpcUrl(String url)
+    {
+        if (TextUtils.isEmpty(url))
+        {
+            return "";
+        }
+        if (UNSAFE_URL_CHARS.matcher(url).find())
+        {
+            Log.w(TAG, "Rejecting RPC URL containing characters unsafe for JS string injection");
+            return "";
+        }
+        HttpUrl parsed = HttpUrl.parse(url);
+        if (parsed == null)
+        {
+            Log.w(TAG, "Rejecting unparseable RPC URL");
+            return "";
+        }
+        String scheme = parsed.scheme();
+        if (!"http".equals(scheme) && !"https".equals(scheme))
+        {
+            Log.w(TAG, "Rejecting RPC URL with non-http(s) scheme: " + scheme);
+            return "";
+        }
+        // Re-serialize through HttpUrl so any odd encodings are normalized to a
+        // canonical form before injection. Re-check the normalized form for
+        // unsafe characters in case parsing decoded any.
+        String normalized = parsed.toString();
+        if (UNSAFE_URL_CHARS.matcher(normalized).find())
+        {
+            Log.w(TAG, "Rejecting normalized RPC URL containing unsafe characters");
+            return "";
+        }
+        return normalized;
     }
 
     public String initJs(Context context)
@@ -193,7 +246,7 @@ public class JsInjectorClient {
     private String loadInitJs(Context context) {
         String initSrc = loadFile(context, R.raw.init);
         String address = walletAddress == null ? Address.EMPTY.toString() : Keys.toChecksumAddress(walletAddress.toString());
-        return String.format(initSrc, address, rpcUrl, chainId);
+        return String.format(initSrc, address, rpcUrl == null ? "" : rpcUrl, chainId);
     }
 
     String injectStyleAndWrap(String view, String style)


### PR DESCRIPTION
## Sanitize the chain RPC URL before injecting it into in-app browser pages

Resolves #2686 - Universal XSS via `wallet_addEthereumChain` RPC URL.

### The vulnerability

`JsInjectorClient.loadInitJs(...)` builds the JavaScript that is injected into
every page loaded in the AlphaWallet dApp browser by interpolating the active
chain's RPC URL into a template with `String.format`:

```java
return String.format(initSrc, address, rpcUrl, chainId);
```

The RPC URL is whatever value the network record holds, which a malicious dApp
can control by calling `wallet_addEthereumChain` with a payload like:

```js
rpcUrls: ['https://rpc-mumbai.matic.today/x"+alert(document.domain)+"']
```

After the user accepts the new chain (a benign-looking confirmation), every
subsequent page loaded in the in-app browser is poisoned with the attacker's
JavaScript, executed in the origin of that page — a classic stored UXSS.

### What this PR does

`app/src/main/java/com/alphawallet/app/web3/JsInjectorClient.java`:

1. Adds `sanitizeRpcUrl(String)` which:
   - rejects empty input;
   - rejects URLs containing characters that have meaning inside a JavaScript
     string literal (`"`, `'`, `\`, `<`, `>`, CR, LF, tab, other control
     bytes);
   - parses with OkHttp's `HttpUrl.parse(...)` and rejects anything that
     isn't a valid `http`/`https` URL;
   - returns the canonical, normalized URL and re-checks it for unsafe
     characters in case the parser decoded any.
2. Pipes the value resolved by
   `EthereumNetworkRepository.getDefaultNodeURL(chainId)` through that helper
   inside both `setChainId` and `setTSChainId` so the field stored on the
   client is always safe to splice.
3. Coalesces a null `rpcUrl` to `""` in `loadInitJs` so `String.format` never
   sees `null` after the change.