### PR TITLE
Handle https://aw.app/openurl?url= universal links so the embedded URL opens

### DIFF
--- a/app/src/main/java/com/alphawallet/app/service/DeepLinkService.java
+++ b/app/src/main/java/com/alphawallet/app/service/DeepLinkService.java
@@ -24,6 +24,8 @@ public class DeepLinkService
     public static final String WC_COMMAND = "wc:";
     public static final String AW_PREFIX = "awallet://";
     public static final String OPEN_URL_PREFIX = "openURL?q=";
+    // Lower case variant produced by web pages that link to https://aw.app/openurl?url=...
+    public static final String OPEN_URL_PREFIX_WEB = "openurl?url=";
 
     public static DeepLinkRequest parseIntent(String importData, Intent startIntent)
     {
@@ -39,10 +41,22 @@ public class DeepLinkService
             importData = importData.substring(AW_PREFIX.length());
         }
 
+        // Universal links arrive as https://aw.app/openurl?url=... so strip the
+        // host part too before we look for the openURL marker.
+        if (importData.startsWith(AW_APP))
+        {
+            importData = importData.substring(AW_APP.length());
+        }
+
         if (importData.startsWith(OPEN_URL_PREFIX))
         {
             isOpenURL = true;
             importData = importData.substring(OPEN_URL_PREFIX.length());
+        }
+        else if (importData.startsWith(OPEN_URL_PREFIX_WEB))
+        {
+            isOpenURL = true;
+            importData = importData.substring(OPEN_URL_PREFIX_WEB.length());
         }
 
         importData = Utils.universalURLDecode(importData);


### PR DESCRIPTION
## Open universal links of the form `https://aw.app/openurl?url=...`

Resolves #2411

On Android, links such as `https://aw.app/openurl?url=http%3A%2F%2Fexample.com`
were caught by the App Links intent filter, but `DeepLinkService.parseIntent`
did not know how to unwrap them. Reading the code:

1. The link did not start with `awallet://`, so the `AW_PREFIX` strip was a no op.
2. The remaining string still started with `https://aw.app/`, so it never matched
   the legacy `OPEN_URL_PREFIX = "openURL?q="` marker (different case, different
   parameter name).
3. The fall through path treated the whole thing as a magic link and bailed out.

The result is the screen the reporter shared, where AlphaWallet opens to the
home tab and the embedded URL is silently dropped. iOS works because its
Universal Link path uses a different code path.

### What changed

1. After stripping `awallet://` we now also strip the `https://aw.app/` host part
   so the parser can look at the path and query in isolation.
2. We accept `openurl?url=` in addition to the legacy `openURL?q=`. Both are
   treated the same way and feed into the existing `URL_REDIRECT` flow.

### Why this is safe

The new `OPEN_URL_PREFIX_WEB` constant is only consulted after the same checks
the legacy prefix already runs through, and the value still has to pass
`Utils.isValidUrl` before it is forwarded. There is no new sink for arbitrary
user input.

### Testing

Reproduced the bug on a Pixel 6 emulator with the link from the issue. With the
patch the in app browser opens the embedded URL. Existing `IntentTest` and
`UniversalLinkTest` cases still pass locally.
