### PR TITLE
Add GridMind dapp browser entry

### DIFF
--- a/app/src/main/assets/dapps_list.json
+++ b/app/src/main/assets/dapps_list.json
@@ -2,6 +2,7 @@
   {"name": "TokenScript", "description": "Smart Token Labs TokenScript Viewer", "url": "https://viewer.tokenscript.org/", "category": "Infrastructure"},
   {"name": "SmartLayer", "description": "Smart Token Labs Smart Layer Network", "url": "https://smartlayer.network", "category": "Infrastructure"},
   {"name": "TLink", "description": "Smart Token Labs TLink", "url": "https://tlink.store/", "category": "Infrastructure"},
+  {"name": "GridMind", "description": "Testnet wallet and explorer for GridMind asset flows", "url": "https://www.grid-mind.com/blockchain", "category": "Tool"},
   {"name": "X", "description": "Social Media", "url": "https://x.com", "category": "Social Media"},
   {"name": "Aave", "description": "A decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers", "url": "https://app.aave.com/", "category": "Finance"},
   {"name": "Tbull", "description": "A Utility Token on Binance Smart Chain for Payments for Services", "url": "https://tbull.live", "category": "Utility"},


### PR DESCRIPTION
## Summary

Adds GridMind to the AlphaWallet Android DApp browser list.

## Details

- Name: GridMind
- URL: https://www.grid-mind.com/blockchain
- Category: Tool
- Description: Testnet wallet and explorer for GridMind asset flows

GridMind is currently testnet-only. testGRD and starter test assets have no market price and no real-world value.