### PR TITLE
Add Block Lottos dapp

### DIFF
--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -17,6 +17,7 @@
   {"name": "CryptoCare", "description": "Social Impact Collectibles", "url": "https://cryptocare.tech/adopt/cryptocare", "category": "Game"},
   {"name": "Dice2win", "description": "Simple and fair dice game", "url": "https://dice2.win/", "category": "Game"},
   {"name": "Dragonereum", "description": "Own and trade dragons, fight with other players", "url": "https://dapp.dragonereum.io/", "category": "Game"},
+  {"name": "Block Lottos", "description": "On-chain lottery games on Polygon and Base", "url": "https://blocklottos.com/games", "category": "Game"},
   {"name": "HyperDragons", "description": "Large scale strategy battle game", "url": "https://hyperdragons.alfakingdom.com/", "category": "Game"},
   {"name": "Last Trip", "description": "A RPG game", "url": "http://lasttrip.matrixdapp.com/", "category": "Game"},
   {"name": "LORDLESS", "description": "Be a bounty hunter in my tavern", "url": "https://game.lordless.io/home", "category": "Game"},


### PR DESCRIPTION
Adds Block Lottos to the dapp browser list under the Game category.\n\nBlock Lottos is an on-chain lottery dapp with live game pages for Polygon and Base.\n\nVerification performed:\n- Confirmed https://blocklottos.com/games returns HTTP 200\n- Parsed app/src/main/assets/dapps_list.json successfully after the change